### PR TITLE
Don't overwrite geometry of poly1

### DIFF
--- a/lib/erase.js
+++ b/lib/erase.js
@@ -19,8 +19,9 @@ module.exports = function(poly1, poly2, done){
   var parser = new jsts.io.GeoJSONParser()
   erased = parser.write(erased)
   
-  poly1.geometry = erased
-  done(null, poly1)
+  var newPoly = _.cloneDeep(poly1);
+  newPoly.geometry = erased
+  done(null, newPoly)
 }
 
 function correctRings(poly){


### PR DESCRIPTION
Just fixing erase so that it doesn't overwrite the geometry of poly1. This could have unintended consequences since poly1 is passed in by reference.

This raises a question though, was the geometry of poly1 being overwritten so that the return value would have the properties of poly1? Is that necessary?
