### PR TITLE
[Fix] Fix a crash of turf-convex when the resulting hull has only 1 or 2 coordinates.

### DIFF
--- a/packages/turf-convex/index.js
+++ b/packages/turf-convex/index.js
@@ -77,7 +77,9 @@ module.exports = function (featurecollection) {
     var points = [];
     each(featurecollection, function (coord) { points.push(coord); });
     var hull = convexHull(points);
-    if (hull.length > 0) {
+
+    // Hull should have at least 3 different vertices in order to create a valid polygon
+    if (hull.length >= 3) {
         var ring = [];
         for (var i = 0; i < hull.length; i++) {
             ring.push(points[hull[i][0]]);


### PR DESCRIPTION
It can happen for instance when the input feature collection contains only a point, the resulting hull has only one point, which makes the turf-polygon algorithm crash because it needs at least 3 different vertices.