### PR TITLE
Rework turf-meta #587

### DIFF
--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -96,7 +96,7 @@ Array.forEach.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (value)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (feature, index)
 
 **Examples**
 

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -8,7 +8,7 @@ Array.forEach.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (value)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (coords, index)
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
     the final coordinate of LinearRings that wraps the ring in its iteration.
 
@@ -16,8 +16,9 @@ Array.forEach.
 
 ```javascript
 var point = { type: 'Point', coordinates: [0, 0] };
-turfMeta.coordEach(point, function(coords) {
+turfMeta.coordEach(point, function(coords, index) {
   // coords is equal to [0, 0]
+  // index is equal to 0
 });
 ```
 
@@ -30,13 +31,12 @@ the reduction, so an array of all coordinates is unnecessary.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (memo, value) and returns
-    a new memo
--   `memo` **Any** the starting value of memo: can be any type.
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (memo, coords, index)
+-   `memo` **\[Any]** Value to use as the first argument to the first call of the callback.
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
     the final coordinate of LinearRings that wraps the ring in its iteration.
 
-Returns **Any** combined value
+Returns **Any** The value that results from the reduction.
 
 # propEach
 

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -2,31 +2,48 @@
 
 # coordEach
 
-Iterate over coordinates in any GeoJSON object, similar to
-Array.forEach.
+Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
 
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (coords, index)
+-   `callback` **coordEachCallback** a method that takes (currentCoords, currentIndex)
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
-    the final coordinate of LinearRings that wraps the ring in its iteration.
+    the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
 
 **Examples**
 
 ```javascript
-var point = { type: 'Point', coordinates: [0, 0] };
-turfMeta.coordEach(point, function(coords, index) {
-  // coords is equal to [0, 0]
-  // index is equal to 0
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+turf.coordEach(features, function (currentCoords, currentIndex) {
+  //=currentCoords
+  //=currentIndex
 });
 ```
 
 # coordReduce
 
-Reduce coordinates in any GeoJSON object into a single value,
-similar to how Array.reduce works. However, in this case we lazily run
-the reduction, so an array of all coordinates is unnecessary.
+Reduce coordinates in any GeoJSON object, similar to Array.reduce()
 
 **Parameters**
 
@@ -34,26 +51,77 @@ the reduction, so an array of all coordinates is unnecessary.
 -   `callback` **coordReduceCallback** a method that takes (previousValue, currentCoords, currentIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
-    the final coordinate of LinearRings that wraps the ring in its iteration.
+    the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
+
+**Examples**
+
+```javascript
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+turf.coordReduce(features, function (previousValue, currentCoords, currentIndex) {
+  //=previousValue
+  //=currentCoords
+  //=currentIndex
+});
+```
 
 Returns **Any** The value that results from the reduction.
 
 # propEach
 
-Iterate over property objects in any GeoJSON object, similar to
-Array.forEach.
+Iterate over properties in any GeoJSON object, similar to Array.forEach()
 
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (value)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentProperties, currentIndex)
 
 **Examples**
 
 ```javascript
-var point = { type: 'Feature', geometry: null, properties: { foo: 1 } };
-turfMeta.propEach(point, function(props) {
-  // props is equal to { foo: 1}
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"foo": "bar"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"hello": "world"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+turf.propEach(features, function (currentProperties, currentIndex) {
+  //=currentProperties
+  //=currentIndex
 });
 ```
 
@@ -66,27 +134,42 @@ the reduction, so an array of all properties is unnecessary.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (memo, coord) and returns
-    a new memo
--   `memo` **Any** the starting value of memo: can be any type.
+-   `callback` **propReduceCallback** a method that takes (previousValue, currentProperties, currentIndex)
+-   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
 **Examples**
 
 ```javascript
-// an example of an even more advanced function that gives you the
-// javascript type of each property of every feature
-function propTypes (layer) {
-  opts = opts || {}
-  return turfMeta.propReduce(layer, function (prev, props) {
-    for (var prop in props) {
-      if (prev[prop]) continue
-      prev[prop] = typeof props[prop]
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"foo": "bar"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"hello": "world"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
     }
-  }, {})
-}
+  ]
+};
+turf.propReduce(features, function (previousValue, currentProperties, currentIndex) {
+  //=previousValue
+  //=currentProperties
+  //=currentIndex
+  return currentProperties
+});
 ```
 
-Returns **Any** combined value
+Returns **Any** The value that results from the reduction.
 
 # featureEach
 
@@ -96,50 +179,200 @@ Array.forEach.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (feature, index)
+-   `callback` **featureEachCallback** a method that takes (currentFeature, currentIndex)
 
 **Examples**
 
 ```javascript
-var feature = { type: 'Feature', geometry: null, properties: {} };
-turfMeta.featureEach(feature, function(feature) {
-  // feature == feature
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+turf.featureEach(features, function (currentFeature) {
+  //=currentFeature
 });
 ```
 
-# coordAll
+# featureReduce
 
-Get all coordinates from any GeoJSON object, returning an array of coordinate
-arrays.
+Reduce features in any GeoJSON object, similar to Array.reduce().
 
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
+-   `callback` **featureReduceCallback** a method that takes (previousValue, currentFeature, currentIndex)
+-   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
+
+**Examples**
+
+```javascript
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"foo": "bar"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"hello": "world"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+turf.featureReduce(features, function (previousValue, currentFeature, currentIndex) {
+  //=previousValue
+  //=currentFeature
+  //=currentIndex
+  return currentFeature
+});
+```
+
+Returns **Any** The value that results from the reduction.
+
+# coordAll
+
+Get all coordinates from any GeoJSON object.
+
+**Parameters**
+
+-   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
+
+**Examples**
+
+```javascript
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+var coords = turf.coordAll(features);
+//=coords
+```
 
 Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>>** coordinate position array
 
 # geomEach
 
-Iterate over each geometry in any GeoJSON object, similar to
-Array.forEach.
+Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
 
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (value)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (geometry)
 
 **Examples**
 
 ```javascript
-var point = {
-  type: 'Feature',
-  geometry: { type: 'Point', coordinates: [0, 0] },
-  properties: {}
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
 };
-turfMeta.geomEach(point, function(geom) {
-  // geom is the point geometry
+turf.geomEach(features, function (geometry) {
+  //=geometry
 });
 ```
