### PR TITLE
Modified the turf module.exports to fix the auto-completion of some IDEs (e.g. WebStorm)

### DIFF
--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -7,6 +7,9 @@
  * @module turf
  * @summary Geospatial analysis for JavaScript
  */
+
+var helpers = require('@turf/helpers');
+
 module.exports = {
     isolines: require('@turf/isolines'),
     convex: require('@turf/convex'),
@@ -50,17 +53,14 @@ module.exports = {
     pointGrid: require('@turf/point-grid'),
     squareGrid: require('@turf/square-grid'),
     triangleGrid: require('@turf/triangle-grid'),
-    hexGrid: require('@turf/hex-grid')
+    hexGrid: require('@turf/hex-grid'),
+    point: helpers.point,
+    polygon: helpers.polygon,
+    lineString: helpers.lineString,
+    multiPoint: helpers.multiPoint,
+    multiPolygon: helpers.multiPolygon,
+    multiLineString: helpers.multiLineString,
+    feature: helpers.feature,
+    featureCollection: helpers.featureCollection,
+    geometryCollection: helpers.geometryCollection
 };
-
-var helpers = require('@turf/helpers');
-
-module.exports.point = helpers.point;
-module.exports.polygon = helpers.polygon;
-module.exports.lineString = helpers.lineString;
-module.exports.multiPoint = helpers.multiPoint;
-module.exports.multiPolygon = helpers.multiPolygon;
-module.exports.multiLineString = helpers.multiLineString;
-module.exports.feature = helpers.feature;
-module.exports.featureCollection = helpers.featureCollection;
-module.exports.geometryCollection = helpers.geometryCollection;


### PR DESCRIPTION
The way the module.exports was built seemed to break the auto-completion of WebStorm.
By moving everything inside one declaration, it works like a charm.