### PR TITLE
Update Intersect for GeoJSON.Feature<any> inputs

### DIFF
--- a/packages/turf-intersect/index.js
+++ b/packages/turf-intersect/index.js
@@ -2,11 +2,11 @@
 var jsts = require('jsts');
 
 /**
- * Takes two {@link Polygon|polygons} and finds their intersection. If they share a border, returns the border; if they don't intersect, returns undefined.
+ * Takes two {@link Feature|feature} and finds their intersection. If they share a border, returns the border; if they don't intersect, returns undefined.
  *
  * @name intersect
- * @param {Feature<Polygon>} poly1 the first polygon
- * @param {Feature<Polygon>} poly2 the second polygon
+ * @param {Feature} feature1 the first feature
+ * @param {Feature} feature2 the second feature
  * @return {(Feature|undefined)} returns a feature representing the point(s) they share (in case of a {@link Point}  or {@link MultiPoint}), the borders they share (in case of a {@link LineString} or a {@link MultiLineString}), the area they share (in case of {@link Polygon} or {@link MultiPolygon}). If they do not share any point, returns `undefined`.
  * @example
  * var poly1 = {
@@ -56,12 +56,12 @@ var jsts = require('jsts');
  *
  * //=intersection
  */
-module.exports = function intersect(poly1, poly2) {
+module.exports = function intersect(feature1, feature2) {
     var geom1, geom2;
-    if (poly1.type === 'Feature') geom1 = poly1.geometry;
-    else geom1 = poly1;
-    if (poly2.type === 'Feature') geom2 = poly2.geometry;
-    else geom2 = poly2;
+    if (feature1.type === 'Feature') geom1 = feature1.geometry;
+    else geom1 = feature1;
+    if (feature2.type === 'Feature') geom2 = feature2.geometry;
+    else geom2 = feature2;
     var reader = new jsts.io.GeoJSONReader();
     var a = reader.read(JSON.stringify(geom1));
     var b = reader.read(JSON.stringify(geom2));


### PR DESCRIPTION
Using `intersection` in `jsts` can be applied to any type of GeoJSON in any combinations.

Things can get pretty confusing depending in the parameters.

Example: **intersect(poly, poly)** returns `Point` | `Line` | `Polygon`

Here's a TypeScript definition that would best describe the functionality with overloaded methods.

```javascript
intersect(
  feature1: GeoJSON.Feature<GeoJSON.Point>,
  feature2: GeoJSON.Feature<GeoJSON.Point>
): GeoJSON.Feature<GeoJSON.Point>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.LineString>,
  feature2: GeoJSON.Feature<GeoJSON.LineString>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.Polygon>,
  feature2: GeoJSON.Feature<GeoJSON.Polygon>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.MultiPoint>,
  feature2: GeoJSON.Feature<GeoJSON.MultiPoint>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.MultiPoint>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.MultiLineString>,
  feature2: GeoJSON.Feature<GeoJSON.MultiLineString>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.MultiLineString>;
    intersect(
  feature1: GeoJSON.Feature<GeoJSON.MultiPolygon>,
  feature2: GeoJSON.Feature<GeoJSON.MultiPolygon>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiPolygon>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.Point>,
  feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.Point>
): GeoJSON.Feature<GeoJSON.Point>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.LineString>,
  feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.LineString>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString>,
  feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.MultiLineString>;
intersect(
  feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>,
  feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>
): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiLineString | GeoJSON.MultiPolygon>;
intersect(
  feature1: GeoJSON.Feature<any>,
  feature2: GeoJSON.Feature<any>
): GeoJSON.Feature<any>;
```