### PR TITLE
Changes to invariant based on comments

### DIFF
--- a/packages/turf-invariant/README.md
+++ b/packages/turf-invariant/README.md
@@ -2,6 +2,16 @@
 
 # getCoord
 
+Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
+
+**Parameters**
+
+-   `obj` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;any> | [Geometry](http://geojson.org/geojson-spec.html#geometry) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;[Point](http://geojson.org/geojson-spec.html#point)>)** any value
+
+Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** coordinates
+
+# getCoords
+
 Unwrap coordinates from a Feature, Geometry Object or an Array of numbers
 
 **Parameters**

--- a/packages/turf-invariant/bench.js
+++ b/packages/turf-invariant/bench.js
@@ -5,22 +5,15 @@ const invariant = require('./');
 const point = helpers.point([-75, 40]);
 const linestring = helpers.lineString([[-75, 40], [-70, 50]]);
 const polygon = helpers.polygon([[[-75, 40], [-80, 50], [-70, 50], [-75, 40]]]);
-
-const fixtures = [
-    {name: 'Point', geojson: point},
-    {name: 'LineString', geojson: linestring},
-    {name: 'Polygon', geojson: polygon}
-];
 const featureCollection = helpers.featureCollection([point, point]);
 
 const suite = new Benchmark.Suite('turf-invariant');
 
-for (const {name, geojson} of fixtures) {
-    suite.add('getCoord.' + name, () => { invariant.getCoord(geojson); });
-    suite.add('geojsonType.' + name, () => { invariant.geojsonType(geojson, 'Feature', name); });
-}
-suite.add('collectionOf', () => { invariant.collectionOf(featureCollection, 'Point', 'bench'); });
 suite
+    .add('getCoord.point', () => { invariant.getCoord(point); })
+    .add('getCoords.linestring', () => { invariant.getCoords(linestring); })
+    .add('getCoords.polygon', () => { invariant.getCoords(polygon); })
+    .add('collectionOf', () => { invariant.collectionOf(featureCollection, 'Point', 'bench'); })
     .on('cycle', e => console.log(String(e.target)))
     .on('complete', () => {})
     .run();

--- a/packages/turf-invariant/index.d.ts
+++ b/packages/turf-invariant/index.d.ts
@@ -12,6 +12,11 @@ export function getCoord(obj: GetCoord): Array<any>;
 /**
  * http://turfjs.org/docs/
  */
+export function getCoords(obj: GetCoord): Array<any>;
+
+/**
+ * http://turfjs.org/docs/
+ */
 export function geojsonType(value: Features, type: string, name: string): void;
 
 /**

--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -2,10 +2,9 @@
  * Unwrap coordinates from a Feature, Geometry Object or an Array of numbers
  *
  * @param {Array<any>|Geometry|Feature<any>} obj any value
- * @param {boolean} [validate=false] checks if coordinates contains a number
  * @returns {Array<any>} coordinates
  */
-function getCoord(obj, validate) {
+function getCoord(obj) {
     if (!obj) throw new Error('No obj passed');
     var coordinates;
 
@@ -23,7 +22,7 @@ function getCoord(obj, validate) {
     }
     // Check if coordinates contains a number
     if (coordinates) {
-        if (validate) validateCoordinates(coordinates);
+        validateCoordinates(coordinates);
         return coordinates;
     }
     throw new Error('No valid coordinates');
@@ -42,7 +41,7 @@ function validateCoordinates(coordinates) {
     if (coordinates[0].length) {
         return validateCoordinates(coordinates[0]);
     }
-    throw new Error('coordinates must only contain numbers');
+    throw new Error('coordinates must an array of numbers');
 }
 
 /**

--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -2,9 +2,10 @@
  * Unwrap coordinates from a Feature, Geometry Object or an Array of numbers
  *
  * @param {Array<any>|Geometry|Feature<any>} obj any value
+ * @param {boolean} [validate=false] checks if coordinates contains a number
  * @returns {Array<any>} coordinates
  */
-function getCoord(obj) {
+function getCoord(obj, validate) {
     if (!obj) throw new Error('No obj passed');
     var coordinates;
 
@@ -22,7 +23,7 @@ function getCoord(obj) {
     }
     // Check if coordinates contains a number
     if (coordinates) {
-        validateCoordinates(coordinates);
+        if (validate) validateCoordinates(coordinates);
         return coordinates;
     }
     throw new Error('No valid coordinates');

--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -5,19 +5,43 @@
  * @returns {Array<any>} coordinates
  */
 function getCoord(obj) {
-    if (obj === undefined) throw new Error('No obj passed');
+    if (!obj) throw new Error('No obj passed');
+    var coordinates;
 
     // Array of numbers
-    if (obj.length) return obj;
+    if (obj.length) {
+        coordinates = obj;
 
     // Geometry Object
-    if (obj.coordinates) return obj.coordinates;
+    } else if (obj.coordinates) {
+        coordinates = obj.coordinates;
 
     // Feature
-    var geometry = obj.geometry;
-    if (geometry && geometry.coordinates) return geometry.coordinates;
-
+    } else if (obj.geometry && obj.geometry.coordinates) {
+        coordinates = obj.geometry.coordinates;
+    }
+    // Check if coordinates contains a number
+    if (coordinates) {
+        validateCoordinates(coordinates);
+        return coordinates;
+    }
     throw new Error('No valid coordinates');
+}
+
+/**
+ * Validates Coordinates
+ *
+ * @param {Array<any>} coordinates GeoJSON Coordinates
+ * @returns {boolean} true if Array contains a number
+ */
+function validateCoordinates(coordinates) {
+    if (typeof coordinates[0] === 'number') {
+        return true;
+    }
+    if (coordinates[0].length) {
+        return validateCoordinates(coordinates[0]);
+    }
+    throw new Error('coordinates must only contain numbers');
 }
 
 /**
@@ -30,9 +54,9 @@ function getCoord(obj) {
  * @throws {Error} if value is not the expected type.
  */
 function geojsonType(value, type, name) {
-    if (type === undefined || name === undefined) throw new Error('type and name required');
+    if (!type || !name) throw new Error('type and name required');
 
-    if (value === undefined || value.type !== type) {
+    if (!value || value.type !== type) {
         throw new Error('Invalid input to ' + name + ': must be a ' + type + ', given ' + value.type);
     }
 }
@@ -48,11 +72,12 @@ function geojsonType(value, type, name) {
  * @throws {Error} error if value is not the expected type.
  */
 function featureOf(feature, type, name) {
-    if (name === undefined) throw new Error('.featureOf() requires a name');
-    if (feature === undefined || feature.type !== 'Feature' || feature.geometry === undefined) {
+    if (!feature) throw new Error('No feature passed');
+    if (!name) throw new Error('.featureOf() requires a name');
+    if (!feature || feature.type !== 'Feature' || !feature.geometry) {
         throw new Error('Invalid input to ' + name + ', Feature with geometry required');
     }
-    if (feature.geometry === undefined || feature.geometry.type !== type) {
+    if (!feature.geometry || feature.geometry.type !== type) {
         throw new Error('Invalid input to ' + name + ': must be a ' + type + ', given ' + feature.geometry.type);
     }
 }
@@ -68,16 +93,17 @@ function featureOf(feature, type, name) {
  * @throws {Error} if value is not the expected type.
  */
 function collectionOf(featureCollection, type, name) {
-    if (name === undefined) throw new Error('.collectionOf() requires a name');
-    if (featureCollection === undefined || featureCollection.type !== 'FeatureCollection') {
+    if (!featureCollection) throw new Error('No featureCollection passed');
+    if (!name) throw new Error('.collectionOf() requires a name');
+    if (!featureCollection || featureCollection.type !== 'FeatureCollection') {
         throw new Error('Invalid input to ' + name + ', FeatureCollection required');
     }
     for (var i = 0; i < featureCollection.features.length; i++) {
         var feature = featureCollection.features[i];
-        if (feature === undefined || feature.type !== 'Feature' || feature.geometry === undefined) {
+        if (!feature || feature.type !== 'Feature' || !feature.geometry) {
             throw new Error('Invalid input to ' + name + ', Feature with geometry required');
         }
-        if (feature.geometry === undefined || feature.geometry.type !== type) {
+        if (!feature.geometry || feature.geometry.type !== type) {
             throw new Error('Invalid input to ' + name + ': must be a ' + type + ', given ' + feature.geometry.type);
         }
     }

--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -1,10 +1,31 @@
 /**
+ * Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
+ *
+ * @param {Array<any>|Geometry|Feature<Point>} obj any value
+ * @returns {Array<number>} coordinates
+ */
+function getCoord(obj) {
+    if (!obj) throw new Error('No obj passed');
+
+    var coordinates = getCoords(obj);
+
+    // getCoord() must contain at least two numbers (Point)
+    if (coordinates.length > 1 &&
+        typeof coordinates[0] === 'number' &&
+        typeof coordinates[1] === 'number') {
+        return coordinates;
+    } else {
+        throw new Error('Coordinate is not a valid Point');
+    }
+}
+
+/**
  * Unwrap coordinates from a Feature, Geometry Object or an Array of numbers
  *
  * @param {Array<any>|Geometry|Feature<any>} obj any value
  * @returns {Array<any>} coordinates
  */
-function getCoord(obj) {
+function getCoords(obj) {
     if (!obj) throw new Error('No obj passed');
     var coordinates;
 
@@ -20,28 +41,31 @@ function getCoord(obj) {
     } else if (obj.geometry && obj.geometry.coordinates) {
         coordinates = obj.geometry.coordinates;
     }
-    // Check if coordinates contains a number
+    // Checks if coordinates contains a number
     if (coordinates) {
-        validateCoordinates(coordinates);
+        containsNumber(coordinates);
         return coordinates;
     }
     throw new Error('No valid coordinates');
 }
 
 /**
- * Validates Coordinates
+ * Checks if coordinates contains a number
  *
+ * @private
  * @param {Array<any>} coordinates GeoJSON Coordinates
  * @returns {boolean} true if Array contains a number
  */
-function validateCoordinates(coordinates) {
-    if (typeof coordinates[0] === 'number') {
+function containsNumber(coordinates) {
+    if (coordinates.length > 1 &&
+        typeof coordinates[0] === 'number' &&
+        typeof coordinates[1] === 'number') {
         return true;
     }
     if (coordinates[0].length) {
-        return validateCoordinates(coordinates[0]);
+        return containsNumber(coordinates[0]);
     }
-    throw new Error('coordinates must an array of numbers');
+    throw new Error('coordinates must only contain numbers');
 }
 
 /**
@@ -113,3 +137,4 @@ module.exports.geojsonType = geojsonType;
 module.exports.collectionOf = collectionOf;
 module.exports.featureOf = featureOf;
 module.exports.getCoord = getCoord;
+module.exports.getCoords = getCoords;

--- a/packages/turf-invariant/test.js
+++ b/packages/turf-invariant/test.js
@@ -1,5 +1,6 @@
-var test = require('tape'),
-    invariant = require('./');
+const test = require('tape');
+const {point, lineString, polygon} = require('@turf/helpers');
+const invariant = require('./');
 
 test('invariant#geojsonType', t => {
     t.throws(() => {
@@ -113,18 +114,58 @@ test('invariant#collectionOf', t => {
 });
 
 test('invariant#getCoord', t => {
+    t.throws(() => invariant.getCoord(lineString([[1, 2], [3, 4]])));
+    t.throws(() => invariant.getCoord(polygon([[[-75, 40], [-80, 50], [-70, 50], [-75, 40]]])));
+
     t.deepEqual(invariant.getCoord({
         type: 'Point',
         coordinates: [1, 2]
     }), [1, 2]);
 
+    t.deepEqual(invariant.getCoord(point([1, 2])), [1, 2]);
+    t.end();
+});
+
+test('invariant#getCoord', t => {
+    t.throws(() => invariant.getCoord({
+        type: 'LineString',
+        coordinates: [[1, 2], [3, 4]]
+    }));
+
+    t.throws(() => invariant.getCoord(false));
+    t.throws(() => invariant.getCoord(null));
+    t.throws(() => invariant.getCoord(lineString([[1, 2], [3, 4]])));
+    t.throws(() => invariant.getCoord(['A', 'B', 'C']));
+    t.throws(() => invariant.getCoord([1, 'foo', 'bar']));
+
     t.deepEqual(invariant.getCoord({
-        type: 'Feature',
-        geometry: {
-            type: 'Point',
-            coordinates: [1, 2]
-        },
-        properties: {}
+        type: 'Point',
+        coordinates: [1, 2]
     }), [1, 2]);
+
+    t.deepEqual(invariant.getCoord(point([1, 2])), [1, 2]);
+    t.deepEqual(invariant.getCoord([1, 2]), [1, 2]);
+    t.end();
+});
+
+test('invariant#getCoords', t => {
+    t.throws(() => invariant.getCoords({
+        type: 'LineString',
+        coordinates: null
+    }));
+
+    t.throws(() => invariant.getCoords(false));
+    t.throws(() => invariant.getCoords(null));
+    t.throws(() => invariant.getCoords(['A', 'B', 'C']));
+    t.throws(() => invariant.getCoords([1, 'foo', 'bar']));
+
+    t.deepEqual(invariant.getCoords({
+        type: 'LineString',
+        coordinates: [[1, 2], [3, 4]]
+    }), [[1, 2], [3, 4]]);
+
+    t.deepEqual(invariant.getCoords(point([1, 2])), [1, 2]);
+    t.deepEqual(invariant.getCoords(lineString([[1, 2], [3, 4]])), [[1, 2], [3, 4]]);
+    t.deepEqual(invariant.getCoords([1, 2]), [1, 2]);
     t.end();
 });


### PR DESCRIPTION
Ok without losing too much performance on `getCoord()` I added a number validation function at the end and checks for `null` & `false`.

~Added a param for the validation, that way you can turn it on or off. (default=false)~

**Benchmark before**

```
getCoord.Point x 18,555,451 ops/sec ±1.18% (86 runs sampled)
```

**Benchmark with number Validation**

```
getCoord.Point x 45,853,256 ops/sec ±0.63% (88 runs sampled)
getCoord.LineString x 33,147,142 ops/sec ±1.29% (91 runs sampled)
getCoord.Polygon x 27,853,174 ops/sec ±0.78% (92 runs sampled)
```

**Benchmark without number Validation**

```
getCoord.Point x 51,871,316 ops/sec ±1.49% (89 runs sampled)
getCoord.LineString x 49,007,217 ops/sec ±2.44% (86 runs sampled)
getCoord.Polygon x 52,104,843 ops/sec ±0.74% (88 runs sampled)
```

CC: @tmcw 