### PR TITLE
Add Typescript 2.0 definition

### DIFF
--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -1,0 +1,69 @@
+/// <reference types="geojson" />
+
+export type Point = Array<number>
+export type LineString = Array<Array<number>>
+export type Polygon = Array<Array<Array<number>>>
+export type MultiPoint = Array<Point>
+export type MultiLineString = Array<LineString>
+export type MultiPolygon = Array<Polygon>
+export type Units = "miles" | "nauticalmiles" | "degrees" | "radians" | "inches" | "yards" | "meters" | "metres" | "kilometers" | "kilometres"
+
+/***
+ * http://turfjs.org/docs/#feature
+ */
+export function feature(geometry: GeoJSON.Feature<any>, properties?: Object): GeoJSON.Feature<any>;
+
+/***
+ * http://turfjs.org/docs/#point
+ */
+export function point(coordinates: Point, properties?: Object): GeoJSON.Feature<GeoJSON.Point>;
+
+/***
+ * http://turfjs.org/docs/#polygon
+ */
+export function polygon(coordinates: Polygon, properties?: Object): GeoJSON.Feature<GeoJSON.Polygon>;
+
+/***
+ * http://turfjs.org/docs/#linestring
+ */
+export function lineString(coordinates: LineString, properties?: Object): GeoJSON.Feature<GeoJSON.LineString>;
+
+/***
+ * http://turfjs.org/docs/#featurecollection
+ */
+export function featureCollection(features: Array<GeoJSON.Feature<any>>): GeoJSON.FeatureCollection<GeoJSON.MultiPoint>;
+
+/***
+ * http://turfjs.org/docs/#multilinestring
+ */
+export function multiLineString(coordinates: MultiLineString, properties?: Object): GeoJSON.Feature<GeoJSON.MultiLineString>;
+
+/***
+ * http://turfjs.org/docs/#multipoint
+ */
+export function multiPoint(coordinates: MultiPoint, properties?: Object): GeoJSON.Feature<GeoJSON.MultiPoint>;
+
+/***
+ * http://turfjs.org/docs/#multipolygon
+ */
+export function multiPolygon(coordinates: MultiPolygon, properties?: Object): GeoJSON.Feature<GeoJSON.MultiPolygon>;
+
+/***
+ * http://turfjs.org/docs/#geometrycollection
+ */
+export function geometryCollection(geometries: Array<GeoJSON.GeometryObject>, properties?: Object): GeoJSON.GeometryCollection;
+
+/***
+ * http://turfjs.org/docs/
+ */
+export function radiansToDistance(radians: number, units: Units): number
+
+/***
+ * http://turfjs.org/docs/
+ */
+export function distanceToRadians(distance: number, units: Units): number
+
+/***
+ * http://turfjs.org/docs/
+ */
+export function distanceToDegrees(distance: number, units: Units): number

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -4,7 +4,7 @@
   "description": "turf geometries",
   "main": "index.js",
   "scripts": {
-    "test": "tape test.js"
+    "test": "tape test.js && tsc index.d.ts"
   },
   "repository": {
     "type": "git",
@@ -23,8 +23,11 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
+    "@types/geojson": "0.0.31",
     "benchmark": "^1.0.0",
-    "tape": "^3.5.0"
+    "tape": "^3.5.0",
+    "typescript": "^2.0.7"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Adding Typescript 2.0 definition inside the sub-modules will be a lot easier to maintain without any external dependencies for Typescript support.

Microsoft Typescript dev teams favours bundling the definitions into the npm package.

> Now that you have authored a declaration file following the steps of this guide, it is time to publish it to npm. There are two main ways you can publish your declaration files to npm:

> 1. bundling with your npm package, or
> 2. publishing to the @types organization on npm.

> If you control the npm package you are publishing declarations for, then the first approach is favored. That way, your declarations and JavaScript always travel together.

https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/declaration%20files/Publishing.md