### PR TITLE
fix broken readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 ![turf](https://raw.githubusercontent.com/Turfjs/turf/9a1d5e8d99564d4080f1e2bf1517ed41d18012fa/logo.png) 
 ======
 
- <sup>[![Version Badge](http://vb.teelaun.ch/Turfjs/turf.svg)](https://npmjs.org/package/turf)</sup> [![Build Status](https://travis-ci.org/Turfjs/turf.svg?branch=master)](https://travis-ci.org/Turfjs/turf) [![Gitter chat](https://badges.gitter.im/Turfjs/turf.png)](https://gitter.im/Turfjs/turf)
+[![Version Badge][npm-img]][npm-url]
+[![Build Status][travis-img]][travis-url]
+[![Gitter chat][gitter-img]][gitter-url]
 
+[npm-img]: https://img.shields.io/npm/v/turf.svg
+[npm-url]: https://www.npmjs.com/package/turf
+[travis-img]: https://travis-ci.org/Turfjs/turf.svg?branch=master
+[travis-url]: https://travis-ci.org/Turfjs/turf
+[gitter-img]: https://badges.gitter.im/Turfjs/turf.png
+[gitter-url]: https://gitter.im/Turfjs/turf
 
 ***A modular geospatial engine written in JavaScript***
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ var point2 = {
 
 [![Build Status](https://travis-ci.org/Turfjs/turf-intersect.svg?branch=master)](https://travis-ci.org/Turfjs/turf-intersect) [intersect](https://github.com/Turfjs/turf-intersect)
 
-[![Build Status](https://travis-ci.org/Turfjs/turf-erase.svg?branch=master)](https://travis-ci.org/Turfjs/turf-erase) [erase](https://github.com/Turfjs/turf-erase)
+[![Build Status](https://travis-ci.org/Turfjs/turf-difference.svg?branch=master)](https://travis-ci.org/Turfjs/turf-difference) [difference](https://github.com/Turfjs/turf-difference)
 
 [![Build Status](https://travis-ci.org/Turfjs/turf-convex.svg?branch=master)](https://travis-ci.org/Turfjs/turf-convex) [convex](https://github.com/Turfjs/turf-convex)
 


### PR DESCRIPTION
Hello Turf team!

Your version badge is broken!

![screen shot 2015-08-14 at 10 45 46 am](https://cloud.githubusercontent.com/assets/427322/9280227/bd6ae1a6-4271-11e5-91dd-d0e88a36ae39.png)

I fixed it!

![screen shot 2015-08-14 at 10 46 04 am](https://cloud.githubusercontent.com/assets/427322/9280232/c5c3025c-4271-11e5-852d-0b5d3d7e6533.png)

I've found http://shields.io to be pretty reliable.

Also noticed the build status for turf-erase was broken, and following the link it looks like that was renamed to turf-difference, so I fixed that too.

:grin: 