### PR TITLE
Improve Typescript types for featureCollection @turf/helper

### DIFF
--- a/packages/turf-buffer/index.d.ts
+++ b/packages/turf-buffer/index.d.ts
@@ -15,8 +15,8 @@ interface Buffer {
     (feature: Points | LineStrings | Polygons | MultiPoint | MultiPoints, radius?: number, unit?: Units, steps?: number): Polygons;
     (feature: MultiLineString | MultiPolygon, radius?: number, unit?: Units, steps?: number): MultiPolygon;
     (feature: MultiLineStrings | MultiPolygons, radius?: number, unit?: Units, steps?: number): MultiPolygons;
-    (feature: Feature, radius?: number, unit?: Units, steps?: number): Polygon | Polygons | MultiPolygon;
-    (feature: Features, radius?: number, unit?: Units, steps?: number): Polygons | MultiPolygons;
+    (feature: Feature<any>, radius?: number, unit?: Units, steps?: number): Polygon | Polygons | MultiPolygon;
+    (feature: Features<any>, radius?: number, unit?: Units, steps?: number): Polygons | MultiPolygons;
     (feature: GeoJSON.GeometryObject, radius?: number, unit?: Units, steps?: number): Polygon | Polygons | MultiPolygon;
     (feature: GeoJSON.GeometryCollection, radius?: number, unit?: Units, steps?: number): Polygons | MultiPolygons;
 }

--- a/packages/turf-flatten/index.d.ts
+++ b/packages/turf-flatten/index.d.ts
@@ -13,8 +13,8 @@ interface Flatten {
     (geojson: Point | Points | MultiPoint | MultiPoints): Points;
     (geojson: LineString | LineStrings | MultiLineString | MultiLineStrings): LineStrings;
     (geojson: Polygons | Polygons | MultiPolygons | MultiPolygons): Polygons;
-    (geojson: Feature | Features): Features;
-    (geojson: GeoJSON.GeometryCollection | GeoJSON.GeometryObject): Features;
+    (geojson: Feature<any> | Features<any>): Features<any>;
+    (geojson: GeoJSON.GeometryCollection | GeoJSON.GeometryObject): Features<any>;
 }
 
 declare const flatten: Flatten;

--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -12,18 +12,21 @@ export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
 export type MultiPolygons = GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>;
 export type MultiPolygon = GeoJSON.Feature<GeoJSON.MultiPolygon>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Feature = GeoJSON.Feature<any>;
 export type Position = GeoJSON.Position;
 export type LineStringFeatures = LineString | LineStrings | MultiLineString | MultiLineStrings | GeoJSON.LineString | GeoJSON.MultiLineString
 export type PolygonFeatures = Polygon | Polygons | MultiPolygon | MultiPolygons | GeoJSON.Polygon | GeoJSON.MultiPolygon
+export type Features<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
+export type Feature<Geom extends GeometryObject> = GeoJSON.Feature<Geom>;
 export type Units = "miles" | "nauticalmiles" | "degrees" | "radians" | "inches" | "yards" | "meters" | "metres" | "kilometers" | "kilometres";
 export type BBox = [number, number, number, number];
+export type GeometryObject = GeoJSON.GeometryObject;
+export type GeometryCollection = GeoJSON.GeometryCollection;
+export type Geoms = GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiPoint | GeoJSON.MultiLineString | GeoJSON.MultiPolygon;
 
 /**
  * http://turfjs.org/docs/#feature
  */
-export function feature(geometry: GeoJSON.GeometryObject, properties?: any): Feature;
+export function feature<Geom extends GeometryObject>(geometry: Geom, properties?: any): Feature<Geom>;
 
 /**
  * http://turfjs.org/docs/#point
@@ -43,15 +46,11 @@ export function lineString(coordinates: Position[], properties?: any): LineStrin
 /**
  * http://turfjs.org/docs/#featurecollection
  */
-export const featureCollection: {
-    (features: Array<Point>): Points;
-    (features: Array<LineString>): LineStrings;
-    (features: Array<Polygon>): Polygons;
-    (features: Array<MultiPoint>): MultiPoints;
-    (features: Array<MultiLineString>): MultiLineStrings;
-    (features: Array<MultiPolygon>): MultiPolygons;
-    (features: Array<Feature>): Features;
-};
+interface featureCollection {
+  <Geom extends Geoms>(features: Feature<Geom>[]): Features<Geom>;
+  (features: Feature<any>[]): Features<any>;
+}
+export const featureCollection: featureCollection;
 
 /**
  * http://turfjs.org/docs/#multilinestring
@@ -71,7 +70,7 @@ export function multiPolygon(coordinates: Position[][][], properties?: any): Mul
 /**
  * http://turfjs.org/docs/#geometrycollection
  */
-export function geometryCollection(geometries: Array<GeoJSON.GeometryObject>, properties?: any): GeoJSON.GeometryCollection;
+export function geometryCollection<Geom extends GeometryObject>(geometries: Geom[], properties?: any): GeometryCollection;
 
 /**
  * http://turfjs.org/docs/#radianstodistance

--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -70,7 +70,7 @@ export function multiPolygon(coordinates: Position[][][], properties?: any): Mul
 /**
  * http://turfjs.org/docs/#geometrycollection
  */
