### PR TITLE
Update cellSize JSDocs

### DIFF
--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -21,15 +21,15 @@ for (var i = 0; i < 6; i++) {
  * @name hexGrid
  * @param {Array<number>} bbox bounding box in [minX, minY, maxX, maxY] order
  * @param {number} cellSize dimension of cell in specified units
- * @param {string} units used in calculating cellWidth ('miles' or 'kilometers')
+ * @param {string} units used in calculating cellSize ('miles' or 'kilometers')
  * @param {boolean} triangles whether to return as triangles instead of hexagons
  * @return {FeatureCollection<Polygon>} a hexagonal grid
  * @example
  * var bbox = [-96,31,-84,40];
- * var cellWidth = 50;
+ * var cellSize = 50;
  * var units = 'miles';
  *
- * var hexgrid = turf.hexGrid(bbox, cellWidth, units);
+ * var hexgrid = turf.hexGrid(bbox, cellSize, units);
  *
  * //=hexgrid
  */


### PR DESCRIPTION
Keeping JSDocs consistent with the input variable `cellSize` instead of using `cellWidth`