### PR TITLE
Wrong example due to API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Most Turf functions work with GeoJSON features. These are are pieces of data tha
 Turf provides a few geometry functions of its own. These are nothing more than simple (and optional) wrappers that output plain old GeoJSON. For example, these two methods of creating a point are functionally equivalent:
 
 ```
-var point1 = turf.point(0,0);
+var point1 = turf.point([0, 0]);
 
 var point2 = {
   type: 'Feature',


### PR DESCRIPTION
Due to API change, turf.point need as parameter an array with coordinates x, y and not two parameters x and y.