-export function geometryCollection<Geom extends GeometryObject>(geometries: Geom[], properties?: any): GeometryCollection;
+export function geometryCollection(geometries: GeometryObject[], properties?: any): GeometryCollection;
 
 /**
  * http://turfjs.org/docs/#radianstodistance

--- a/packages/turf-helpers/test/types.ts
+++ b/packages/turf-helpers/test/types.ts
@@ -1,13 +1,45 @@
-import * as turf from '../'
+import {
+  Feature, Points, Polygons, LineStrings,
+  point, lineString, polygon,
+  multiPoint, multiLineString, multiPolygon,
+  feature, featureCollection, geometryCollection,
+  radiansToDistance, distanceToDegrees, distanceToRadians} from '../'
 
-turf.point([0, 1])
-turf.lineString([[0, 1], [2, 3]])
-turf.polygon([[[0, 1], [2, 3], [0, 1]]])
-turf.feature({coordinates: [1, 0], type: 'point'})
-turf.multiLineString([[[0, 1], [2, 3], [0, 1]]])
-turf.multiPoint([[0, 1], [2, 3], [0, 1]])
-turf.multiPolygon([[[[0, 1], [2, 3], [0, 1]]]])
-turf.geometryCollection([{coordinates: [1, 0], type: 'point'}])
-turf.radiansToDistance(5)
-turf.distanceToRadians(10)
-turf.distanceToDegrees(45)
+const pt = point([0, 1])
+const line = lineString([[0, 1], [2, 3]])
+const poly = polygon([[[0, 1], [2, 3], [0, 1]]])
+feature({coordinates: [1, 0], type: 'point'})
+multiLineString([[[0, 1], [2, 3], [0, 1]]])
+multiPoint([[0, 1], [2, 3], [0, 1]])
+multiPolygon([[[[0, 1], [2, 3], [0, 1]]]])
+geometryCollection([{coordinates: [1, 0], type: 'point'}])
+radiansToDistance(5)
+distanceToRadians(10)
+distanceToDegrees(45)
+
+/**
+ * Feature Collection
+ */
+// Mixed collection is defiend as FeatureCollection<any>
+const mixed = featureCollection([pt, poly])
+mixed.features.push(pt)
+mixed.features.push(line)
+mixed.features.push(poly)
+
+// Blank collection is defined as FeatureCollection<any>
+const blank = featureCollection([])
+blank.features.push(pt)
+blank.features.push(line)
+blank.features.push(poly)
+
+// Collection with only Points
+const points = featureCollection<GeoJSON.Point>([])
+points.features.push(pt)
+
+// Collection with only LineStrings
+const lines = featureCollection([line])
+lines.features.push(line)
+
+// Collection with only Polygons
+const polygons = featureCollection<GeoJSON.Polygon>([])
+polygons.features.push(poly)

--- a/packages/turf-point-grid/index.d.ts
+++ b/packages/turf-point-grid/index.d.ts
@@ -3,6 +3,6 @@ import {BBox, Points, Units, Feature, Features} from '@turf/helpers';
 /**
  * http://turfjs.org/docs/#pointgrid
  */
-declare function pointGrid(bbox: BBox | Feature | Features, cellSize: number, units?: Units): Points;
+declare function pointGrid(bbox: BBox | Feature<any> | Features<any>, cellSize: number, units?: Units): Points;
 declare namespace pointGrid { }
 export = pointGrid;

--- a/packages/turf-square-grid/index.d.ts
+++ b/packages/turf-square-grid/index.d.ts
@@ -3,6 +3,6 @@ import {Units, BBox, Polygons, Feature, Features} from '@turf/helpers'
 /**
  * http://turfjs.org/docs/#squaregrid
  */
-declare function squareGrid(bbox: BBox | Feature | Features, cellSize: number, units?: Units, completelyWithin?: boolean): Polygons;
+declare function squareGrid(bbox: BBox | Feature<any> | Features<any>, cellSize: number, units?: Units, completelyWithin?: boolean): Polygons;
 declare namespace squareGrid { }
 export = squareGrid;


### PR DESCRIPTION
Improve Typescript types for `featureCollection()` `@turf/helper`.

Main issue was if you created a blank FeatureCollection the type definition would assume it was a `FeatureCollection<Point>`. Better handling of mixed contents and inherit types based on input.

## Typescript Examples
```typescript
// Mixed collection is defiend as FeatureCollection<any>
const mixed = featureCollection([pt, poly])
mixed.features.push(pt)
mixed.features.push(line)
mixed.features.push(poly)

// Blank collection is defined as FeatureCollection<any>
const blank = featureCollection([])
blank.features.push(pt)
blank.features.push(line)
blank.features.push(poly)

// Collection with only Points
const points = featureCollection<GeoJSON.Point>([])
points.features.push(pt)

// Collection with only LineStrings
const lines = featureCollection([line])
lines.features.push(line)

// Collection with only Polygons
const polygons = featureCollection<GeoJSON.Polygon>([])
polygons.features.push(poly)
```