### PR TITLE
Check turf-concave if not enough polygons to compute hull

### DIFF
--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -85,7 +85,7 @@ function concave(points, maxEdge, units) {
     var filteredPolys = tinPolys.features.filter(filterTriangles);
     tinPolys.features = filteredPolys;
     if (tinPolys.features.length < 1) {
-        throw new Error("too few polygons found to compute concave hull");
+        throw new Error('too few polygons found to compute concave hull');
     }
 
     function filterTriangles(triangle) {

--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -17,7 +17,7 @@ var distance = require('@turf/distance');
  * hull to become concave (in miles)
  * @param {string} [units=kilometers] can be degrees, radians, miles, or kilometers
  * @returns {Feature<Polygon>} a concave hull
- * @throws {Error} if maxEdge parameter is missing
+ * @throws {Error} if maxEdge parameter is missing or unable to compute hull
  * @example
  * var points = {
  *   "type": "FeatureCollection",
@@ -84,6 +84,9 @@ function concave(points, maxEdge, units) {
     var tinPolys = tin(points);
     var filteredPolys = tinPolys.features.filter(filterTriangles);
     tinPolys.features = filteredPolys;
+    if (tinPolys.features.length < 1) {
+        throw new Error("too few polygons found to compute concave hull");
+    }
 
     function filterTriangles(triangle) {
         var pt1 = triangle.geometry.coordinates[0][0];

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "benchmark": "^1.0.0",
     "glob": "~4.3.5",
-    "tape": "~3.5.0"
+    "tape": "~3.5.0",
+    "@turf/helpers": "^3.7.3"
   },
   "dependencies": {
     "@turf/meta": "^3.7.3",

--- a/packages/turf-concave/test.js
+++ b/packages/turf-concave/test.js
@@ -1,9 +1,29 @@
 var concave = require('./');
 var test = require('tape');
 var fs = require('fs');
+var featureCollection = require('@turf/helpers').featureCollection;
+var point = require('@turf/helpers').point;
 
 var pts1 = JSON.parse(fs.readFileSync(__dirname+'/test/fixtures/in/pts1.geojson'));
 var pts2 = JSON.parse(fs.readFileSync(__dirname+'/test/fixtures/in/pts2.geojson'));
+
+test('concave', function(t){
+
+  var ptsOnePoint = featureCollection([point([0, 0])]);
+  var ptsOnePointHull = null;
+  t.throws(function(){
+      ptsOnePointHull = concave(ptsOnePoint, 5.5, 'miles');
+  }, Error, "fails with too few points");
+  t.notOk(ptsOnePointHull, 'hull not computed with too few points');
+
+  var ptsNoPointHull = null;
+  t.throws(function(){
+      ptsNoPointHull = concave(pts1, 0, 'miles');
+  }, Error, "fails with small maxEdge");
+  t.notOk(ptsNoPointHull, 'hull not computed with small maxEdge');
+
+  t.end();
+});
 
 test('concave', function(t){
   var pts1HullMiles = concave(pts1, 5.5, 'miles');

--- a/packages/turf-concave/test.js
+++ b/packages/turf-concave/test.js
@@ -13,13 +13,13 @@ test('concave', function(t){
   var ptsOnePointHull = null;
   t.throws(function(){
       ptsOnePointHull = concave(ptsOnePoint, 5.5, 'miles');
-  }, Error, "fails with too few points");
+  }, Error, 'fails with too few points');
   t.notOk(ptsOnePointHull, 'hull not computed with too few points');
 
   var ptsNoPointHull = null;
   t.throws(function(){
       ptsNoPointHull = concave(pts1, 0, 'miles');
-  }, Error, "fails with small maxEdge");
+  }, Error, 'fails with small maxEdge');
   t.notOk(ptsNoPointHull, 'hull not computed with small maxEdge');
 
   t.end();


### PR DESCRIPTION
Added a check and new tests to address #550. The new code still throws an exception like the old code but it now has a sensible message that there was a problem instead of the cryptic SyntaxError token thrown previously.