### PR TITLE
[line-slice-along] Fix a crash (accessing coord[i+1] when i is the last index) when overshooting a line in some cases.

### DIFF
--- a/packages/turf-line-slice-along/index.js
+++ b/packages/turf-line-slice-along/index.js
@@ -85,6 +85,10 @@ module.exports = function lineSliceAlong(line, startDist, stopDist, units) {
             slice.push(coords[i]);
         }
 
+        if (i === coords.length - 1) {
+            return lineString(slice);
+        }
+
         travelled += distance(coords[i], coords[i + 1], units);
     }
     return lineString(coords[coords.length - 1]);

--- a/packages/turf-line-slice-along/test.js
+++ b/packages/turf-line-slice-along/test.js
@@ -23,6 +23,21 @@ test('turf-line-slice -- line1', function (t) {
 		t.end();
 });
 
+test('turf-line-slice -- line1 overshoot', function (t) {
+		var start = 500;
+		var stop = 1500;
+	  var units = 'miles';
+
+		var start_point = along(line1, start, units);
+		var end_point = along(line1, stop, units);
+		var sliced = lineSliceAlong(line1, start, stop, units);
+		t.equal(sliced.type, 'Feature');
+		t.equal(sliced.geometry.type, 'LineString');
+		t.deepEqual(sliced.geometry.coordinates[0], start_point.geometry.coordinates);
+		t.deepEqual(sliced.geometry.coordinates[sliced.geometry.coordinates.length - 1], end_point.geometry.coordinates);
+		t.end();
+});
+
 test('turf-line-slice-along -- route1', function (t) {
 		var start = 500;
 		var stop = 750;


### PR DESCRIPTION
When startDist = 0 and stopDist is greater than the line length, line-slice-along crashes because it tries to access the n+1 index of an array (OutOfBound).

I added a simple check to return the current slice if we've travelled until the end of the line.
