### PR TITLE
Remove turf modules v3.0.x from dependencies

### DIFF
--- a/packages/turf-line-slice-along/index.js
+++ b/packages/turf-line-slice-along/index.js
@@ -1,7 +1,7 @@
-var bearing = require('turf-bearing');
-var distance = require('turf-distance');
-var destination = require('turf-destination');
-var lineString = require('turf-helpers').lineString;
+var bearing = require('@turf/bearing');
+var distance = require('@turf/distance');
+var destination = require('@turf/destination');
+var lineString = require('@turf/helpers').lineString;
 
 
 /**

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -21,15 +21,15 @@
     "url": "https://github.com/Turfjs/turf/issues"
   },
   "homepage": "https://github.com/Turfjs/turf",
-  "dependencies": {
-    "turf-bearing": "^3.0.1",
-    "turf-destination": "^3.0.5",
-    "turf-distance": "^3.0.5",
-    "turf-helpers": "^3.0.5"
-  },
   "devDependencies": {
     "benchmark": "^1.0.0",
     "tape": "^3.5.0",
-    "turf-along": "^3.0.5"
+    "@turf/along": "^3.5.2"
+  },
+  "dependencies": {
+    "@turf/bearing": "^3.5.2",
+    "@turf/destination": "^3.5.2",
+    "@turf/distance": "^3.5.2",
+    "@turf/helpers": "^3.5.2"
   }
 }

--- a/packages/turf-line-slice-along/test.js
+++ b/packages/turf-line-slice-along/test.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var lineSliceAlong = require('./');
-var along = require('turf-along');
+var along = require('@turf/along');
 
 var line1 = JSON.parse(fs.readFileSync(path.join(__dirname, '/test/fixtures/line1.geojson')));
 var route1 = JSON.parse(fs.readFileSync(path.join(__dirname, '/test/fixtures/route1.geojson')));


### PR DESCRIPTION
Fix #501 removing deps to v3.0.x modules

Still have a dep to "turf-grid" in turf-isolines though (vs **turf-point-grid** 3.0.x / **@turf/point-grid** 3.5.x ?)