### PR TITLE
Refactor line-distance using segmentReduce

### DIFF
--- a/packages/turf-line-distance/index.js
+++ b/packages/turf-line-distance/index.js
@@ -1,13 +1,18 @@
 var distance = require('@turf/distance');
+var featureEach = require('@turf/meta').featureEach;
+var coordReduce = require('@turf/meta').coordReduce;
+var geomEach = require('@turf/meta').geomEach;
+var flatten = require('@turf/flatten');
+var lineString = require('@turf/helpers').lineString;
 var point = require('@turf/helpers').point;
 
 /**
  * Takes a {@link LineString} or {@link Polygon} and measures its length in the specified units.
  *
  * @name lineDistance
- * @param {Feature<(LineString|Polygon)>|FeatureCollection<(LineString|Polygon)>} line line to measure
+ * @param {Feature<(LineString|Polygon)>|FeatureCollection<(LineString|Polygon)>} geojson feature to measure
  * @param {string} [units=kilometers] can be degrees, radians, miles, or kilometers
- * @returns {number} length of the input line
+ * @returns {number} length feature
  * @example
  * var line = {
  *   "type": "Feature",
@@ -31,51 +36,74 @@ var point = require('@turf/helpers').point;
  *
  * //=length
  */
-module.exports = function lineDistance(line, units) {
-    if (line.type === 'FeatureCollection') {
-        return line.features.reduce(function (memo, feature) {
-            return memo + lineDistance(feature, units);
-        }, 0);
-    }
+module.exports = function lineDistance(geojson, units) {
+    // Input Validation
+    if (!geojson) throw new Error('geojson is required');
+    geomEach(geojson, function (geometry) {
+        if (geometry.type === 'Point') throw new Error('geojson cannot be a Point');
+        if (geometry.type === 'MultiPoint') throw new Error('geojson cannot be a MultiPoint');
+    });
 
-    var geometry = line.type === 'Feature' ? line.geometry : line;
-    var d, i;
-
-    if (geometry.type === 'LineString') {
-        return length(geometry.coordinates, units);
-    } else if (geometry.type === 'Polygon' || geometry.type === 'MultiLineString') {
-        d = 0;
-        for (i = 0; i < geometry.coordinates.length; i++) {
-            d += length(geometry.coordinates[i], units);
-        }
-        return d;
-    } else if (geometry.type === 'MultiPolygon') {
-        d = 0;
-        for (i = 0; i < geometry.coordinates.length; i++) {
-            for (var j = 0; j < geometry.coordinates[i].length; j++) {
-                d += length(geometry.coordinates[i][j], units);
-            }
-        }
-        return d;
-    } else {
-        throw new Error('input must be a LineString, MultiLineString, ' +
-            'Polygon, or MultiPolygon Feature or Geometry (or a FeatureCollection ' +
-            'containing only those types)');
-    }
-
+    // Calculate distance from 2-vertex line segements
+    return segmentReduce(geojson, function (previousValue, segment) {
+        var coords = segment.geometry.coordinates;
+        var start = point(coords[0]);
+        var end = point(coords[1]);
+        return previousValue + distance(start, end, units);
+    }, 0);
 };
 
-function length(coords, units) {
-    var travelled = 0;
-    var prevCoords = point(coords[0]);
-    var curCoords = point(coords[0]);
-    var temp;
-    for (var i = 1; i < coords.length; i++) {
-        curCoords.geometry.coordinates = coords[i];
-        travelled += distance(prevCoords, curCoords, units);
-        temp = prevCoords;
-        prevCoords = curCoords;
-        curCoords = temp;
-    }
-    return travelled;
+/**
+ * Iterate over 2-vertex line segment in any GeoJSON object, similar to Array.forEach()
+ *
+ * @private
+ * @param {FeatureCollection|Feature<any>} geojson any GeoJSON
+ * @param {Function} callback a method that takes (currentSegment, currentIndex)
+ * @returns {void}
+ * @example
+ * var polygon = {
+ *   "type": "Feature",
+ *   "properties": {},
+ *   "geometry": {
+ *     "type": "Polygon",
+ *     "coordinates": [[[-50, 5], [-40, -10], [-50, -10], [-40, 5], [-50, 5]]]
+ *   }
+ * }
+ * turf.segmentEach(polygon, function (segment) {
+ *   //= segment
+ * });
+ */
+function segmentEach(geojson, callback) {
+    var count = 0;
+    featureEach(geojson, function (multiFeature) {
+        featureEach(flatten(multiFeature), function (feature) {
+            coordReduce(feature, function (previousCoords, currentCoords) {
+                var line = lineString([previousCoords, currentCoords], feature.properties);
+                callback(line, count);
+                count++;
+                return currentCoords;
+            });
+        });
+    });
+}
+
+/**
+ * Reduce 2-vertex line segment in any GeoJSON object, similar to Array.reduce()
+ *
+ * @private
+ * @param {FeatureCollection|Feature<any>} geojson any GeoJSON
+ * @param {Function} callback a method that takes (previousValue, currentSegment, currentIndex)
+ * @param {*} [initialValue] Value to use as the first argument to the first call of the callback.
+ * @returns {void}
+ */
+function segmentReduce(geojson, callback, initialValue) {
+    var previousValue = initialValue;
+    segmentEach(geojson, function (currentSegment, currentIndex) {
+        if (currentIndex === 0 && initialValue === undefined) {
+            previousValue = currentSegment;
+        } else {
+            previousValue = callback(previousValue, currentSegment, currentIndex);
+        }
+    });
+    return previousValue;
 }

--- a/packages/turf-line-distance/package.json
+++ b/packages/turf-line-distance/package.json
@@ -38,6 +38,8 @@
   },
   "dependencies": {
     "@turf/distance": "^3.13.0",
-    "@turf/helpers": "^3.13.0"
+    "@turf/flatten": "^3.13.0",
+    "@turf/helpers": "^3.13.0",
+    "@turf/meta": "^3.13.0"
   }
 }


### PR DESCRIPTION
Proof of concept of `segmentReduce()` & `segmentEach()` discussed in PR https://github.com/Turfjs/turf/pull/611 & Issue https://github.com/Turfjs/turf/issues/205.

These types of methods help clean out messy code and helps you focus on logic instead of handling every GeoJSON geometry types.

In my opinion, this would fit very nicely in `@turf/meta` since it returns callbacks and not everyone understands how to use callbacks as a general use module.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occured.
- [x] Run `npm run lint` to ensure code style at the turf module level.
