### PR TITLE
JSDocs triangleGrid update

### DIFF
--- a/packages/turf-triangle-grid/index.js
+++ b/packages/turf-triangle-grid/index.js
@@ -8,14 +8,14 @@ var distance = require('@turf/distance');
  * @name triangleGrid
  * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
  * @param {number} cellSize dimension of each cell
- * @param {string} units units to use for cellWidth
+ * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
  * @return {FeatureCollection<Polygon>} grid of polygons
  * @example
- * var extent = [-77.3876953125,38.71980474264239,-76.9482421875,39.027718840211605];
- * var cellWidth = 10;
+ * var bbox = [-96,31,-84,40]
+ * var cellSize = 10;
  * var units = 'miles';
  *
- * var triangleGrid = turf.triangleGrid(extent, cellWidth, units);
+ * var triangleGrid = turf.triangleGrid(extent, cellSize, units);
  *
  * //=triangleGrid
  */


### PR DESCRIPTION
- replaced `cellWidth` with `cellSize`.
- simplified `bbox`.
- added 4 standard units of measurement (of many more).