### PR TITLE
Shorten Turf intersect example

### DIFF
--- a/packages/turf-intersect/index.js
+++ b/packages/turf-intersect/index.js
@@ -9,46 +9,25 @@ var jsts = require('jsts');
  * @param {Feature<Polygon>} poly2 the second polygon
  * @return {(Feature|undefined)} returns a feature representing the point(s) they share (in case of a {@link Point}  or {@link MultiPoint}), the borders they share (in case of a {@link LineString} or a {@link MultiLineString}), the area they share (in case of {@link Polygon} or {@link MultiPolygon}). If they do not share any point, returns `undefined`.
  * @example
- * var poly1 = {
- *   "type": "Feature",
- *   "properties": {
- *     "fill": "#0f0"
- *   },
- *   "geometry": {
- *     "type": "Polygon",
- *     "coordinates": [[
- *       [-122.801742, 45.48565],
- *       [-122.801742, 45.60491],
- *       [-122.584762, 45.60491],
- *       [-122.584762, 45.48565],
- *       [-122.801742, 45.48565]
- *     ]]
- *   }
- * }
- * var poly2 = {
- *   "type": "Feature",
- *   "properties": {
- *     "fill": "#00f"
- *   },
- *   "geometry": {
- *     "type": "Polygon",
- *     "coordinates": [[
- *       [-122.520217, 45.535693],
- *       [-122.64038, 45.553967],
- *       [-122.720031, 45.526554],
- *       [-122.669906, 45.507309],
- *       [-122.723464, 45.446643],
- *       [-122.532577, 45.408574],
- *       [-122.487258, 45.477466],
- *       [-122.520217, 45.535693]
- *     ]]
- *   }
- * }
+ * var poly1 = polygon([[
+ *   [-122.801742, 45.48565],
+ *   [-122.801742, 45.60491],
+ *   [-122.584762, 45.60491],
+ *   [-122.584762, 45.48565],
+ *   [-122.801742, 45.48565]
+ * ]]);
  *
- * var polygons = {
- *   "type": "FeatureCollection",
- *   "features": [poly1, poly2]
- * };
+ * var poly2 = polygon([[
+ *   [-122.520217, 45.535693],
+ *   [-122.64038, 45.553967],
+ *   [-122.720031, 45.526554],
+ *   [-122.669906, 45.507309],
+ *   [-122.723464, 45.446643],
+ *   [-122.532577, 45.408574],
+ *   [-122.487258, 45.477466],
+ *   [-122.520217, 45.535693]
+ * ]]);
+ * var polygons = featureCollection([poly1, poly2]);
  *
  * var intersection = turf.intersect(poly1, poly2);
  *

--- a/packages/turf-intersect/index.js
+++ b/packages/turf-intersect/index.js
@@ -27,11 +27,8 @@ var jsts = require('jsts');
  *   [-122.487258, 45.477466],
  *   [-122.520217, 45.535693]
  * ]]);
- * var polygons = featureCollection([poly1, poly2]);
  *
  * var intersection = turf.intersect(poly1, poly2);
- *
- * //=polygons
  *
  * //=intersection
  */


### PR DESCRIPTION
Using the `helpers` methods can shorten the lines of code used for the example. Easier to read the JSDoc with editors such as VSCode or Atom.

![image](https://cloud.githubusercontent.com/assets/550895/18526755/d3e59fe6-7a8f-11e6-9e38-17d6476ca15a.png)
