### PR TITLE
Fix turf-along using raw geometry

### DIFF
--- a/packages/turf-along/index.js
+++ b/packages/turf-along/index.js
@@ -41,7 +41,7 @@ var destination = require('turf-destination');
 module.exports = function (line, dist, units) {
     var coords;
     if (line.type === 'Feature') coords = line.geometry.coordinates;
-    else if (line.type === 'LineString') coords = line.geometry.coordinates;
+    else if (line.type === 'LineString') coords = line.coordinates;
     else throw new Error('input must be a LineString Feature or Geometry');
 
     var travelled = 0;

--- a/packages/turf-along/test.js
+++ b/packages/turf-along/test.js
@@ -7,13 +7,13 @@ var line = JSON.parse(fs.readFileSync(__dirname + '/test/fixtures/dc-line.geojso
 
 test('turf-along', function (t) {
 	var pt1 = along(line, 1, 'miles');
-	var pt2 = along(line, 1.2, 'miles');
+	var pt2 = along(line.geometry, 1.2, 'miles');
 	var pt3 = along(line, 1.4, 'miles');
-	var pt4 = along(line, 1.6, 'miles');
+	var pt4 = along(line.geometry, 1.6, 'miles');
 	var pt5 = along(line, 1.8, 'miles');
-	var pt6 = along(line, 2, 'miles');
+	var pt6 = along(line.geometry, 2, 'miles');
 	var pt7 = along(line, 100, 'miles');
-	var pt8 = along(line, 0, 'miles');
+	var pt8 = along(line.geometry, 0, 'miles');
     var fc = featurecollection([pt1,pt2,pt3,pt4,pt5,pt6,pt7,pt8]);
 
     fc.features.forEach(function (f) {


### PR DESCRIPTION
I am looking at implementing #365 and found that turf-along throws an exception when passing in a raw LineString geometry.

The PR sets the coordinate array as line.coordinates (rather than line.geometry.coordiantes). The PR also updates the test suite to pepper in some raw geometry while testing turf-along.

If there are anything changes I need to make, please let me know.

Thanks!