### PR TITLE
license fix in package.json files #569

### DIFF
--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -13,7 +13,7 @@
     "multipolygon"
   ],
   "author": "Tom MacWright",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.2"
   },

--- a/packages/turf-bezier/package.json
+++ b/packages/turf-bezier/package.json
@@ -18,7 +18,7 @@
     "linestring"
   ],
   "author": "Morgan Herlocker",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -16,7 +16,7 @@
     "geometry"
   ],
   "author": "Morgan Herlocker",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -18,7 +18,7 @@
     "gis"
   ],
   "author": "Morgan Herlocker",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -16,7 +16,7 @@
     "intersect"
   ],
   "author": "Morgan Herlocker",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -12,7 +12,7 @@
     "expectations"
   ],
   "author": "Tom MacWright",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -12,7 +12,7 @@
     "turfjs"
   ],
   "author": "Tom MacWright",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@turf/random": "^3.7.5",
     "eslint": "^3.14.1",

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -15,7 +15,7 @@
     "gis"
   ],
   "author": "Tom MacWright",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -19,7 +19,7 @@
     "simplify"
   ],
   "author": "Morgan Herlocker",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -15,7 +15,7 @@
     "gif"
   ],
   "author": "Morgan Herlocker",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
   },


### PR DESCRIPTION
Code not changed.

ISC just replaced with MIT in `package.json` files
