### PR TITLE
JSDocs update hex-grid

### DIFF
--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -21,7 +21,7 @@ for (var i = 0; i < 6; i++) {
  * @name hexGrid
  * @param {Array<number>} bbox bounding box in [minX, minY, maxX, maxY] order
  * @param {number} cellSize dimension of cell in specified units
- * @param {string} units used in calculating cellSize ('miles' or 'kilometers')
+ * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
  * @param {boolean} triangles whether to return as triangles instead of hexagons
  * @return {FeatureCollection<Polygon>} a hexagonal grid
  * @example


### PR DESCRIPTION
Hexgrid units are optional using the `distance` method.

Closed PR https://github.com/Turfjs/turf/pull/474 due to conflicts
