### PR TITLE
maintain linestring altitude data when simplifying a linestring with altitude data

### DIFF
--- a/packages/turf-simplify/index.js
+++ b/packages/turf-simplify/index.js
@@ -147,17 +147,9 @@ function simpleFeature(geom, properties) {
 
 function simplifyLine(coordinates, tolerance, highQuality) {
     return simplify(coordinates.map(function (coord) {
-        if (coord.len === 2){
-            return {x: coord[0], y: coord[1]};
-        } else {
-            return {x: coord[0], y: coord[1], z: coord[2]};
-        }
+        return {x: coord[0], y: coord[1]};
     }), tolerance, highQuality).map(function (coords) {
-        if (coords.len === 2){
-            return [coords.x, coords.y];
-        } else {
-            return [coords.x, coords.y, coords.z];
-        }
+        return [coords.x, coords.y, coords.z];
     });
 }
 

--- a/packages/turf-simplify/index.js
+++ b/packages/turf-simplify/index.js
@@ -147,9 +147,17 @@ function simpleFeature(geom, properties) {
 
 function simplifyLine(coordinates, tolerance, highQuality) {
     return simplify(coordinates.map(function (coord) {
-        return {x: coord[0], y: coord[1]};
+        if (coord.len === 2){
+            return {x: coord[0], y: coord[1]};
+        } else {
+            return {x: coord[0], y: coord[1], z: coord[2]};
+        }
     }), tolerance, highQuality).map(function (coords) {
-        return [coords.x, coords.y];
+        if (coords.len === 2){
+            return [coords.x, coords.y];
+        } else {
+            return [coords.x, coords.y, coords.z];
+        }
     });
 }
 


### PR DESCRIPTION
extended functionality to maintain elevation in case the positions of a linestring contains elevation data as well (currently unsupported)

note: this is in line with specs which foresees the elevation as 3rd element of positions -> https://tools.ietf.org/html/rfc7946#section-3.1.1 (and http://geojson.org/geojson-spec.html#positions)