### PR TITLE
Upgrade geojson-area dependency

### DIFF
--- a/packages/turf-area/index.js
+++ b/packages/turf-area/index.js
@@ -1,4 +1,4 @@
-var geometryArea = require('geojson-area').geometry;
+var geometryArea = require('@mapbox/geojson-area').geometry;
 
 /**
  * Takes one or more features and returns their area

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -15,7 +15,7 @@
   "author": "Tom MacWright",
   "license": "ISC",
   "dependencies": {
-    "geojson-area": "^0.2.1"
+    "@mapbox/geojson-area": "^0.2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previous version (0.2.1):

* Couldn't be used with "use strict" (due to a global loop "i" variable)
  See https://git.io/v1hEy for more details.

* Showed a deprecation message (because it should be used as
  "@mapbox/geojson-area"