### PR TITLE
Fix comparison operator throwing linting error in the tests

### DIFF
--- a/packages/turf-inside/index.js
+++ b/packages/turf-inside/index.js
@@ -56,7 +56,7 @@ function inRing(pt, ring) {
     for (var i = 0, j = ring.length - 1; i < ring.length; j = i++) {
         var xi = ring[i][0], yi = ring[i][1];
         var xj = ring[j][0], yj = ring[j][1];
-        if ((xi == pt[0] && yi == pt[1]) || (xj == pt[0] && yj == pt[1])) return true;
+        if ((xi === pt[0] && yi === pt[1]) || (xj === pt[0] && yj === pt[1])) return true;
         var intersect = ((yi > pt[1]) !== (yj > pt[1])) &&
         (pt[0] < (xj - xi) * (pt[1] - yi) / (yj - yi) + xi);
         if (intersect) isInside = !isInside;


### PR DESCRIPTION
ESlint was throwing an error because of a `==` equality operator so simply changed it `===`