### PR TITLE
Updated package.json to include latest published npm turf-buffer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "turf-bbox-polygon": "^1.0.1",
     "turf-bearing": "1.0.1",
     "turf-bezier": "1.0.2",
-    "turf-buffer": "1.0.1",
+    "turf-buffer": "^1.0.4",
     "turf-center": "^1.0.2",
     "turf-centroid": "^1.1.2",
     "turf-combine": "1.0.2",


### PR DESCRIPTION
Updates package file to include the latest published version of turf-buffer (https://www.npmjs.com/package/turf-buffer).  All test executed and passed.