### PR TITLE
Add package name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "turf",
   "private": true,
   "version": "3.0.0",
   "description": "a node.js library for performing geospatial operations with geojson",


### PR DESCRIPTION
I couldn't install latest turf with npm install, because "name" property was missing from the package.json:
```
ERR! No name provided in package.json
```

It was removed in this commit :
https://github.com/Turfjs/turf/commit/55656b92f44d97633c13ab70cc27586150d8fd3c

I'm not sure if it was intentional or not, but would help me a lot if you could merge this pull request.