### PR TITLE
Implementing export default to Turf

### DIFF
--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -9,7 +9,7 @@
  */
 var helpers = require('@turf/helpers');
 
-module.exports = {
+var turf = {
     isolines: require('@turf/isolines'),
     convex: require('@turf/convex'),
     within: require('@turf/within'),
@@ -67,3 +67,8 @@ module.exports = {
     featureCollection: helpers.featureCollection,
     geometryCollection: helpers.geometryCollection
 };
+
+module.exports = turf;
+
+// Allow use of default import syntax in TypeScript
+module.exports.default = turf;


### PR DESCRIPTION
Added export default to root library to enable the default import syntax in Typescript.

This would also make ES6 import a lot cleaner.

**Before** - Current state
```javascript
import * as turf from 'turf'
```
**After** - Using export default
```javascript
import turf from 'turf'
```