+
+# geomReduce
+
+Reduce geometry in any GeoJSON object, similar to Array.reduce().
+
+**Parameters**
+
+-   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
+-   `callback` **geomReduceCallback** a method that takes (previousValue, currentGeometry, currentIndex)
+-   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
+
+**Examples**
+
+```javascript
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"foo": "bar"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"hello": "world"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [36, 53]
+      }
+    }
+  ]
+};
+turf.geomReduce(features, function (previousValue, currentGeometry, currentIndex) {
+  //=previousValue
+  //=currentGeometry
+  //=currentIndex
+  return currentGeometry
+});
+```
+
+Returns **Any** The value that results from the reduction.
 
 <!-- This file is automatically generated. Please don't edit it directly:
 if you find an error, edit the source file (likely index.js), and re-run

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -31,8 +31,8 @@ the reduction, so an array of all coordinates is unnecessary.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (memo, coords, index)
--   `memo` **\[Any]** Value to use as the first argument to the first call of the callback.
+-   `callback` **coordReduceCallback** a method that takes (previousValue, currentCoords, currentIndex)
+-   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
     the final coordinate of LinearRings that wraps the ring in its iteration.
 

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -81,6 +81,7 @@ turf.coordReduce(features, function (previousValue, currentCoords, currentIndex)
   //=previousValue
   //=currentCoords
   //=currentIndex
+  return currentCoords;
 });
 ```
 
@@ -205,8 +206,9 @@ var features = {
     }
   ]
 };
-turf.featureEach(features, function (currentFeature) {
+turf.featureEach(features, function (currentFeature, currentIndex) {
   //=currentFeature
+  //=currentIndex
 });
 ```
 
@@ -299,7 +301,7 @@ Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (geometry)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentGeometry, currentIndex)
 
 **Examples**
 
@@ -325,8 +327,9 @@ var features = {
     }
   ]
 };
