### PR TITLE
Ignore the Calculate Final Bearing function so it doesn't appear in docs

### DIFF
--- a/packages/turf-bearing/index.js
+++ b/packages/turf-bearing/index.js
@@ -58,7 +58,7 @@ function bearing(start, end, final) {
 
 /**
  * Calculates Final Bearing
- * @ignore
+ * @private
  * @param {Feature<Point>} start starting Point
  * @param {Feature<Point>} end ending Point
  * @returns {number} bearing

--- a/packages/turf-bearing/index.js
+++ b/packages/turf-bearing/index.js
@@ -58,7 +58,7 @@ function bearing(start, end, final) {
 
 /**
  * Calculates Final Bearing
- *
+ * @ignore
  * @param {Feature<Point>} start starting Point
  * @param {Feature<Point>} end ending Point
  * @returns {number} bearing


### PR DESCRIPTION
Currently the calculatefinalbearing function is appearing in the [docs](http://turfjs.org/docs/#calculatefinalbearing), it needs to be ignored by jsdocs

