### PR TITLE
Add ignoreBoundary param @turf/inside

### DIFF
--- a/packages/turf-inside/README.md
+++ b/packages/turf-inside/README.md
@@ -9,6 +9,7 @@ be convex or concave. The function accounts for holes.
 
 -   `point` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;[Point](http://geojson.org/geojson-spec.html#point)>** input point
 -   `polygon` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;([Polygon](http://geojson.org/geojson-spec.html#polygon) \| [MultiPolygon](http://geojson.org/geojson-spec.html#multipolygon))>** input polygon or multipolygon
+-   `ignoreBoundary` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** True if polygon boundary should be ignored when determining if the point is inside the polygon otherwise false. (optional, default `false`)
 
 **Examples**
 

--- a/packages/turf-inside/index.js
+++ b/packages/turf-inside/index.js
@@ -13,6 +13,7 @@ var getCoords = invariant.getCoords;
  * @name inside
  * @param {Feature<Point>} point input point
  * @param {Feature<Polygon|MultiPolygon>} polygon input polygon or multipolygon
+ * @param {boolean} [ignoreBoundary=false] True if polygon boundary should be ignored when determining if the point is inside the polygon otherwise false.
  * @returns {boolean} `true` if the Point is inside the Polygon; `false` if the Point is not inside the Polygon
  * @example
  * var pt = turf.point([-77, 44]);
@@ -30,7 +31,7 @@ var getCoords = invariant.getCoords;
  * pt.properties.isInside = isInside
  * var addToMap = [pt, poly]
  */
-module.exports = function (point, polygon) {
+module.exports = function (point, polygon, ignoreBoundary) {
     // validation
     if (!point) throw new Error('point is required');
     if (!polygon) throw new Error('polygon is required');
@@ -48,12 +49,12 @@ module.exports = function (point, polygon) {
 
     for (var i = 0, insidePoly = false; i < polys.length && !insidePoly; i++) {
         // check if it is in the outer ring first
-        if (inRing(pt, polys[i][0])) {
+        if (inRing(pt, polys[i][0], ignoreBoundary)) {
             var inHole = false;
             var k = 1;
             // check for the point in any of the holes
             while (k < polys[i].length && !inHole) {
-                if (inRing(pt, polys[i][k], true)) {
+                if (inRing(pt, polys[i][k], !ignoreBoundary)) {
                     inHole = true;
                 }
                 k++;

--- a/packages/turf-inside/test.js
+++ b/packages/turf-inside/test.js
@@ -101,51 +101,55 @@ test('Boundary test', function (t) {
     [ 20, 10 ],
     [ 10, 20 ]
   ]]);
+  function runTest(t, ignoreBoundary) {
+    var isBoundaryIncluded = (ignoreBoundary === false);
+    var tests = [
+      [poly1, point([ 10, 10 ]), isBoundaryIncluded], //0
+      [poly1, point([ 30, 20 ]), isBoundaryIncluded],
+      [poly1, point([ 50, 10 ]), isBoundaryIncluded],
+      [poly1, point([ 30, 10 ]), true],
+      [poly1, point([  0, 10 ]), false],
+      [poly1, point([ 60, 10 ]), false],
+      [poly1, point([ 30,-10 ]), false],
+      [poly1, point([ 30, 30 ]), false],
+      [poly2, point([ 30,  0 ]), false],
+      [poly2, point([  0,  0 ]), false],
+      [poly2, point([ 60,  0 ]), false], //10
+      [poly3, point([ 30,  0 ]), true],
+      [poly3, point([  0,  0 ]), false],
+      [poly3, point([ 60,  0 ]), false],
+      [poly4, point([  0, 20 ]), isBoundaryIncluded],
+      [poly4, point([ 10, 20 ]), isBoundaryIncluded],
+      [poly4, point([ 50, 20 ]), isBoundaryIncluded],
+      [poly4, point([  0, 10 ]), isBoundaryIncluded],
+      [poly4, point([  5, 10 ]), true],
+      [poly4, point([ 25, 10 ]), true],
+      [poly4, point([ 35, 10 ]), true], //20
+      [poly4, point([  0,  0 ]), isBoundaryIncluded],
+      [poly4, point([ 20,  0 ]), false],
+      [poly4, point([ 35,  0 ]), false],
+      [poly4, point([ 50,  0 ]), isBoundaryIncluded],
+      [poly4, point([ 50, 10 ]), isBoundaryIncluded],
+      [poly4, point([  5,  0 ]), isBoundaryIncluded],
+      [poly4, point([ 10,  0 ]), isBoundaryIncluded],
+      [poly5, point([ 20, 30 ]), isBoundaryIncluded],
+      [poly5, point([ 25, 25 ]), isBoundaryIncluded],
+      [poly5, point([ 30, 20 ]), isBoundaryIncluded], //30
+      [poly5, point([ 25, 15 ]), isBoundaryIncluded],
+      [poly5, point([ 20, 10 ]), isBoundaryIncluded],
+      [poly5, point([ 15, 15 ]), isBoundaryIncluded],
+      [poly5, point([ 10, 20 ]), isBoundaryIncluded],
+      [poly5, point([ 15, 25 ]), isBoundaryIncluded],
+      [poly5, point([ 20, 20 ]), false]
+    ];
 
-  var tests = [
-    [poly1, point([ 10, 10 ]), true], //0
-    [poly1, point([ 30, 20 ]), true],
-    [poly1, point([ 50, 10 ]), true],
-    [poly1, point([ 30, 10 ]), true],
-    [poly1, point([  0, 10 ]), false],
-    [poly1, point([ 60, 10 ]), false],
-    [poly1, point([ 30,-10 ]), false],
-    [poly1, point([ 30, 30 ]), false],
-    [poly2, point([ 30,  0 ]), false],
-    [poly2, point([  0,  0 ]), false],
-    [poly2, point([ 60,  0 ]), false], //10
-    [poly3, point([ 30,  0 ]), true],
-    [poly3, point([  0,  0 ]), false],
-    [poly3, point([ 60,  0 ]), false],
-    [poly4, point([  0, 20 ]), true],
-    [poly4, point([ 10, 20 ]), true],
-    [poly4, point([ 50, 20 ]), true],
-    [poly4, point([  0, 10 ]), true],
-    [poly4, point([  5, 10 ]), true],
-    [poly4, point([ 25, 10 ]), true],
-    [poly4, point([ 35, 10 ]), true], //20
-    [poly4, point([  0,  0 ]), true],
-    [poly4, point([ 20,  0 ]), false],
-    [poly4, point([ 35,  0 ]), false],
-    [poly4, point([ 50,  0 ]), true],
-    [poly4, point([ 50, 10 ]), true],
-    [poly4, point([  5,  0 ]), true],
-    [poly4, point([ 10,  0 ]), true],
-    [poly5, point([ 20, 30 ]), true],
-    [poly5, point([ 25, 25 ]), true],
-    [poly5, point([ 30, 20 ]), true], //30
-    [poly5, point([ 25, 15 ]), true],
-    [poly5, point([ 20, 10 ]), true],
-    [poly5, point([ 15, 15 ]), true],
-    [poly5, point([ 10, 20 ]), true],
-    [poly5, point([ 15, 25 ]), true],
-    [poly5, point([ 20, 20 ]), false]
-  ];
-
-  for (var i=0;i<tests.length;i++) {
-    var item = tests[i];
-    t.true(inside(item[1], item[0]) == item[2], "Boundary test number " + i);
+    var testTitle = "Boundary " + (ignoreBoundary ? "ignored " : "") + "test number ";
+    for (var i=0;i<tests.length;i++) {
+      var item = tests[i];
+        t.true(inside(item[1], item[0], ignoreBoundary) == item[2], testTitle + i);
+    }
   }
-
+  runTest(t, false);
+  runTest(t, true);
   t.end();
 });


### PR DESCRIPTION
This addresses issue #699 to allow polygon boundary to be ignored when testing if point is inside.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [X] Run `npm test` at the sub modules where changes have occurred.
- [X] Run `npm run lint` to ensure code style at the turf module level.