-turf.geomEach(features, function (geometry) {
-  //=geometry
+turf.geomEach(features, function (currentGeometry, currentIndex) {
+  //=currentGeometry
+  //=currentIndex
 });
 ```
 

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -7,7 +7,7 @@ Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **coordEachCallback** a method that takes (currentCoords, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentCoords, currentIndex)
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
     the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
 
@@ -48,7 +48,7 @@ Reduce coordinates in any GeoJSON object, similar to Array.reduce()
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **coordReduceCallback** a method that takes (previousValue, currentCoords, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentCoords, currentIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 -   `excludeWrapCoord` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether or not to include
     the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
@@ -134,7 +134,7 @@ the reduction, so an array of all properties is unnecessary.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **propReduceCallback** a method that takes (previousValue, currentProperties, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentProperties, currentIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
 **Examples**
@@ -179,7 +179,7 @@ Array.forEach.
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **featureEachCallback** a method that takes (currentFeature, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentFeature, currentIndex)
 
 **Examples**
 
@@ -217,7 +217,7 @@ Reduce features in any GeoJSON object, similar to Array.reduce().
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **featureReduceCallback** a method that takes (previousValue, currentFeature, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentFeature, currentIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
 **Examples**
@@ -337,7 +337,7 @@ Reduce geometry in any GeoJSON object, similar to Array.reduce().
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **geomReduceCallback** a method that takes (previousValue, currentGeometry, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentGeometry, currentIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
 **Examples**

--- a/packages/turf-meta/bench.js
+++ b/packages/turf-meta/bench.js
@@ -13,13 +13,31 @@ const suite = new Benchmark.Suite('turf-meta');
 
 Object.keys(fixtures).forEach(name => {
     const fixture = fixtures[name];
-    suite.add('coordEach#' + name, () => {
-        meta.coordEach(fixture, (coords, index) => { });
+    suite.add('coordEach     - ' + name, () => {
+        meta.coordEach(fixture, (currentCoords, currentIndex) => { });
     });
-    suite.add('coordReduce#' + name, () => {
-        meta.coordReduce(fixture, (previousValue, currentCoords, index) => { });
+    suite.add('coordReduce   - ' + name, () => {
+        meta.coordReduce(fixture, (previousValue, currentCoords, currentIndex) => { });
     });
-    suite.add('coordAll#' + name, () => {
+    suite.add('propEach      - ' + name, () => {
+        meta.propEach(fixture, (currentProperties, currentIndex) => { });
+    });
+    suite.add('propReduce    - ' + name, () => {
+        meta.propReduce(fixture, (previousValue, currentProperties, currentIndex) => { });
+    });
+    suite.add('geomEach      - ' + name, () => {
+        meta.geomEach(fixture, (currentGeometry, currentIndex) => { });
+    });
+    suite.add('geomReduce    - ' + name, () => {
+        meta.geomReduce(fixture, (previousValue, currentGeometry, currentIndex) => { });
+    });
+    suite.add('featureEach   - ' + name, () => {
+        meta.featureEach(fixture, (currentFeature, currentIndex) => { });
+    });
+    suite.add('featureReduce - ' + name, () => {
+        meta.featureReduce(fixture, (previousValue, currentFeature, currentIndex) => { });
+    });
+    suite.add('coordAll      - ' + name, () => {
         meta.coordAll(fixture);
     });
 });

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -21,18 +21,18 @@ interface MetaStatic {
     /**
      * http://turfjs.org/docs/#coordeach
      */
-    coordEach(layer: Points | Point | MultiPoint | MultiPoints, callback: (coords: Array<number>) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (coords: Array<Array<number>>) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (coords: Array<Array<Array<number>>>) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: GeometryCollection | GeometryObject, callback: (coords: Array<any>) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: Points | Point | MultiPoint | MultiPoints, callback: (coords: Array<number>, index: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (coords: Array<Array<number>>, index: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (coords: Array<Array<Array<number>>>, index: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: GeometryCollection | GeometryObject, callback: (coords: Array<any>, index: number) => void, excludeWrapCoord?: boolean): void;
 
     /**
      * http://turfjs.org/docs/#coordeach
      */
-    coordReduce(layer: Points | Point | MultiPoint | MultiPoints, callback: (memo: any, coords: Array<number>) => void, memo: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (memo: any, coords: Array<Array<number>>) => void, memo: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (memo: any, coords: Array<Array<Array<number>>>) => void, memo: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: GeometryCollection | GeometryObject, callback: (memo: any, coords: Array<any>) => void, memo: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: Points | Point | MultiPoint | MultiPoints, callback: (previousValue: any, currentCoords: Array<number>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (previousValue: any, currentCoords: Array<Array<number>>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (previousValue: any, currentCoords: Array<Array<Array<number>>>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: GeometryCollection | GeometryObject, callback: (previousValue: any, currentCoords: Array<any>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
 
     /**
      * http://turfjs.org/docs/#propeach
@@ -47,13 +47,13 @@ interface MetaStatic {
     /**
      * http://turfjs.org/docs/#featureeach
      */
-    featureEach(layer: Point | Points, callback: (feature: Point) => void): void;
-    featureEach(layer: LineString | LineStrings, callback: (feature: LineString) => void): void;
-    featureEach(layer: Polygon | Polygons, callback: (feature: Polygon) => void): void;
-    featureEach(layer: MultiPoint | MultiPoints, callback: (feature: MultiPoint) => void): void;
-    featureEach(layer: MultiLineString | MultiLineStrings, callback: (feature: MultiLineString) => void): void;
-    featureEach(layer: MultiPolygon | MultiPolygons, callback: (feature: MultiPolygon) => void): void;
-    featureEach(layer: Feature | Features, callback: (feature: Feature) => void): void;
+    featureEach(layer: Point | Points, callback: (feature: Point, index: number) => void): void;
+    featureEach(layer: LineString | LineStrings, callback: (feature: LineString, index: number) => void): void;
+    featureEach(layer: Polygon | Polygons, callback: (feature: Polygon, index: number) => void): void;
+    featureEach(layer: MultiPoint | MultiPoints, callback: (feature: MultiPoint, index: number) => void): void;
+    featureEach(layer: MultiLineString | MultiLineStrings, callback: (feature: MultiLineString, index: number) => void): void;
+    featureEach(layer: MultiPolygon | MultiPolygons, callback: (feature: MultiPolygon, index: number) => void): void;
+    featureEach(layer: Feature | Features, callback: (feature: Feature, index: number) => void): void;
 
     /**
      * http://turfjs.org/docs/#coordall

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -21,39 +21,51 @@ interface MetaStatic {
     /**
      * http://turfjs.org/docs/#coordeach
      */
-    coordEach(layer: Points | Point | MultiPoint | MultiPoints, callback: (coords: Array<number>, index: number) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (coords: Array<Array<number>>, index: number) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (coords: Array<Array<Array<number>>>, index: number) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: GeometryCollection | GeometryObject, callback: (coords: Array<any>, index: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: Points | Point | MultiPoint | MultiPoints, callback: (currentCoords: Array<number>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (currentCoords: Array<Array<number>>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (currentCoords: Array<Array<Array<number>>>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
+    coordEach(layer: GeometryCollection | GeometryObject, callback: (currentCoords: Array<any>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
 
     /**
-     * http://turfjs.org/docs/#coordeach
+     * http://turfjs.org/docs/#coordreduce
      */
-    coordReduce(layer: Points | Point | MultiPoint | MultiPoints, callback: (previousValue: any, currentCoords: Array<number>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (previousValue: any, currentCoords: Array<Array<number>>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (previousValue: any, currentCoords: Array<Array<Array<number>>>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: GeometryCollection | GeometryObject, callback: (previousValue: any, currentCoords: Array<any>, index: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: Points | Point | MultiPoint | MultiPoints, callback: (previousValue: any, currentCoords: Array<number>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (previousValue: any, currentCoords: Array<Array<number>>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (previousValue: any, currentCoords: Array<Array<Array<number>>>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
+    coordReduce(layer: GeometryCollection | GeometryObject, callback: (previousValue: any, currentCoords: Array<any>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
 
     /**
      * http://turfjs.org/docs/#propeach
      */
-    propEach(layer: Feature | Features, callback: (properties: any) => void): void;
+    propEach(layer: Feature | Features, callback: (currentProperties: any, currentIndex: number) => void): void;
 
     /**
      * http://turfjs.org/docs/#propreduce
      */
-    propReduce(layer: Feature | Features, callback: (prev: any, props: any) => any, memo: any): any;
+    propReduce(layer: Feature | Features, callback: (previousValue: any, currentProperties: any, currentIndex: number) => void, initialValue: any): any;
+
+    /**
+     * http://turfjs.org/docs/#featurereduce
+     */
+    featureReduce(layer: Point | Points, callback: (previousValue: any, currentFeature: Point, currentIndex: number) => void, initialValue: any): any;
+    featureReduce(layer: LineString | LineStrings, callback: (previousValue: any, currentFeature: LineString, currentIndex: number) => void, initialValue: any): any;
+    featureReduce(layer: Polygon | Polygons, callback: (previousValue: any, currentFeature: Polygon, currentIndex: number) => void, initialValue: any): any;
+    featureReduce(layer: MultiPoint | MultiPoints, callback: (previousValue: any, currentFeature: MultiPoint, currentIndex: number) => void, initialValue: any): any;
+    featureReduce(layer: MultiLineString | MultiLineStrings, callback: (previousValue: any, currentFeature: MultiLineString, currentIndex: number) => void, initialValue: any): any;
+    featureReduce(layer: MultiPolygon | MultiPolygons, callback: (previousValue: any, currentFeature: MultiPolygon, currentIndex: number) => void, initialValue: any): any;
+    featureReduce(layer: Feature | Features, callback: (previousValue: any, currentFeature: Feature, currentIndex: number) => void, initialValue: any): any;
+
 
     /**
      * http://turfjs.org/docs/#featureeach
      */
-    featureEach(layer: Point | Points, callback: (feature: Point, index: number) => void): void;
-    featureEach(layer: LineString | LineStrings, callback: (feature: LineString, index: number) => void): void;
-    featureEach(layer: Polygon | Polygons, callback: (feature: Polygon, index: number) => void): void;
-    featureEach(layer: MultiPoint | MultiPoints, callback: (feature: MultiPoint, index: number) => void): void;
-    featureEach(layer: MultiLineString | MultiLineStrings, callback: (feature: MultiLineString, index: number) => void): void;
-    featureEach(layer: MultiPolygon | MultiPolygons, callback: (feature: MultiPolygon, index: number) => void): void;
-    featureEach(layer: Feature | Features, callback: (feature: Feature, index: number) => void): void;
+    featureEach(layer: Point | Points, callback: (currentFeature: Point, currentIndex: number) => void): void;
+    featureEach(layer: LineString | LineStrings, callback: (currentFeature: LineString, currentIndex: number) => void): void;
+    featureEach(layer: Polygon | Polygons, callback: (currentFeature: Polygon, currentIndex: number) => void): void;
+    featureEach(layer: MultiPoint | MultiPoints, callback: (currentFeature: MultiPoint, currentIndex: number) => void): void;
+    featureEach(layer: MultiLineString | MultiLineStrings, callback: (currentFeature: MultiLineString, currentIndex: number) => void): void;
+    featureEach(layer: MultiPolygon | MultiPolygons, callback: (currentFeature: MultiPolygon, currentIndex: number) => void): void;
+    featureEach(layer: Feature | Features, callback: (currentFeature: Feature, currentIndex: number) => void): void;
 
     /**
      * http://turfjs.org/docs/#coordall
@@ -61,16 +73,28 @@ interface MetaStatic {
     coordAll(layer: Feature | Features | GeometryCollection | GeometryObject): Array<Array<number>>
 
     /**
+     * http://turfjs.org/docs/#geomreduce
+     */
+    geomReduce(layer: Point | Points, callback: (previousValue: any, currentGeometry: GeoJSON.Point, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: LineString | LineStrings, callback: (previousValue: any, currentGeometry: GeoJSON.LineString, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: Polygon | Polygons, callback: (previousValue: any, currentGeometry: GeoJSON.Polygon, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: MultiPoint | MultiPoints, callback: (previousValue: any, currentGeometry: GeoJSON.MultiPoint, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: MultiLineString | MultiLineStrings, callback: (previousValue: any, currentGeometry: GeoJSON.MultiLineString, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: MultiPolygon | MultiPolygons, callback: (previousValue: any, currentGeometry: GeoJSON.MultiPolygon, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: Feature | Features, callback: (previousValue: any, currentGeometry: GeometryObject, currentIndex: number) => void, initialValue: any): any;
+    geomReduce(layer: GeometryCollection | GeometryObject, callback: (previousValue: any, currentGeometry: GeometryObject, currentIndex: number) => void, initialValue: any): any;
+
+    /**
      * http://turfjs.org/docs/#geomeach
      */
-    geomEach(layer: Point | Points, callback: (geom: GeoJSON.Point) => void): void;
-    geomEach(layer: LineString | LineStrings, callback: (geom: GeoJSON.LineString) => void): void;
-    geomEach(layer: Polygon | Polygons, callback: (geom: GeoJSON.Polygon) => void): void;
-    geomEach(layer: MultiPoint | MultiPoints, callback: (geom: GeoJSON.MultiPoint) => void): void;
-    geomEach(layer: MultiLineString | MultiLineStrings, callback: (geom: GeoJSON.MultiLineString) => void): void;
-    geomEach(layer: MultiPolygon | MultiPolygons, callback: (geom: GeoJSON.MultiPolygon) => void): void;
-    geomEach(layer: Feature | Features, callback: (geom: GeometryObject) => void): void;
-    geomEach(layer: GeometryCollection | GeometryObject, callback: (geom: GeometryObject) => void): void;
+    geomEach(layer: Point | Points, callback: (currentGeometry: GeoJSON.Point, currentIndex: number) => void): void;
+    geomEach(layer: LineString | LineStrings, callback: (currentGeometry: GeoJSON.LineString, currentIndex: number) => void): void;
+    geomEach(layer: Polygon | Polygons, callback: (currentGeometry: GeoJSON.Polygon, currentIndex: number) => void): void;
+    geomEach(layer: MultiPoint | MultiPoints, callback: (currentGeometry: GeoJSON.MultiPoint, currentIndex: number) => void): void;
+    geomEach(layer: MultiLineString | MultiLineStrings, callback: (currentGeometry: GeoJSON.MultiLineString, currentIndex: number) => void): void;
+    geomEach(layer: MultiPolygon | MultiPolygons, callback: (currentGeometry: GeoJSON.MultiPolygon, currentIndex: number) => void): void;
+    geomEach(layer: Feature | Features, callback: (currentGeometry: GeometryObject, currentIndex: number) => void): void;
+    geomEach(layer: GeometryCollection | GeometryObject, callback: (currentGeometry: GeometryObject, currentIndex: number) => void): void;
 }
 
 declare const meta: MetaStatic

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -1,17 +1,46 @@
 /**
- * Iterate over coordinates in any GeoJSON object, similar to
- * Array.forEach.
+ * Callback for coordEach
+ *
+ * @private
+ * @callback coordEachCallback
+ * @param {[number, number]} currentCoords The current coordinates being processed.
+ * @param {number} currentIndex The index of the current element being processed in the
+ * array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+ */
+
+/**
+ * Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
  *
  * @name coordEach
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (coords, index)
- * @param {boolean=} excludeWrapCoord whether or not to include
+ * @param {coordEachCallback} callback a method that takes (currentCoords, currentIndex)
+ * @param {boolean} [excludeWrapCoord=false] whether or not to include
  * the final coordinate of LinearRings that wraps the ring in its iteration.
  * @example
- * var point = { type: 'Point', coordinates: [0, 0] };
- * turfMeta.coordEach(point, function(coords, index) {
- *   // coords is equal to [0, 0]
- *   // index is equal to 0
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * turf.coordEach(features, function (currentCoords, currentIndex) {
+ *   //=currentCoords
+ *   //=currentIndex
  * });
  */
 function coordEach(layer, callback, excludeWrapCoord) {
@@ -100,7 +129,7 @@ module.exports.coordEach = coordEach;
  *
  * @private
  * @callback coordReduceCallback
- * @param {*} accumulator The accumulated value previously returned in the last invocation
+ * @param {*} previousValue The accumulated value previously returned in the last invocation
  * of the callback, or initialValue, if supplied.
  * @param {[number, number]} currentCoords The current coordinate being processed.
  * @param {number} currentIndex The index of the current element being processed in the
@@ -108,17 +137,42 @@ module.exports.coordEach = coordEach;
  */
 
 /**
- * Reduce coordinates in any GeoJSON object into a single value,
- * similar to how Array.reduce works. However, in this case we lazily run
- * the reduction, so an array of all coordinates is unnecessary.
+ * Reduce coordinates in any GeoJSON object, similar to Array.reduce()
  *
  * @name coordReduce
  * @param {Object} layer any GeoJSON object
  * @param {coordReduceCallback} callback a method that takes (previousValue, currentCoords, currentIndex)
  * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
- * @param {boolean=} excludeWrapCoord whether or not to include
+ * @param {boolean} [excludeWrapCoord=false] whether or not to include
  * the final coordinate of LinearRings that wraps the ring in its iteration.
  * @returns {*} The value that results from the reduction.
+ * @example
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * turf.coordReduce(features, function (previousValue, currentCoords, currentIndex) {
+ *   //=previousValue
+ *   //=currentCoords
+ *   //=currentIndex
+ * });
  */
 function coordReduce(layer, callback, initialValue, excludeWrapCoord) {
     var previousValue = initialValue;
@@ -134,16 +188,46 @@ function coordReduce(layer, callback, initialValue, excludeWrapCoord) {
 module.exports.coordReduce = coordReduce;
 
 /**
- * Iterate over property objects in any GeoJSON object, similar to
- * Array.forEach.
+ * Callback for propEach
+ *
+ * @private
+ * @callback propEachCallback
+ * @param {*} currentProperties The current properties being processed.
+ * @param {number} currentIndex The index of the current element being processed in the
+ * array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+ */
+
+/**
+ * Iterate over properties in any GeoJSON object, similar to Array.forEach()
  *
  * @name propEach
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (value)
+ * @param {Function} callback a method that takes (currentProperties, currentIndex)
  * @example
- * var point = { type: 'Feature', geometry: null, properties: { foo: 1 } };
- * turfMeta.propEach(point, function(props) {
- *   // props is equal to { foo: 1}
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"foo": "bar"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"hello": "world"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * turf.propEach(features, function (currentProperties, currentIndex) {
+ *   //=currentProperties
+ *   //=currentIndex
  * });
  */
 function propEach(layer, callback) {
@@ -161,6 +245,30 @@ function propEach(layer, callback) {
 }
 module.exports.propEach = propEach;
 
+
+/**
+ * Callback for propReduce
+ *
+ * The first time the callback function is called, the values provided as arguments depend
+ * on whether the reduce method has an initialValue argument.
+ *
+ * If an initialValue is provided to the reduce method:
+ *  - The previousValue argument is initialValue.
+ *  - The currentValue argument is the value of the first element present in the array.
+ *
+ * If an initialValue is not provided:
+ *  - The previousValue argument is the value of the first element present in the array.
+ *  - The currentValue argument is the value of the second element present in the array.
+ *
+ * @private
+ * @callback propReduceCallback
+ * @param {*} previousValue The accumulated value previously returned in the last invocation
+ * of the callback, or initialValue, if supplied.
+ * @param {*} currentProperties The current properties being processed.
+ * @param {number} currentIndex The index of the current element being processed in the
+ * array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+ */
+
 /**
  * Reduce properties in any GeoJSON object into a single value,
  * similar to how Array.reduce works. However, in this case we lazily run
@@ -168,30 +276,60 @@ module.exports.propEach = propEach;
  *
  * @name propReduce
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (memo, coord) and returns
- * a new memo
- * @param {*} memo the starting value of memo: can be any type.
- * @returns {*} combined value
+ * @param {propReduceCallback} callback a method that takes (previousValue, currentProperties, currentIndex)
+ * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
+ * @returns {*} The value that results from the reduction.
  * @example
- * // an example of an even more advanced function that gives you the
- * // javascript type of each property of every feature
- * function propTypes (layer) {
- *   opts = opts || {}
- *   return turfMeta.propReduce(layer, function (prev, props) {
- *     for (var prop in props) {
- *       if (prev[prop]) continue
- *       prev[prop] = typeof props[prop]
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"foo": "bar"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"hello": "world"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
  *     }
- *   }, {})
- * }
+ *   ]
+ * };
+ * turf.propReduce(features, function (previousValue, currentProperties, currentIndex) {
+ *   //=previousValue
+ *   //=currentProperties
+ *   //=currentIndex
+ *   return currentProperties
+ * });
  */
-function propReduce(layer, callback, memo) {
-    propEach(layer, function (prop, i) {
-        memo = callback(memo, prop, i);
+function propReduce(layer, callback, initialValue) {
+    var previousValue = initialValue;
+    propEach(layer, function (currentProperties, currentIndex) {
+        if (currentIndex === 0 && initialValue === undefined) {
+            previousValue = currentProperties;
+        } else {
+            previousValue = callback(previousValue, currentProperties, currentIndex);
+        }
     });
-    return memo;
+    return previousValue;
 }
 module.exports.propReduce = propReduce;
+
+/**
+ * Callback for featureEach
+ *
+ * @private
+ * @callback featureEachCallback
+ * @param {Feature<any>} currentFeature The current feature being processed.
+ * @param {number} currentIndex The index of the current element being processed in the
+ * array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+ */
 
 /**
  * Iterate over features in any GeoJSON object, similar to
@@ -199,11 +337,31 @@ module.exports.propReduce = propReduce;
  *
  * @name featureEach
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (feature, index)
+ * @param {featureEachCallback} callback a method that takes (currentFeature, currentIndex)
  * @example
- * var feature = { type: 'Feature', geometry: null, properties: {} };
- * turfMeta.featureEach(feature, function(feature) {
- *   // feature == feature
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * turf.featureEach(features, function (currentFeature) {
+ *   //=currentFeature
  * });
  */
 function featureEach(layer, callback) {
@@ -218,12 +376,108 @@ function featureEach(layer, callback) {
 module.exports.featureEach = featureEach;
 
 /**
- * Get all coordinates from any GeoJSON object, returning an array of coordinate
- * arrays.
+ * Callback for featureReduce
+ *
+ * The first time the callback function is called, the values provided as arguments depend
+ * on whether the reduce method has an initialValue argument.
+ *
+ * If an initialValue is provided to the reduce method:
+ *  - The previousValue argument is initialValue.
+ *  - The currentValue argument is the value of the first element present in the array.
+ *
+ * If an initialValue is not provided:
+ *  - The previousValue argument is the value of the first element present in the array.
+ *  - The currentValue argument is the value of the second element present in the array.
+ *
+ * @private
+ * @callback featureReduceCallback
+ * @param {*} previousValue The accumulated value previously returned in the last invocation
+ * of the callback, or initialValue, if supplied.
+ * @param {Feature<any>} currentFeature The current Feature being processed.
+ * @param {number} currentIndex The index of the current element being processed in the
+ * array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+ */
+
+/**
+ * Reduce features in any GeoJSON object, similar to Array.reduce().
+ *
+ * @name featureReduce
+ * @param {Object} layer any GeoJSON object
+ * @param {featureReduceCallback} callback a method that takes (previousValue, currentFeature, currentIndex)
+ * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
+ * @returns {*} The value that results from the reduction.
+ * @example
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"foo": "bar"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"hello": "world"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * turf.featureReduce(features, function (previousValue, currentFeature, currentIndex) {
+ *   //=previousValue
+ *   //=currentFeature
+ *   //=currentIndex
+ *   return currentFeature
+ * });
+ */
+function featureReduce(layer, callback, initialValue) {
+    var previousValue = initialValue;
+    featureEach(layer, function (currentFeature, currentIndex) {
+        if (currentIndex === 0 && initialValue === undefined) {
+            previousValue = currentFeature;
+        } else {
+            previousValue = callback(previousValue, currentFeature, currentIndex);
+        }
+    });
+    return previousValue;
+}
+module.exports.featureReduce = featureReduce;
+
+/**
+ * Get all coordinates from any GeoJSON object.
  *
  * @name coordAll
  * @param {Object} layer any GeoJSON object
  * @returns {Array<Array<number>>} coordinate position array
+ * @example
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * var coords = turf.coordAll(features);
+ * //=coords
  */
 function coordAll(layer) {
     var coords = [];
@@ -235,20 +489,35 @@ function coordAll(layer) {
 module.exports.coordAll = coordAll;
 
 /**
- * Iterate over each geometry in any GeoJSON object, similar to
- * Array.forEach.
+ * Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
  *
  * @name geomEach
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (value)
+ * @param {Function} callback a method that takes (geometry)
  * @example
- * var point = {
- *   type: 'Feature',
- *   geometry: { type: 'Point', coordinates: [0, 0] },
- *   properties: {}
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
  * };
- * turfMeta.geomEach(point, function(geom) {
- *   // geom is the point geometry
+ * turf.geomEach(features, function (geometry) {
+ *   //=geometry
  * });
  */
 function geomEach(layer, callback) {
@@ -299,3 +568,76 @@ function geomEach(layer, callback) {
     }
 }
 module.exports.geomEach = geomEach;
+
+/**
+ * Callback for geomReduce
+ *
+ * The first time the callback function is called, the values provided as arguments depend
+ * on whether the reduce method has an initialValue argument.
+ *
+ * If an initialValue is provided to the reduce method:
+ *  - The previousValue argument is initialValue.
+ *  - The currentValue argument is the value of the first element present in the array.
+ *
+ * If an initialValue is not provided:
+ *  - The previousValue argument is the value of the first element present in the array.
+ *  - The currentValue argument is the value of the second element present in the array.
+ *
+ * @private
+ * @callback geomReduceCallback
+ * @param {*} previousValue The accumulated value previously returned in the last invocation
+ * of the callback, or initialValue, if supplied.
+ * @param {*} currentGeometry The current Feature being processed.
+ * @param {number} currentIndex The index of the current element being processed in the
+ * array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+ */
+
+/**
+ * Reduce geometry in any GeoJSON object, similar to Array.reduce().
+ *
+ * @name geomReduce
+ * @param {Object} layer any GeoJSON object
+ * @param {geomReduceCallback} callback a method that takes (previousValue, currentGeometry, currentIndex)
+ * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
+ * @returns {*} The value that results from the reduction.
+ * @example
+ * var features = {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"foo": "bar"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [26, 37]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {"hello": "world"},
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [36, 53]
+ *       }
+ *     }
+ *   ]
+ * };
+ * turf.geomReduce(features, function (previousValue, currentGeometry, currentIndex) {
+ *   //=previousValue
+ *   //=currentGeometry
+ *   //=currentIndex
+ *   return currentGeometry
+ * });
+ */
+function geomReduce(layer, callback, initialValue) {
+    var previousValue = initialValue;
+    featureEach(layer, function (currentGeometry, currentIndex) {
+        if (currentIndex === 0 && initialValue === undefined) {
+            previousValue = currentGeometry;
+        } else {
+            previousValue = callback(previousValue, currentGeometry, currentIndex);
+        }
+    });
+    return previousValue;
+}
+module.exports.geomReduce = geomReduce;

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -13,7 +13,7 @@
  *
  * @name coordEach
  * @param {Object} layer any GeoJSON object
- * @param {coordEachCallback} callback a method that takes (currentCoords, currentIndex)
+ * @param {Function} callback a method that takes (currentCoords, currentIndex)
  * @param {boolean} [excludeWrapCoord=false] whether or not to include
  * the final coordinate of LinearRings that wraps the ring in its iteration.
  * @example
@@ -141,7 +141,7 @@ module.exports.coordEach = coordEach;
  *
  * @name coordReduce
  * @param {Object} layer any GeoJSON object
- * @param {coordReduceCallback} callback a method that takes (previousValue, currentCoords, currentIndex)
+ * @param {Function} callback a method that takes (previousValue, currentCoords, currentIndex)
  * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
  * @param {boolean} [excludeWrapCoord=false] whether or not to include
  * the final coordinate of LinearRings that wraps the ring in its iteration.
@@ -276,7 +276,7 @@ module.exports.propEach = propEach;
  *
  * @name propReduce
  * @param {Object} layer any GeoJSON object
- * @param {propReduceCallback} callback a method that takes (previousValue, currentProperties, currentIndex)
+ * @param {Function} callback a method that takes (previousValue, currentProperties, currentIndex)
  * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
  * @returns {*} The value that results from the reduction.
  * @example
@@ -337,7 +337,7 @@ module.exports.propReduce = propReduce;
  *
  * @name featureEach
  * @param {Object} layer any GeoJSON object
- * @param {featureEachCallback} callback a method that takes (currentFeature, currentIndex)
+ * @param {Function} callback a method that takes (currentFeature, currentIndex)
  * @example
  * var features = {
  *   "type": "FeatureCollection",
@@ -403,7 +403,7 @@ module.exports.featureEach = featureEach;
  *
  * @name featureReduce
  * @param {Object} layer any GeoJSON object
- * @param {featureReduceCallback} callback a method that takes (previousValue, currentFeature, currentIndex)
+ * @param {Function} callback a method that takes (previousValue, currentFeature, currentIndex)
  * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
  * @returns {*} The value that results from the reduction.
  * @example
@@ -597,7 +597,7 @@ module.exports.geomEach = geomEach;
  *
  * @name geomReduce
  * @param {Object} layer any GeoJSON object
- * @param {geomReduceCallback} callback a method that takes (previousValue, currentGeometry, currentIndex)
+ * @param {Function} callback a method that takes (previousValue, currentGeometry, currentIndex)
  * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
  * @returns {*} The value that results from the reduction.
  * @example

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -299,16 +299,3 @@ function geomEach(layer, callback) {
     }
 }
 module.exports.geomEach = geomEach;
-
-if (module.parent === null) {
-    var lineString = require('@turf/helpers').lineString;
-
-    var index = [];
-    var line = lineString([[126, -11], [129, -21], [135, -31]]);
-    coordReduce(line, function (previousCoords, currentCoords, currentIndex) {
-        index.push(currentIndex);
-        console.log(previousCoords, currentCoords);
-        return currentCoords;
-    });
-    console.log(index);
-}

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -47,7 +47,7 @@ function coordEach(layer, callback, excludeWrapCoord) {
     var i, j, k, g, l, geometry, stopG, coords,
         geometryMaybeCollection,
         wrapShrink = 0,
-        index = 0,
+        currentIndex = 0,
         isGeometryCollection,
         isFeatureCollection = layer.type === 'FeatureCollection',
         isFeature = layer.type === 'Feature',
@@ -82,25 +82,25 @@ function coordEach(layer, callback, excludeWrapCoord) {
                 1 : 0;
 
             if (geometry.type === 'Point') {
-                callback(coords, index);
-                index++;
+                callback(coords, currentIndex);
+                currentIndex++;
             } else if (geometry.type === 'LineString' || geometry.type === 'MultiPoint') {
                 for (j = 0; j < coords.length; j++) {
-                    callback(coords[j], index);
-                    index++;
+                    callback(coords[j], currentIndex);
+                    currentIndex++;
                 }
             } else if (geometry.type === 'Polygon' || geometry.type === 'MultiLineString') {
                 for (j = 0; j < coords.length; j++)
                     for (k = 0; k < coords[j].length - wrapShrink; k++) {
-                        callback(coords[j][k], index);
-                        index++;
+                        callback(coords[j][k], currentIndex);
+                        currentIndex++;
                     }
             } else if (geometry.type === 'MultiPolygon') {
                 for (j = 0; j < coords.length; j++)
                     for (k = 0; k < coords[j].length; k++)
                         for (l = 0; l < coords[j][k].length - wrapShrink; l++) {
-                            callback(coords[j][k][l], index);
-                            index++;
+                            callback(coords[j][k][l], currentIndex);
+                            currentIndex++;
                         }
             } else if (geometry.type === 'GeometryCollection') {
                 for (j = 0; j < geometry.geometries.length; j++)
@@ -172,6 +172,7 @@ module.exports.coordEach = coordEach;
  *   //=previousValue
  *   //=currentCoords
  *   //=currentIndex
+ *   return currentCoords;
  * });
  */
 function coordReduce(layer, callback, initialValue, excludeWrapCoord) {
@@ -360,8 +361,9 @@ module.exports.propReduce = propReduce;
  *     }
  *   ]
  * };
- * turf.featureEach(features, function (currentFeature) {
+ * turf.featureEach(features, function (currentFeature, currentIndex) {
  *   //=currentFeature
+ *   //=currentIndex
  * });
  */
 function featureEach(layer, callback) {
@@ -493,7 +495,7 @@ module.exports.coordAll = coordAll;
  *
  * @name geomEach
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (geometry)
+ * @param {Function} callback a method that takes (currentGeometry, currentIndex)
  * @example
  * var features = {
  *   "type": "FeatureCollection",
@@ -516,14 +518,16 @@ module.exports.coordAll = coordAll;
  *     }
  *   ]
  * };
- * turf.geomEach(features, function (geometry) {
- *   //=geometry
+ * turf.geomEach(features, function (currentGeometry, currentIndex) {
+ *   //=currentGeometry
+ *   //=currentIndex
  * });
  */
 function geomEach(layer, callback) {
     var i, j, g, geometry, stopG,
         geometryMaybeCollection,
         isGeometryCollection,
+        currentIndex = 0,
         isFeatureCollection = layer.type === 'FeatureCollection',
         isFeature = layer.type === 'Feature',
         stop = isFeatureCollection ? layer.features.length : 1;
@@ -557,10 +561,13 @@ function geomEach(layer, callback) {
                 geometry.type === 'Polygon' ||
                 geometry.type === 'MultiLineString' ||
                 geometry.type === 'MultiPolygon') {
-                callback(geometry);
+                callback(geometry, currentIndex);
+                currentIndex++;
             } else if (geometry.type === 'GeometryCollection') {
-                for (j = 0; j < geometry.geometries.length; j++)
-                    callback(geometry.geometries[j]);
+                for (j = 0; j < geometry.geometries.length; j++) {
+                    callback(geometry.geometries[j], currentIndex);
+                    currentIndex++;
+                }
             } else {
                 throw new Error('Unknown Geometry Type');
             }

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -54,24 +54,24 @@ function coordEach(layer, callback, excludeWrapCoord) {
 
             if (geometry.type === 'Point') {
                 callback(coords, index);
-                index++
+                index++;
             } else if (geometry.type === 'LineString' || geometry.type === 'MultiPoint') {
                 for (j = 0; j < coords.length; j++) {
                     callback(coords[j], index);
-                    index++
+                    index++;
                 }
             } else if (geometry.type === 'Polygon' || geometry.type === 'MultiLineString') {
                 for (j = 0; j < coords.length; j++)
                     for (k = 0; k < coords[j].length - wrapShrink; k++) {
                         callback(coords[j][k], index);
-                        index++
+                        index++;
                     }
             } else if (geometry.type === 'MultiPolygon') {
                 for (j = 0; j < coords.length; j++)
                     for (k = 0; k < coords[j].length; k++)
                         for (l = 0; l < coords[j][k].length - wrapShrink; l++) {
                             callback(coords[j][k][l], index);
-                            index++
+                            index++;
                         }
             } else if (geometry.type === 'GeometryCollection') {
                 for (j = 0; j < geometry.geometries.length; j++)

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -171,7 +171,7 @@ module.exports.propReduce = propReduce;
  *
  * @name featureEach
  * @param {Object} layer any GeoJSON object
- * @param {Function} callback a method that takes (value)
+ * @param {Function} callback a method that takes (feature, index)
  * @example
  * var feature = { type: 'Feature', geometry: null, properties: {} };
  * turfMeta.featureEach(feature, function(feature) {

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@turf/helpers": "^3.10.3",
     "@turf/random": "^3.10.0",
+    "benchmark": "^2.1.3",
     "eslint": "^3.14.1",
     "eslint-config-mourner": "^2.0.1",
     "tape": "^3.4.0"

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -14,6 +14,7 @@
   "author": "Turf Authors",
   "license": "MIT",
   "devDependencies": {
+    "@turf/helpers": "^3.10.3",
     "@turf/random": "^3.10.0",
     "eslint": "^3.14.1",
     "eslint-config-mourner": "^2.0.1",

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -150,15 +150,84 @@ featureAndCollection(geometryCollection).forEach(function (input) {
     });
 });
 
-test('coordReduce', function (t) {
+test('coordReduce#initialValue', function (t) {
     var lastIndex;
     var line = lineString([[126, -11], [129, -21], [135, -31]]);
-    var sum = meta.coordReduce(line, function (memo, current, index) {
-        lastIndex = index;
-        return memo + current[0];
+    var sum = meta.coordReduce(line, function (previousValue, currentCoords, currentIndex) {
+        lastIndex = currentIndex;
+        return previousValue + currentCoords[0];
     }, 0);
     t.equal(lastIndex, 2);
     t.equal(sum, 390);
+    t.end();
+});
+
+test('Array.reduce()#initialValue', function (t) {
+    var lastIndex;
+    var line = [[126, -11], [129, -21], [135, -31]];
+    var sum = line.reduce(function (previousValue, currentCoords, currentIndex) {
+        lastIndex = currentIndex;
+        return previousValue + currentCoords[0];
+    }, 0);
+    t.equal(lastIndex, 2);
+    t.equal(sum, 390);
+    t.end();
+});
+
+test('coordReduce#previous-coordinates', function (t) {
+    var lastIndex;
+    var coords = [];
+    var line = lineString([[126, -11], [129, -21], [135, -31]]);
+    meta.coordReduce(line, function (previousCoords, currentCoords, currentIndex) {
+        lastIndex = currentIndex;
+        coords.push(currentCoords);
+        return currentCoords;
+    });
+    t.equal(lastIndex, 2);
+    t.equal(coords.length, 2);
+    t.end();
+});
+
+test('Array.reduce()#previous-coordinates', function (t) {
+    var lastIndex;
+    var coords = [];
+    var line = [[126, -11], [129, -21], [135, -31]];
+    line.reduce(function (previousCoords, currentCoords, currentIndex) {
+        lastIndex = currentIndex;
+        coords.push(currentCoords);
+        return currentCoords;
+    });
+    t.equal(lastIndex, 2);
+    t.equal(coords.length, 2);
+    t.end();
+});
+
+
+test('coordReduce#previous-coordinates+initialValue', function (t) {
+    var lastIndex;
+    var coords = [];
+    var line = lineString([[126, -11], [129, -21], [135, -31]]);
+    meta.coordReduce(line, function (previousCoords, currentCoords, currentIndex) {
+        lastIndex = currentIndex;
+        coords.push(currentCoords);
+        return currentCoords;
+    }, line.geometry.coordinates[0]);
+    t.equal(lastIndex, 2);
+    t.equal(coords.length, 3);
+    t.end();
+});
+
+test('Array.reduce()#previous-coordinates+initialValue', function (t) {
+    var lastIndex;
+    var coords = [];
+    var line = [[126, -11], [129, -21], [135, -31]];
+    line.reduce(function (previousCoords, currentCoords, currentIndex) {
+        lastIndex = currentIndex;
+        coords.push(currentCoords);
+        return currentCoords;
+    }, line[0]);
+    t.equal(lastIndex, 2);
+    t.equal(coords.length, 3);
     t.end();
 });
 

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -1,4 +1,5 @@
 var test = require('tape');
+var lineString = require('@turf/helpers').lineString;
 var meta = require('./');
 
 var pointGeometry = {
@@ -69,8 +70,9 @@ collection(pointFeature).forEach(function (input) {
 
 featureAndCollection(pointGeometry).forEach(function (input) {
     test('coordEach#Point', function (t) {
-        meta.coordEach(input, function (coord) {
+        meta.coordEach(input, function (coord, index) {
             t.deepEqual(coord, [0, 0]);
+            t.equal(index, 0);
             t.end();
         });
     });
@@ -79,10 +81,13 @@ featureAndCollection(pointGeometry).forEach(function (input) {
 featureAndCollection(lineStringGeometry).forEach(function (input) {
     test('coordEach#LineString', function (t) {
         var output = [];
-        meta.coordEach(input, function (coord) {
+        var lastIndex;
+        meta.coordEach(input, function (coord, index) {
             output.push(coord);
+            lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [1, 1]]);
+        t.equal(lastIndex, 1);
         t.end();
     });
 });
@@ -90,10 +95,13 @@ featureAndCollection(lineStringGeometry).forEach(function (input) {
 featureAndCollection(polygonGeometry).forEach(function (input) {
     test('coordEach#Polygon', function (t) {
         var output = [];
-        meta.coordEach(input, function (coord) {
+        var lastIndex;
+        meta.coordEach(input, function (coord, index) {
             output.push(coord);
+            lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [1, 1], [0, 1], [0, 0]]);
+        t.equal(lastIndex, 3);
         t.end();
     });
 });
@@ -101,10 +109,13 @@ featureAndCollection(polygonGeometry).forEach(function (input) {
 featureAndCollection(polygonGeometry).forEach(function (input) {
     test('coordEach#Polygon excludeWrapCoord', function (t) {
         var output = [];
-        meta.coordEach(input, function (coord) {
+        var lastIndex;
+        meta.coordEach(input, function (coord, index) {
             output.push(coord);
+            lastIndex = index;
         }, true);
         t.deepEqual(output, [[0, 0], [1, 1], [0, 1]]);
+        t.equal(lastIndex, 2);
         t.end();
     });
 });
@@ -114,10 +125,13 @@ featureAndCollection(polygonGeometry).forEach(function (input) {
 featureAndCollection(multiPolygonGeometry).forEach(function (input) {
     test('coordEach#MultiPolygon', function (t) {
         var output = [];
-        meta.coordEach(input, function (coord) {
+        var lastIndex;
+        meta.coordEach(input, function (coord, index) {
             output.push(coord);
+            lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [1, 1], [0, 1], [0, 0]]);
+        t.equal(lastIndex, 3);
         t.end();
     });
 });
@@ -125,12 +139,27 @@ featureAndCollection(multiPolygonGeometry).forEach(function (input) {
 featureAndCollection(geometryCollection).forEach(function (input) {
     test('coordEach#GeometryCollection', function (t) {
         var output = [];
-        meta.coordEach(input, function (coord) {
+        var lastIndex;
+        meta.coordEach(input, function (coord, index) {
             output.push(coord);
+            lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [0, 0], [1, 1]]);
+        t.equal(lastIndex, 2);
         t.end();
     });
+});
+
+test('coordReduce', function (t) {
+    var lastIndex;
+    var line = lineString([[126, -11], [129, -21], [135, -31]]);
+    var sum = meta.coordReduce(line, function (memo, current, index) {
+        lastIndex = index;
+        return memo + current[0];
+    }, 0);
+    t.equal(lastIndex, 2);
+    t.equal(sum, 390);
+    t.end();
 });
 
 test('unknown', function (t) {

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -20,8 +20,10 @@ import {
     propEach,
     propReduce,
     featureEach,
+    featureReduce,
     coordAll,
-    geomEach
+    geomEach,
+    geomReduce
 } from '@turf/meta';
 
 import * as isolines from '@turf/isolines';

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -80,8 +80,10 @@ var turf = {
     propEach: meta.propEach,
     propReduce: meta.propReduce,
     featureEach: meta.featureEach,
+    featureReduce: meta.featureReduce,
     coordAll: meta.coordAll,
-    geomEach: meta.geomEach
+    geomEach: meta.geomEach,
+    geomReduce: meta.geomReduce
 };
 
 module.exports = turf;


### PR DESCRIPTION
**New Fixes**
- Added `featureReduce` & `geomReduce`
- Added `currentIndex` in the callback for both `coordEach()` & `coordReduce`
- Major changes to `coordReduce`.
- Overhaul Meta JSDocs
- Keep JSDocs `@example` consistent 
- Add `current` in front of the callbacks params (`currentProperties` / `currentFeature` / `currentGeometry`)
- Update Typescript definitions with changes

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occured.
- [x] Run `npm run lint` to ensure code style at the turf module level.

**Benchmark results**

```
coordReduce   - points x 43,196 ops/sec ±1.15% (89 runs sampled)
propEach      - points x 121,516 ops/sec ±0.62% (89 runs sampled)
propReduce    - points x 64,152 ops/sec ±1.27% (90 runs sampled)
geomEach      - points x 54,124 ops/sec ±0.59% (91 runs sampled)
geomReduce    - points x 66,653 ops/sec ±1.13% (88 runs sampled)
featureEach   - points x 140,041 ops/sec ±0.44% (89 runs sampled)
featureReduce - points x 61,951 ops/sec ±3.48% (84 runs sampled)
coordAll      - points x 36,686 ops/sec ±1.32% (87 runs sampled)
coordEach     - polygon x 5,494,072 ops/sec ±2.25% (85 runs sampled)
coordReduce   - polygon x 2,960,680 ops/sec ±3.38% (84 runs sampled)
propEach      - polygon x 27,077,690 ops/sec ±0.80% (87 runs sampled)
propReduce    - polygon x 13,852,393 ops/sec ±1.03% (91 runs sampled)
geomEach      - polygon x 19,027,907 ops/sec ±0.93% (89 runs sampled)
geomReduce    - polygon x 13,950,967 ops/sec ±0.89% (90 runs sampled)
featureEach   - polygon x 27,857,137 ops/sec ±1.04% (87 runs sampled)
featureReduce - polygon x 14,092,110 ops/sec ±1.01% (89 runs sampled)
coordAll      - polygon x 2,736,967 ops/sec ±3.20% (85 runs sampled)
coordEach     - polygons x 8,257 ops/sec ±0.77% (91 runs sampled)
coordReduce   - polygons x 4,413 ops/sec ±1.15% (90 runs sampled)
propEach      - polygons x 125,444 ops/sec ±0.81% (89 runs sampled)
propReduce    - polygons x 62,163 ops/sec ±1.31% (87 runs sampled)
geomEach      - polygons x 49,086 ops/sec ±0.61% (89 runs sampled)
geomReduce    - polygons x 63,831 ops/sec ±1.79% (84 runs sampled)
featureEach   - polygons x 132,376 ops/sec ±0.54% (88 runs sampled)
featureReduce - polygons x 65,754 ops/sec ±1.28% (91 runs sampled)
coordAll      - polygons x 3,613 ops/sec ±1.15% (90 runs sampled)
```

CC: @tmcw 