### PR TITLE
Fix typings for tin

### DIFF
--- a/packages/turf-tin/index.d.ts
+++ b/packages/turf-tin/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="geojson" />
 
-type Point = GeoJSON.FeatureCollection<GeoJSON.Point>;
+type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
 type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
 /**


### PR DESCRIPTION
Otherwise `typescript@2.1.4` correctly complains:
```
ERROR in …/node_modules/@turf/tin/index.d.ts
(9,30): error TS2304: Cannot find name 'Points'.
```