### PR TITLE
Fix error on "npm run build" in packages/turf

### DIFF
--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo 1",
-    "build": "browserify index.js -s turf > turf.js && uglifyjs turf.js -c -m > turf.min.js;",
+    "build": "browserify index.js -s turf > turf.js && uglifyjs turf.js -c -m > turf.min.js",
     "size": "browserify index.js --full-paths -s turf | uglifyjs -c -m | discify | hcat"
   },
   "repository": {


### PR DESCRIPTION
npm ERR! Failed at the turf@3.0.11 build script (Win10 - MinGW64)