### PR TITLE
Expose turf.circle on index.

### DIFF
--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -23,6 +23,7 @@ module.exports = {
     sample: require('@turf/sample'),
     envelope: require('@turf/envelope'),
     square: require('@turf/square'),
+    circle: require('@turf/circle'),
     midpoint: require('@turf/midpoint'),
     buffer: require('@turf/buffer'),
     center: require('@turf/center'),


### PR DESCRIPTION
turf.circle is not exposed in index, and what's odd too is that turf.circle is that turf.circle is classified with the "assertions" in the [documentation](http://turfjs.org/docs/#circle).