### PR TITLE
Replaced turf-grid with @turf/point-grid

### DIFF
--- a/packages/turf-isolines/index.js
+++ b/packages/turf-isolines/index.js
@@ -2,11 +2,13 @@
 //http://stackoverflow.com/questions/263305/drawing-a-topographical-map
 var tin = require('@turf/tin');
 var inside = require('@turf/inside');
-var grid = require('turf-grid');
+var grid = require('@turf/point-grid');
+var distance = require('@turf/distance');
 var bbox = require('@turf/bbox');
 var planepoint = require('@turf/planepoint');
 var featurecollection = require('@turf/helpers').featureCollection;
 var linestring = require('@turf/helpers').lineString;
+var point = require('@turf/helpers').point;
 var square = require('@turf/square');
 var Conrec = require('./conrec');
 
@@ -37,7 +39,8 @@ module.exports = function (points, z, resolution, breaks) {
     var tinResult = tin(points, z);
     var bboxBBox = bbox(points);
     var squareBBox = square(bboxBBox);
-    var gridResult = grid(squareBBox, resolution);
+    var sizeCellGrid = distance(point([squareBBox[0], squareBBox[1]]), point([squareBBox[2], squareBBox[1]]), 'kilometers') / resolution;
+    var gridResult = grid(squareBBox, sizeCellGrid, 'kilometers');
     var data = [];
 
     for (var i = 0; i < gridResult.features.length; i++) {

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@turf/bbox": "^3.5.2",
-    "turf-grid": "1.0.1",
+    "@turf/point-grid": "^3.5.2",
+    "@@turf/distance": "^3.5.2",
     "@turf/inside": "^3.5.2",
     "@turf/helpers": "^3.5.2",
     "@turf/planepoint": "^3.5.2",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@turf/bbox": "^3.5.2",
     "@turf/point-grid": "^3.5.2",
-    "@@turf/distance": "^3.5.2",
+    "@turf/distance": "^3.5.2",
     "@turf/inside": "^3.5.2",
     "@turf/helpers": "^3.5.2",
     "@turf/planepoint": "^3.5.2",


### PR DESCRIPTION
This change fixes issue #501 

The @turf/point-grid package has the 'unit' input parameter, but is not defined as input in or used by the @turf/isolines package. The parameter is canceled out with the added code.
