### PR TITLE
Turf.invariant fails on string value as coordinate

### DIFF
--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -62,7 +62,8 @@ function containsNumber(coordinates) {
         typeof coordinates[1] === 'number') {
         return true;
     }
-    if (coordinates[0].length) {
+
+    if (Array.isArray(coordinates[0]) && coordinates[0].length) {
         return containsNumber(coordinates[0]);
     }
     throw new Error('coordinates must only contain numbers');
@@ -138,3 +139,4 @@ module.exports.collectionOf = collectionOf;
 module.exports.featureOf = featureOf;
 module.exports.getCoord = getCoord;
 module.exports.getCoords = getCoords;
+module.exports.containsNumber = containsNumber;

--- a/packages/turf-invariant/test.js
+++ b/packages/turf-invariant/test.js
@@ -2,6 +2,18 @@ const test = require('tape');
 const {point, lineString, polygon} = require('@turf/helpers');
 const invariant = require('./');
 
+test('invariant#containsNumber', t => {
+    t.equals(invariant.containsNumber([1, 1]), true);
+    t.equals(invariant.containsNumber([[1, 1], [1, 1]]), true);
+    t.equals(invariant.containsNumber([[[1,1], [1,1]], [1, 1]]), true);
+
+    //# Ensure recusive call handles Max callstack exceeded
+    t.throws(() => {
+        invariant.containsNumber(['1', 1]);
+    }, /coordinates must only contain numbers/, 'Must only contain numbers');
+    t.end();
+});
+
 test('invariant#geojsonType', t => {
     t.throws(() => {
         invariant.geojsonType();

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -12,7 +12,8 @@ import {
     getCoord,
     geojsonType,
     featureOf,
-    collectionOf
+    collectionOf,
+    containsNumber
 } from '@turf/invariant';
 import {
     coordEach,
@@ -146,6 +147,7 @@ export {
     geojsonType,
     featureOf,
     collectionOf,
+    containsNumber,
     truncate,
     flatten,
     coordEach,

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -83,6 +83,7 @@ var turf = {
     geojsonType: invariant.geojsonType,
     featureOf: invariant.featureOf,
     collectionOf: invariant.collectionOf,
+    containsNumber: invariant.containsNumber,
     coordEach: meta.coordEach,
     coordReduce: meta.coordReduce,
     propEach: meta.propEach,


### PR DESCRIPTION
Turf.invariant fails with a Max Callstack Exceeded when a string value is in the coordinates array.

cc/ @DenisCarriere @morganherlocker 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.
