### PR TITLE
Update turf-simplify optional params

### DIFF
--- a/packages/turf-simplify/index.js
+++ b/packages/turf-simplify/index.js
@@ -8,8 +8,8 @@ var supportedTypes = ['LineString', 'MultiLineString', 'Polygon', 'MultiPolygon'
  *
  * @name simplify
  * @param {Feature<(LineString|Polygon|MultiLineString|MultiPolygon)>|FeatureCollection|GeometryCollection} feature feature to be simplified
- * @param {number} tolerance simplification tolerance
- * @param {boolean} highQuality whether or not to spend more time to create
+ * @param {number} [tolerance=1] simplification tolerance
+ * @param {boolean} [highQuality=false] whether or not to spend more time to create
  * a higher-quality simplification with a different algorithm
  * @return {Feature<(LineString|Polygon|MultiLineString|MultiPolygon)>|FeatureCollection|GeometryCollection} a simplified feature
  * @example


### PR DESCRIPTION
This package uses `simplify-js`.

The reference for the added optional `@params` can be found here:

https://github.com/mourner/simplify-js/blob/master/simplify.js#L103-L113