### PR TITLE
Round index up

### DIFF
--- a/packages/turf-point-on-line/index.js
+++ b/packages/turf-point-on-line/index.js
@@ -99,7 +99,7 @@ module.exports = function (line, pt, units) {
         }
         if (stop.properties.dist < closestPt.properties.dist) {
             closestPt = stop;
-            closestPt.properties.index = i;
+            closestPt.properties.index = i + 1;
             closestPt.properties.location = length + sectionLength;
         }
         if (intersectPt && intersectPt.properties.dist < closestPt.properties.dist) {

--- a/packages/turf-point-on-line/test/test.js
+++ b/packages/turf-point-on-line/test/test.js
@@ -154,3 +154,15 @@ test('turf-point-on-line - points on sides of lines', function (t) {
 
     t.end();
 });
+
+test('turf-point-on-line - check dist and index', function(t) {
+    var line = linestring([[-92.09049224853516,41.10289743708757],[-92.19108581542969,41.07986874098993],[-92.22850799560547,41.05605531253442],[-92.23709106445312,41.00814350872298],[-92.22576141357422,40.96693739752686],[-92.15023040771484,40.93685883302701],[-92.11246490478516,40.97756533655244],[-92.06268310546874,41.03456405894359],[-92.10079193115234,41.04000226828482]]);
+    var pt = point([-92.11057662963867, 41.04064964423169]);
+    var snapped = pointOnLine(line, pt);
+
+    t.equal(snapped.properties.index, 8, 'properties.index');
+    t.equal(snapped.properties.dist, 0.8240378840589049, 'properties.dist');
+    t.deepEqual(snapped.geometry.coordinates,[-92.10079193115234, 41.04000226828482], 'coordinates');
+
+    t.end();
+});


### PR DESCRIPTION
_Pulled from https://github.com/turf-junkyard/turf-point-on-line/pull/8_

The current behavior is biased towards the beginning of the line. In other words, if you’re midway between two vertices on the line, the returned index always corresponds to the earlier vertex, even if the point is closer to the later vertex. (The distance is consistent with this bias.) It’s as if the function “rounds down”. 

Here is the test case I added: 
![](https://cldup.com/ZlXrFgp6cp.png)
>[Link](http://geojson.io/#id=gist:bsudekum/c2967fcaf2cbbef16d57401e40007ace&map=12/41.0328/-92.1629)

On master, the index will be `7`, on this PR the index would be `8` or the last (middle most) point. Visually, this makes sense; the point is closest to the endpoint of the line

We discovered this bug while porting this library to [swift](https://github.com/mapbox/MapboxNavigation.swift/blob/master/MapboxNavigation/Geometry.swift#L142-L177) and started to see some interesting edge cases when using this lib to draw maneuver arrows:

![](https://cldup.com/Dahiek7MUf.png)

> _We use the index to know where to put the tip of the arrow_

/cc @DenisCarriere @tmcw @morganherlocker @1ec5