### PR TITLE
Test all Typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "a node.js library for performing geospatial operations with geojson",
   "scripts": {
-    "test": "npm run lint && npm run types && lerna bootstrap && lerna run test",
+    "test": "npm run lint && lerna bootstrap && lerna run test && npm run types",
     "lint": "eslint packages",
     "types": "tsc",
     "prepublish": "node ./scripts/generate-readmes"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "npm run lint && npm run types && lerna bootstrap && lerna run test",
     "lint": "eslint packages",
-    "types": "tsc **/test/types.ts --noImplicitAny",
+    "types": "tsc",
     "prepublish": "node ./scripts/generate-readmes"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "3.0.0",
   "description": "a node.js library for performing geospatial operations with geojson",
   "scripts": {
-    "test": "npm run lint && lerna bootstrap && lerna run test",
+    "test": "npm run lint && npm run types && lerna bootstrap && lerna run test",
     "lint": "eslint packages",
+    "types": "tsc **/test/types.ts --noImplicitAny",
     "prepublish": "node ./scripts/generate-readmes"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES5",
+        "noImplicitAny": true
+    },
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Need some input on how to tackle this. 

**Option 1**
Add a single npm script in the root directory to test valid Typescript definitions via `test/types.ts` (current PR).

**Option 2**
Have tests running in each individual package? If that's the case, all Typescript dependencies needs to be included (@types/node, @types/geojson & typescript), this option sounds overkill.

@tmcw @morganherlocker 