### PR TITLE
@turf/inside performance increase

### DIFF
--- a/packages/turf-inside/bench.js
+++ b/packages/turf-inside/bench.js
@@ -14,9 +14,9 @@ var multiPolyHole = JSON.parse(fs.readFileSync(__dirname + '/test/in/multipoly-w
 /**
  * Benchmark Results
  *
- * simple x 3,185,225 ops/sec ±0.99% (90 runs sampled)
- * multiPolyHole - inside x 1,234,815 ops/sec ±0.90% (90 runs sampled)
- * multiPolyHole - outside x 1,644,657 ops/sec ±1.26% (88 runs sampled)
+ * simple x 3,219,331 ops/sec ±1.14% (91 runs sampled)
+ * multiPolyHole - inside x 1,171,486 ops/sec ±1.10% (90 runs sampled)
+ * multiPolyHole - outside x 7,697,033 ops/sec ±0.89% (89 runs sampled)
  */
 var suite = new Benchmark.Suite('turf-inside');
 suite

--- a/packages/turf-inside/index.js
+++ b/packages/turf-inside/index.js
@@ -38,6 +38,10 @@ module.exports = function (point, polygon) {
     var pt = getCoord(point);
     var polys = getCoords(polygon);
     var type = (polygon.geometry) ? polygon.geometry.type : polygon.type;
+    var bbox = polygon.bbox;
+
+    // Quick elimination if point is not inside bbox
+    if (bbox && inBBox(pt, bbox) === false) return false;
 
     // normalize to multipolygon
     if (type === 'Polygon') polys = [polys];
@@ -84,4 +88,18 @@ function inRing(pt, ring, ignoreBoundary) {
         if (intersect) isInside = !isInside;
     }
     return isInside;
+}
+
+/**
+ * inBBox
+ *
+ * @param {[number, number]} pt point [x,y]
+ * @param {[number, number, number, number]} bbox BBox [west, south, east, north]
+ * @returns {boolean} true/false if point is inside BBox
+ */
+function inBBox(pt, bbox) {
+    return bbox[0] <= pt[0] &&
+           bbox[1] <= pt[1] &&
+           bbox[2] >= pt[0] &&
+           bbox[3] >= pt[1];
 }


### PR DESCRIPTION
# @turf/inside performance increase

Utilising the `bbox` properties can speed up this module significantly for points outside the `BBox`.

If `BBox` exists on Polygons, calculate quickly if point is inside `BBox` and return `false` immediately if `false`. Performance increase (**7x or greater**) for a points outside `BBox` with very little performance loss for points inside poly.

Influenced by: https://github.com/Turfjs/turf/issues/173