### PR TITLE
Fixed some doc typos in turf-center-of-mass

### DIFF
--- a/packages/turf-center-of-mass/README.md
+++ b/packages/turf-center-of-mass/README.md
@@ -1,6 +1,6 @@
 # @turf/center-of-mass
 
-# center-of-mass
+# centerOfMass
 
 Takes a [feature](http://geojson.org/geojson-spec.html#feature-objects)
 or a [featureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects)
@@ -9,7 +9,9 @@ using this formula: [Centroid of Polygon](https://en.wikipedia.org/wiki/Centroid
 
 **Parameters**
 
--   `feature` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)** the feature
+-   `feature` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)** or
+**[featureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects)**
+the feature or feature collection
 
 **Examples**
 
@@ -106,7 +108,7 @@ var feature = {
   }
 };
 
-var centerOfMass = turf.center-of-mass(feature);
+var centerOfMass = turf.centerOfMass(feature);
 
 //=centerOfMass
 ```

--- a/packages/turf-center-of-mass/index.js
+++ b/packages/turf-center-of-mass/index.js
@@ -10,7 +10,7 @@ var each = require('@turf/meta').coordEach,
  * and returns its [center of mass](https://en.wikipedia.org/wiki/Center_of_mass)
  * using this formula: [Centroid of Polygon](https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon).
  *
- * @name center-of-mass
+ * @name centerOfMass
  * @param {FeatureCollection|Feature} fc - the feature collection or feature
  * @returns {Feature<Point>} the center of mass
  * @example
@@ -106,7 +106,7 @@ var each = require('@turf/meta').coordEach,
  *   }
  * };
  *
- * var centerOfMass = turf.center-of-mass(feature);
+ * var centerOfMass = turf.centerOfMass(feature);
  *
  * //=centerOfMass
  */


### PR DESCRIPTION
I made some typos in the doc of turf-center-of-mass, mainly writing "center-of-mass" instead of "centerOfMass" in code examples, and forgot to update README.md for the FC support.