### PR TITLE
meta coordEach method now handles nested GeometryCollections.

### DIFF
--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -62,6 +62,9 @@ function coordEach(layer, callback, excludeWrapCoord) {
                     for (k = 0; k < coords[j].length; k++)
                         for (l = 0; l < coords[j][k].length - wrapShrink; l++)
                             callback(coords[j][k][l]);
+            } else if (geometry.type === 'GeometryCollection') {
+                for (j = 0; j < geometry.geometries.length; j++)
+                    coordEach(geometry.geometries[j], callback, excludeWrapCoord);
             } else {
                 throw new Error('Unknown Geometry Type');
             }


### PR DESCRIPTION
Example:
```
turf.explode(turf.geometryCollection([
	turf.geometryCollection([
		turf.point([0, 0]).geometry,
		turf.point([1, 1]).geometry
	]).geometry,
	turf.lineString([[2, 2], [3, 2]]).geometry
]));
```

Before, this code would have sent an error, but now the feature is correctly exploded.