### PR TITLE
Add flattenEach/flattenReduce to @turf/meta.

### DIFF
--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -300,7 +300,7 @@ Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentGeometry, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentGeometry, currentIndex, currentProperties)
 
 **Examples**
 
@@ -326,9 +326,10 @@ var features = {
     }
   ]
 };
-turf.geomEach(features, function (currentGeometry, currentIndex) {
+turf.geomEach(features, function (currentGeometry, currentIndex, currentProperties) {
   //=currentGeometry
   //=currentIndex
+  //=currentProperties
 });
 ```
 
@@ -339,7 +340,7 @@ Reduce geometry in any GeoJSON object, similar to Array.reduce().
 **Parameters**
 
 -   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
--   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentGeometry, currentIndex)
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentGeometry, currentIndex, currentProperties)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
 **Examples**
@@ -371,6 +372,92 @@ turf.geomReduce(features, function (previousValue, currentGeometry, currentIndex
   //=currentGeometry
   //=currentIndex
   return currentGeometry
+});
+```
+
+Returns **Any** The value that results from the reduction.
+
+# flattenEach
+
+Iterate over flattened features in any GeoJSON object, similar to
+Array.forEach.
+
+**Parameters**
+
+-   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentFeature, currentIndex, currentSubIndex)
+
+**Examples**
+
+```javascript
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [ [36, 53], [46, 69] ]
+      }
+    }
+  ]
+};
+turf.flattenEach(features, function (currentFeature, currentIndex, currentSubIndex) {
+  //=currentFeature
+  //=currentIndex
+  //=currentSubIndex
+});
+```
+
+# flattenReduce
+
+Reduce flattened features in any GeoJSON object, similar to Array.reduce().
+
+**Parameters**
+
+-   `layer` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** any GeoJSON object
+-   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentFeature, currentIndex, currentSubIndex)
+-   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
+
+**Examples**
+
+```javascript
+var features = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"foo": "bar"},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [26, 37]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"hello": "world"},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [ [36, 53], [46, 69] ]
+      }
+    }
+  ]
+};
+turf.flattenReduce(features, function (previousValue, currentFeature, currentIndex, currentSubIndex) {
+  //=previousValue
+  //=currentFeature
+  //=currentIndex
+  //=currentSubIndex
+  return currentFeature
 });
 ```
 

--- a/packages/turf-meta/bench.js
+++ b/packages/turf-meta/bench.js
@@ -11,9 +11,10 @@ const fixtures = {
 
 const suite = new Benchmark.Suite('turf-meta');
 
-
 /**
  * Benchmark Results
+ * flattenEach   - point x 6,447,234 ops/sec ±5.56% (79 runs sampled)
+ * flattenReduce - point x 5,415,555 ops/sec ±1.28% (85 runs sampled)
  * coordEach     - point x 19,941,547 ops/sec ±0.64% (84 runs sampled)
  * coordReduce   - point x 11,959,189 ops/sec ±1.53% (85 runs sampled)
  * propEach      - point x 29,317,809 ops/sec ±1.38% (85 runs sampled)
@@ -23,6 +24,8 @@ const suite = new Benchmark.Suite('turf-meta');
  * featureEach   - point x 29,588,658 ops/sec ±1.02% (88 runs sampled)
  * featureReduce - point x 15,372,497 ops/sec ±1.11% (89 runs sampled)
  * coordAll      - point x 8,348,718 ops/sec ±0.68% (92 runs sampled)
+ * flattenEach   - points x 18,821 ops/sec ±7.17% (76 runs sampled)
+ * flattenReduce - points x 17,848 ops/sec ±1.10% (88 runs sampled)
  * coordEach     - points x 71,017 ops/sec ±0.80% (90 runs sampled)
  * coordReduce   - points x 46,986 ops/sec ±1.24% (91 runs sampled)
  * propEach      - points x 137,509 ops/sec ±0.38% (96 runs sampled)
@@ -32,6 +35,8 @@ const suite = new Benchmark.Suite('turf-meta');
  * featureEach   - points x 151,234 ops/sec ±0.45% (92 runs sampled)
  * featureReduce - points x 71,235 ops/sec ±1.51% (92 runs sampled)
  * coordAll      - points x 40,960 ops/sec ±0.88% (94 runs sampled)
+ * flattenEach   - polygon x 6,262,904 ops/sec ±2.84% (85 runs sampled)
+ * flattenReduce - polygon x 4,944,606 ops/sec ±4.15% (82 runs sampled)
  * coordEach     - polygon x 6,153,922 ops/sec ±2.36% (87 runs sampled)
  * coordReduce   - polygon x 3,348,489 ops/sec ±2.08% (91 runs sampled)
  * propEach      - polygon x 30,816,868 ops/sec ±0.96% (88 runs sampled)
@@ -41,6 +46,8 @@ const suite = new Benchmark.Suite('turf-meta');
  * featureEach   - polygon x 29,478,632 ops/sec ±1.86% (87 runs sampled)
  * featureReduce - polygon x 14,642,632 ops/sec ±2.62% (81 runs sampled)
  * coordAll      - polygon x 2,080,425 ops/sec ±13.27% (61 runs sampled)
+ * flattenEach   - polygons x 17,587 ops/sec ±3.05% (85 runs sampled)
+ * flattenReduce - polygons x 16,576 ops/sec ±1.33% (86 runs sampled)
  * coordEach     - polygons x 3,040 ops/sec ±15.62% (41 runs sampled)
  * coordReduce   - polygons x 4,100 ops/sec ±7.31% (85 runs sampled)
  * propEach      - polygons x 126,455 ops/sec ±0.85% (87 runs sampled)
@@ -54,6 +61,8 @@ const suite = new Benchmark.Suite('turf-meta');
 Object.keys(fixtures).forEach(name => {
     const geojson = fixtures[name];
     suite
+        .add('flattenEach   - ' + name, () => meta.flattenEach(geojson, () => {}))
+        .add('flattenReduce - ' + name, () => meta.flattenReduce(geojson, () => {}))
         .add('coordEach     - ' + name, () => meta.coordEach(geojson, () => {}))
         .add('coordReduce   - ' + name, () => meta.coordReduce(geojson, () => {}))
         .add('propEach      - ' + name, () => meta.propEach(geojson, () => {}))
@@ -66,6 +75,6 @@ Object.keys(fixtures).forEach(name => {
 });
 
 suite
-  .on('cycle', e => { console.log(String(e.target)); })
+  .on('cycle', e => console.log(String(e.target)))
   .on('complete', () => {})
   .run();

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -1,101 +1,83 @@
 /// <reference types="geojson" />
 
-type Points = GeoJSON.FeatureCollection<GeoJSON.Point>
-type Point = GeoJSON.Feature<GeoJSON.Point> | GeoJSON.Point
-type MultiPoints = GeoJSON.FeatureCollection<GeoJSON.MultiPoint>
-type MultiPoint = GeoJSON.Feature<GeoJSON.MultiPoint> | GeoJSON.MultiPoint
-type LineStrings = GeoJSON.FeatureCollection<GeoJSON.LineString>
-type LineString = GeoJSON.Feature<GeoJSON.LineString> | GeoJSON.LineString
-type MultiLineStrings = GeoJSON.FeatureCollection<GeoJSON.MultiLineString>
-type MultiLineString = GeoJSON.Feature<GeoJSON.MultiLineString> | GeoJSON.MultiLineString
-type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>
-type Polygon = GeoJSON.Feature<GeoJSON.Polygon> | GeoJSON.Polygon
-type MultiPolygons = GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>
-type MultiPolygon = GeoJSON.Feature<GeoJSON.MultiPolygon> | GeoJSON.MultiPolygon
-type Feature = GeoJSON.Feature<any>
-type Features = GeoJSON.FeatureCollection<any>
-type GeometryCollection = GeoJSON.GeometryCollection
-type GeometryObject = GeoJSON.GeometryObject
+export type Point = GeoJSON.Point;
+export type LineString = GeoJSON.LineString;
+export type Polygon = GeoJSON.Polygon;
+export type MultiPoint = GeoJSON.MultiPoint;
+export type MultiLineString = GeoJSON.MultiLineString;
+export type MultiPolygon = GeoJSON.MultiPolygon;
+export type Features<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
+export type Feature<Geom extends GeometryObject> = GeoJSON.Feature<Geom>;
+export type GeometryObject = GeoJSON.GeometryObject;
+export type GeometryCollection = GeoJSON.GeometryCollection;
+export type Geoms = GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiPoint | GeoJSON.MultiLineString | GeoJSON.MultiPolygon | GeometryObject;
+export type Position = GeoJSON.Position;
 
-interface MetaStatic {
-    /**
-     * http://turfjs.org/docs/#coordeach
-     */
-    coordEach(layer: Points | Point | MultiPoint | MultiPoints, callback: (currentCoords: Array<number>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (currentCoords: Array<Array<number>>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (currentCoords: Array<Array<Array<number>>>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
-    coordEach(layer: GeometryCollection | GeometryObject, callback: (currentCoords: Array<any>, currentIndex: number) => void, excludeWrapCoord?: boolean): void;
-
+interface CoordReduce {
     /**
      * http://turfjs.org/docs/#coordreduce
      */
-    coordReduce(layer: Points | Point | MultiPoint | MultiPoints, callback: (previousValue: any, currentCoords: Array<number>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: LineStrings | LineString | MultiLineString | MultiLineStrings, callback: (previousValue: any, currentCoords: Array<Array<number>>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: Polygons | Polygon | MultiPolygons | MultiPolygon, callback: (previousValue: any, currentCoords: Array<Array<Array<number>>>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-    coordReduce(layer: GeometryCollection | GeometryObject, callback: (previousValue: any, currentCoords: Array<any>, currentIndex: number) => void, initialValue: any, excludeWrapCoord?: boolean): any;
-
-    /**
-     * http://turfjs.org/docs/#propeach
-     */
-    propEach(layer: Feature | Features, callback: (currentProperties: any, currentIndex: number) => void): void;
-
-    /**
-     * http://turfjs.org/docs/#propreduce
-     */
-    propReduce(layer: Feature | Features, callback: (previousValue: any, currentProperties: any, currentIndex: number) => void, initialValue: any): any;
-
-    /**
-     * http://turfjs.org/docs/#featurereduce
-     */
-    featureReduce(layer: Point | Points, callback: (previousValue: any, currentFeature: Point, currentIndex: number) => void, initialValue: any): any;
-    featureReduce(layer: LineString | LineStrings, callback: (previousValue: any, currentFeature: LineString, currentIndex: number) => void, initialValue: any): any;
-    featureReduce(layer: Polygon | Polygons, callback: (previousValue: any, currentFeature: Polygon, currentIndex: number) => void, initialValue: any): any;
-    featureReduce(layer: MultiPoint | MultiPoints, callback: (previousValue: any, currentFeature: MultiPoint, currentIndex: number) => void, initialValue: any): any;
-    featureReduce(layer: MultiLineString | MultiLineStrings, callback: (previousValue: any, currentFeature: MultiLineString, currentIndex: number) => void, initialValue: any): any;
-    featureReduce(layer: MultiPolygon | MultiPolygons, callback: (previousValue: any, currentFeature: MultiPolygon, currentIndex: number) => void, initialValue: any): any;
-    featureReduce(layer: Feature | Features, callback: (previousValue: any, currentFeature: Feature, currentIndex: number) => void, initialValue: any): any;
-
-
-    /**
-     * http://turfjs.org/docs/#featureeach
-     */
-    featureEach(layer: Point | Points, callback: (currentFeature: Point, currentIndex: number) => void): void;
-    featureEach(layer: LineString | LineStrings, callback: (currentFeature: LineString, currentIndex: number) => void): void;
-    featureEach(layer: Polygon | Polygons, callback: (currentFeature: Polygon, currentIndex: number) => void): void;
-    featureEach(layer: MultiPoint | MultiPoints, callback: (currentFeature: MultiPoint, currentIndex: number) => void): void;
-    featureEach(layer: MultiLineString | MultiLineStrings, callback: (currentFeature: MultiLineString, currentIndex: number) => void): void;
-    featureEach(layer: MultiPolygon | MultiPolygons, callback: (currentFeature: MultiPolygon, currentIndex: number) => void): void;
-    featureEach(layer: Feature | Features, callback: (currentFeature: Feature, currentIndex: number) => void): void;
-
-    /**
-     * http://turfjs.org/docs/#coordall
-     */
-    coordAll(layer: Feature | Features | GeometryCollection | GeometryObject): Array<Array<number>>
-
-    /**
-     * http://turfjs.org/docs/#geomreduce
-     */
-    geomReduce(layer: Point | Points, callback: (previousValue: any, currentGeometry: GeoJSON.Point, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: LineString | LineStrings, callback: (previousValue: any, currentGeometry: GeoJSON.LineString, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: Polygon | Polygons, callback: (previousValue: any, currentGeometry: GeoJSON.Polygon, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: MultiPoint | MultiPoints, callback: (previousValue: any, currentGeometry: GeoJSON.MultiPoint, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: MultiLineString | MultiLineStrings, callback: (previousValue: any, currentGeometry: GeoJSON.MultiLineString, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: MultiPolygon | MultiPolygons, callback: (previousValue: any, currentGeometry: GeoJSON.MultiPolygon, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: Feature | Features, callback: (previousValue: any, currentGeometry: GeometryObject, currentIndex: number) => void, initialValue: any): any;
-    geomReduce(layer: GeometryCollection | GeometryObject, callback: (previousValue: any, currentGeometry: GeometryObject, currentIndex: number) => void, initialValue: any): any;
-
-    /**
-     * http://turfjs.org/docs/#geomeach
-     */
-    geomEach(layer: Point | Points, callback: (currentGeometry: GeoJSON.Point, currentIndex: number) => void): void;
-    geomEach(layer: LineString | LineStrings, callback: (currentGeometry: GeoJSON.LineString, currentIndex: number) => void): void;
-    geomEach(layer: Polygon | Polygons, callback: (currentGeometry: GeoJSON.Polygon, currentIndex: number) => void): void;
-    geomEach(layer: MultiPoint | MultiPoints, callback: (currentGeometry: GeoJSON.MultiPoint, currentIndex: number) => void): void;
-    geomEach(layer: MultiLineString | MultiLineStrings, callback: (currentGeometry: GeoJSON.MultiLineString, currentIndex: number) => void): void;
-    geomEach(layer: MultiPolygon | MultiPolygons, callback: (currentGeometry: GeoJSON.MultiPolygon, currentIndex: number) => void): void;
-    geomEach(layer: Feature | Features, callback: (currentGeometry: GeometryObject, currentIndex: number) => void): void;
-    geomEach(layer: GeometryCollection | GeometryObject, callback: (currentGeometry: GeometryObject, currentIndex: number) => void): void;
+    <Geom extends Point>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (previousValue: any, currentCoords: Position, currentIndex: number) => void, initialValue?: any): void;
+    <Geom extends LineString | MultiPoint>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (previousValue: any, currentCoords: Position[], currentIndex: number) => void, initialValue?: any): void;
+    <Geom extends Polygon | MultiLineString>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (previousValue: any, currentCoords: Position[][], currentIndex: number) => void, initialValue?: any): void;
+    <Geom extends MultiPolygon>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (previousValue: any, currentCoords: Position[][][], currentIndex: number) => void, initialValue?: any): void;
+    (layer: Feature<any> | Features<any> | GeometryObject | GeometryCollection, callback: (previousValue: any, currentCoords: any[], currentIndex: number) => void, initialValue?: any): void;
 }
+export const coordReduce: CoordReduce;
 
-declare const meta: MetaStatic
-export = meta
+interface CoordEach {
+    /**
+     * http://turfjs.org/docs/#coordeach
+     */
+    <Geom extends Point>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (currentCoords: Position, currentIndex: number) => void): void;
+    <Geom extends LineString | MultiPoint>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (currentCoords: Position[], currentIndex: number) => void): void;
+    <Geom extends Polygon | MultiLineString>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (currentCoords: Position[][], currentIndex: number) => void): void;
+    <Geom extends MultiPolygon>(layer: Feature<Geom> | Features<Geom> | Geom, callback: (currentCoords: Position[][][], currentIndex: number) => void): void;
+    (layer: Feature<any> | Features<any> | GeometryObject | GeometryCollection, callback: (currentCoords: any[], currentIndex: number) => void): void;
+}
+export const coordEach: CoordEach;
+
+/**
+ * http://turfjs.org/docs/#propeach
+ */
+export function propEach<Props extends any>(layer: Feature<any> | Features<any> | Geoms | GeometryCollection, callback: (currentProperties: Props, currentIndex: number) => void): void;
+
+/**
+ * http://turfjs.org/docs/#propreduce
+ */
+export function propReduce<Props extends any>(layer: Feature<any> | Features<any> | Geoms | GeometryCollection, callback: (previousValue: any, currentProperties: Props, currentIndex: number) => void, initialValue?: any): any;
+
+/**
+ * http://turfjs.org/docs/#featurereduce
+ */
+export function featureReduce<Geom extends Geoms>(layer: Feature<Geom> | Features<Geom>, callback: (previousValue: any, currentFeature: Feature<Geom>, currentIndex: number) => void, initialValue?: any): void;
+
+/**
+ * http://turfjs.org/docs/#featureeach
+ */
+export function featureEach<Geom extends Geoms>(layer: Feature<Geom> | Features<Geom>, callback: (currentFeature: Feature<Geom>, currentIndex: number) => void): void;
+
+/**
+ * http://turfjs.org/docs/#coordall
+ */
+export function coordAll(layer: Feature<any> | Features<any> | Geoms | GeometryCollection): Position[];
+
+/**
+ * http://turfjs.org/docs/#geomreduce
+ */
+export function geomReduce<Geom extends Geoms>(layer: Feature<Geom> | Features<Geom> | Geoms | GeometryCollection, callback: (previousValue: any, currentGeometry: Geom, currentIndex: number, currentProperties: any) => void, initialValue?: any): void;
+
+/**
+ * http://turfjs.org/docs/#geomeach
+ */
+export function geomEach<Geom extends Geoms>(layer: Feature<Geom> | Features<Geom> | Geoms | GeometryCollection, callback: (currentGeometry: Geom, currentIndex: number, currentProperties: any) => void): void;
+
+/**
+ * http://turfjs.org/docs/#flattenreduce
+ */
+export function flattenReduce<Geom extends Geoms>(layer: Feature<Geom> | Features<Geom> | Geoms | GeometryCollection, callback: (previousValue: any, currentGeometry: Feature<Geom>, currentIndex: number, currentProperties: any) => void, initialValue?: any): void;
+
+/**
+ * http://turfjs.org/docs/#flatteneach
+ */
+export function flattenEach<Geom extends Geoms>(layer: Feature<Geom> | Features<Geom> | Geoms | GeometryCollection, callback: (currentGeometry: Feature<Geom>, currentIndex: number, currentProperties: any) => void): void;

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -28,12 +28,13 @@
     "url": "https://github.com/Turfjs/turf/issues"
   },
   "devDependencies": {
-    "@turf/helpers": "^4.2.0",
     "@turf/random": "^4.2.0",
     "benchmark": "^2.1.3",
     "eslint": "^3.14.1",
     "eslint-config-mourner": "^2.0.1",
     "tape": "^3.4.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@turf/helpers": "^4.2.0"
+  }
 }

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -28,13 +28,12 @@
     "url": "https://github.com/Turfjs/turf/issues"
   },
   "devDependencies": {
+    "@turf/helpers": "^4.2.0",
     "@turf/random": "^4.2.0",
     "benchmark": "^2.1.3",
     "eslint": "^3.14.1",
     "eslint-config-mourner": "^2.0.1",
     "tape": "^3.4.0"
   },
-  "dependencies": {
-    "@turf/helpers": "^4.2.0"
-  }
+  "dependencies": {}
 }

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -1,61 +1,61 @@
-var test = require('tape');
-var lineString = require('@turf/helpers').lineString;
-var meta = require('./');
+const test = require('tape');
+const {lineString} = require('@turf/helpers');
+const meta = require('./');
 
-var pointGeometry = {
+const pointGeometry = {
     type: 'Point',
     coordinates: [0, 0]
 };
 
-var point2Geometry = {
+const point2Geometry = {
     type: 'Point',
     coordinates: [1, 1]
 };
 
-var lineStringGeometry = {
+const lineStringGeometry = {
     type: 'LineString',
     coordinates: [[0, 0], [1, 1]]
 };
 
-var polygonGeometry = {
+const polygonGeometry = {
     type: 'Polygon',
     coordinates: [[[0, 0], [1, 1], [0, 1], [0, 0]]]
 };
 
-var multiPointGeometry = {
+const multiPointGeometry = {
     type: 'MultiPoint',
-    coordinates: [ pointGeometry.coordinates, point2Geometry.coordinates ]
+    coordinates: [pointGeometry.coordinates, point2Geometry.coordinates]
 };
 
-var multiPolygonGeometry = {
+const multiPolygonGeometry = {
     type: 'MultiPolygon',
     coordinates: [[[[0, 0], [1, 1], [0, 1], [0, 0]]]]
 };
 
-var geometryCollection = {
+const geometryCollection = {
     type: 'GeometryCollection',
     geometries: [pointGeometry, lineStringGeometry]
 };
 
-var multiGeometryCollection = {
+const multiGeometryCollection = {
     type: 'GeometryCollection',
     geometries: [lineStringGeometry, multiPointGeometry]
 };
 
-var pointFeature = {
+const pointFeature = {
     type: 'Feature',
     properties: {a: 1},
     geometry: pointGeometry
 };
 
-var multiGeometryFeature = {
+const multiGeometryFeature = {
     type: 'Feature',
     properties: {a: 1},
     geometry: multiGeometryCollection
 };
 
 function collection(feature) {
-    var featureCollection = {
+    const featureCollection = {
         type: 'FeatureCollection',
         features: [feature]
     };
@@ -64,13 +64,13 @@ function collection(feature) {
 }
 
 function featureAndCollection(geometry) {
-    var feature = {
+    const feature = {
         type: 'Feature',
         geometry: geometry,
         properties: {a: 1}
     };
 
-    var featureCollection = {
+    const featureCollection = {
         type: 'FeatureCollection',
         features: [feature]
     };
@@ -79,128 +79,128 @@ function featureAndCollection(geometry) {
 }
 
 
-collection(pointFeature).forEach(function (input) {
-    test('propEach', function (t) {
-        meta.propEach(input, function (prop, i) {
+test('propEach', t => {
+    collection(pointFeature).forEach(input => {
+        meta.propEach(input, (prop, i) => {
             t.deepEqual(prop, {a: 1});
             t.equal(i, 0);
-            t.end();
         });
     });
+    t.end();
 });
 
-featureAndCollection(pointGeometry).forEach(function (input) {
-    test('coordEach#Point', function (t) {
-        meta.coordEach(input, function (coord, index) {
+test('coordEach#Point', t => {
+    featureAndCollection(pointGeometry).forEach(input => {
+        meta.coordEach(input, (coord, index) => {
             t.deepEqual(coord, [0, 0]);
             t.equal(index, 0);
-            t.end();
         });
     });
+    t.end();
 });
 
-featureAndCollection(lineStringGeometry).forEach(function (input) {
-    test('coordEach#LineString', function (t) {
-        var output = [];
-        var lastIndex;
-        meta.coordEach(input, function (coord, index) {
+test('coordEach#LineString', t => {
+    featureAndCollection(lineStringGeometry).forEach(input => {
+        const output = [];
+        let lastIndex;
+        meta.coordEach(input, (coord, index) => {
             output.push(coord);
             lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [1, 1]]);
         t.equal(lastIndex, 1);
-        t.end();
     });
+    t.end();
 });
 
-featureAndCollection(polygonGeometry).forEach(function (input) {
-    test('coordEach#Polygon', function (t) {
-        var output = [];
-        var lastIndex;
-        meta.coordEach(input, function (coord, index) {
+test('coordEach#Polygon', t => {
+    featureAndCollection(polygonGeometry).forEach(input => {
+        const output = [];
+        let lastIndex;
+        meta.coordEach(input, (coord, index) => {
             output.push(coord);
             lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [1, 1], [0, 1], [0, 0]]);
         t.equal(lastIndex, 3);
-        t.end();
     });
+    t.end();
 });
 
-featureAndCollection(polygonGeometry).forEach(function (input) {
-    test('coordEach#Polygon excludeWrapCoord', function (t) {
-        var output = [];
-        var lastIndex;
-        meta.coordEach(input, function (coord, index) {
+test('coordEach#Polygon excludeWrapCoord', t => {
+    featureAndCollection(polygonGeometry).forEach(input => {
+        const output = [];
+        let lastIndex;
+        meta.coordEach(input, (coord, index) => {
             output.push(coord);
             lastIndex = index;
         }, true);
         t.deepEqual(output, [[0, 0], [1, 1], [0, 1]]);
         t.equal(lastIndex, 2);
-        t.end();
     });
+    t.end();
 });
 
 
 
-featureAndCollection(multiPolygonGeometry).forEach(function (input) {
-    test('coordEach#MultiPolygon', function (t) {
-        var output = [];
-        var lastIndex;
-        meta.coordEach(input, function (coord, index) {
+test('coordEach#MultiPolygon', t => {
+    featureAndCollection(multiPolygonGeometry).forEach(input => {
+        const output = [];
+        let lastIndex;
+        meta.coordEach(input, (coord, index) => {
             output.push(coord);
             lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [1, 1], [0, 1], [0, 0]]);
         t.equal(lastIndex, 3);
-        t.end();
     });
+    t.end();
 });
 
-featureAndCollection(geometryCollection).forEach(function (input) {
-    test('coordEach#GeometryCollection', function (t) {
-        var output = [];
-        var lastIndex;
-        meta.coordEach(input, function (coord, index) {
+test('coordEach#GeometryCollection', t => {
+    featureAndCollection(geometryCollection).forEach(input => {
+        const output = [];
+        let lastIndex;
+        meta.coordEach(input, (coord, index) => {
             output.push(coord);
             lastIndex = index;
         });
         t.deepEqual(output, [[0, 0], [0, 0], [1, 1]]);
         t.equal(lastIndex, 2);
-        t.end();
     });
+    t.end();
 });
 
-test('coordReduce#initialValue', function (t) {
-    var lastIndex;
-    var line = lineString([[126, -11], [129, -21], [135, -31]]);
-    var sum = meta.coordReduce(line, function (previousValue, currentCoords, currentIndex) {
-        lastIndex = currentIndex;
-        return previousValue + currentCoords[0];
+test('coordReduce#initialValue', t => {
+    let lastIndex;
+    const line = lineString([[126, -11], [129, -21], [135, -31]]);
+    const sum = meta.coordReduce(line, (previous, currentCoords, index) => {
+        lastIndex = index;
+        return previous + currentCoords[0];
     }, 0);
     t.equal(lastIndex, 2);
     t.equal(sum, 390);
     t.end();
 });
 
-test('Array.reduce()#initialValue', function (t) {
-    var lastIndex;
-    var line = [[126, -11], [129, -21], [135, -31]];
-    var sum = line.reduce(function (previousValue, currentCoords, currentIndex) {
-        lastIndex = currentIndex;
-        return previousValue + currentCoords[0];
+test('Array.reduce()#initialValue', t => {
+    let lastIndex;
+    const line = [[126, -11], [129, -21], [135, -31]];
+    const sum = line.reduce((previous, currentCoords, index) => {
+        lastIndex = index;
+        return previous + currentCoords[0];
     }, 0);
     t.equal(lastIndex, 2);
     t.equal(sum, 390);
     t.end();
 });
 
-test('coordReduce#previous-coordinates', function (t) {
-    var lastIndex;
-    var coords = [];
-    var line = lineString([[126, -11], [129, -21], [135, -31]]);
-    meta.coordReduce(line, function (previousCoords, currentCoords, currentIndex) {
-        lastIndex = currentIndex;
+test('coordReduce#previous-coordinates', t => {
+    let lastIndex;
+    const coords = [];
+    const line = lineString([[126, -11], [129, -21], [135, -31]]);
+    meta.coordReduce(line, (previousCoords, currentCoords, index) => {
+        lastIndex = index;
         coords.push(currentCoords);
         return currentCoords;
     });
@@ -209,12 +209,12 @@ test('coordReduce#previous-coordinates', function (t) {
     t.end();
 });
 
-test('Array.reduce()#previous-coordinates', function (t) {
-    var lastIndex;
-    var coords = [];
-    var line = [[126, -11], [129, -21], [135, -31]];
-    line.reduce(function (previousCoords, currentCoords, currentIndex) {
-        lastIndex = currentIndex;
+test('Array.reduce()#previous-coordinates', t => {
+    let lastIndex;
+    const coords = [];
+    const line = [[126, -11], [129, -21], [135, -31]];
+    line.reduce((previousCoords, currentCoords, index) => {
+        lastIndex = index;
         coords.push(currentCoords);
         return currentCoords;
     });
@@ -224,12 +224,12 @@ test('Array.reduce()#previous-coordinates', function (t) {
 });
 
 
-test('coordReduce#previous-coordinates+initialValue', function (t) {
-    var lastIndex;
-    var coords = [];
-    var line = lineString([[126, -11], [129, -21], [135, -31]]);
-    meta.coordReduce(line, function (previousCoords, currentCoords, currentIndex) {
-        lastIndex = currentIndex;
+test('coordReduce#previous-coordinates+initialValue', t => {
+    let lastIndex;
+    const coords = [];
+    const line = lineString([[126, -11], [129, -21], [135, -31]]);
+    meta.coordReduce(line, (previousCoords, currentCoords, index) => {
+        lastIndex = index;
         coords.push(currentCoords);
         return currentCoords;
     }, line.geometry.coordinates[0]);
@@ -238,12 +238,12 @@ test('coordReduce#previous-coordinates+initialValue', function (t) {
     t.end();
 });
 
-test('Array.reduce()#previous-coordinates+initialValue', function (t) {
-    var lastIndex;
-    var coords = [];
-    var line = [[126, -11], [129, -21], [135, -31]];
-    line.reduce(function (previousCoords, currentCoords, currentIndex) {
-        lastIndex = currentIndex;
+test('Array.reduce()#previous-coordinates+initialValue', t => {
+    let lastIndex;
+    const coords = [];
+    const line = [[126, -11], [129, -21], [135, -31]];
+    line.reduce((previousCoords, currentCoords, index) => {
+        lastIndex = index;
         coords.push(currentCoords);
         return currentCoords;
     }, line[0]);
@@ -252,114 +252,111 @@ test('Array.reduce()#previous-coordinates+initialValue', function (t) {
     t.end();
 });
 
-test('unknown', function (t) {
+test('unknown', t => {
     t.throws(function () {
         meta.coordEach({});
     });
     t.end();
 });
 
-featureAndCollection(geometryCollection).forEach(function (input) {
-    test('geomEach#GeometryCollection', function (t) {
-        var output = [];
-        meta.geomEach(input, function (geom) {
+test('geomEach#GeometryCollection', t => {
+    featureAndCollection(geometryCollection).forEach(input => {
+        const output = [];
+        meta.geomEach(input, geom => {
             output.push(geom);
         });
         t.deepEqual(output, geometryCollection.geometries);
-        t.end();
     });
+    t.end();
 });
 
-test('geomEach#bare-GeometryCollection', function (t) {
-    var output = [];
-    meta.geomEach(geometryCollection, function (geom) {
+test('geomEach#bare-GeometryCollection', t => {
+    const output = [];
+    meta.geomEach(geometryCollection, geom => {
         output.push(geom);
     });
     t.deepEqual(output, geometryCollection.geometries);
     t.end();
 });
 
-test('geomEach#bare-pointGeometry', function (t) {
-    var output = [];
-    meta.geomEach(pointGeometry, function (geom) {
+test('geomEach#bare-pointGeometry', t => {
+    const output = [];
+    meta.geomEach(pointGeometry, geom => {
         output.push(geom);
     });
     t.deepEqual(output, [pointGeometry]);
     t.end();
 });
 
-test('geomEach#bare-pointFeature', function (t) {
-    var output = [];
-    meta.geomEach(pointFeature, function (geom) {
+test('geomEach#bare-pointFeature', t => {
+    const output = [];
+    meta.geomEach(pointFeature, geom => {
         output.push(geom);
     });
     t.deepEqual(output, [pointGeometry]);
     t.end();
 });
 
-test('geomEach#multiGeometryFeature-properties', function (t) {
-    var lastProperties;
-    meta.geomEach(multiGeometryFeature, function (geom, index, properties) {
+test('geomEach#multiGeometryFeature-properties', t => {
+    let lastProperties;
+    meta.geomEach(multiGeometryFeature, (geom, index, properties) => {
         lastProperties = properties;
     });
     t.deepEqual(lastProperties, multiGeometryFeature.properties);
     t.end();
 });
 
-featureAndCollection(multiPointGeometry).forEach(function (input) {
-    test('flattenEach#MultiPoint', function (t) {
-        var output = [];
-        meta.flattenEach(input, function (feature) {
+test('flattenEach#MultiPoint', t => {
+    featureAndCollection(multiPointGeometry).forEach(input => {
+        const output = [];
+        meta.flattenEach(input, feature => {
             output.push(feature.geometry);
         });
         t.deepEqual(output, [pointGeometry, point2Geometry]);
-        t.end();
     });
+    t.end();
 });
 
-featureAndCollection(multiGeometryCollection).forEach(function (input) {
-    test('flattenEach#MultiGeometryCollection', function (t) {
-        var output = [];
-        meta.flattenEach(input, function (feature) {
+test('flattenEach#MultiGeometryCollection', t => {
+    featureAndCollection(multiGeometryCollection).forEach(input => {
+        const output = [];
+        meta.flattenEach(input, feature => {
             output.push(feature.geometry);
         });
         t.deepEqual(output, [lineStringGeometry, pointGeometry, point2Geometry]);
-        t.end();
     });
+    t.end();
 });
 
-collection(pointFeature).forEach(function (input) {
-    test('flattenEach#Point-properties', function (t) {
-        var lastProperties;
-        meta.flattenEach(input, function (feature) {
+test('flattenEach#Point-properties', t => {
+    collection(pointFeature).forEach(input => {
+        let lastProperties;
+        meta.flattenEach(input, feature => {
             lastProperties = feature.properties;
         });
         t.deepEqual(lastProperties, pointFeature.properties);
-        t.end();
     });
+    t.end();
 });
 
-collection(multiGeometryFeature).forEach(function (input) {
-    test('flattenEach#multiGeometryFeature-properties', function (t) {
-        var lastProperties;
-        meta.flattenEach(input, function (feature) {
+test('flattenEach#multiGeometryFeature-properties', t => {
+    collection(multiGeometryFeature).forEach(input => {
+        let lastProperties;
+        meta.flattenEach(input, feature => {
             lastProperties = feature.properties;
         });
         t.deepEqual(lastProperties, multiGeometryFeature.properties);
-        t.end();
     });
+    t.end();
 });
 
-test('flattenReduce#initialValue', function (t) {
-    var lastIndex;
-    var lastSubIndex;
-    var sum = meta.flattenReduce(multiPointGeometry, function (previousValue,
-                                                               currentFeature,
-                                                               currentIndex,
-                                                               currentSubIndex) {
-        lastIndex = currentIndex;
-        lastSubIndex = currentSubIndex;
-        return previousValue + currentFeature.geometry.coordinates[0];
+test('flattenReduce#initialValue', t => {
+    let lastIndex;
+    let lastSubIndex;
+    const sum = meta.flattenReduce(multiPointGeometry, (previous, current, index, subIndex) => {
+        lastIndex = index;
+        lastSubIndex = subIndex;
+        return previous + current.geometry.coordinates[0];
     }, 0);
     t.equal(lastIndex, 0);
     t.equal(lastSubIndex, 1);
@@ -367,18 +364,15 @@ test('flattenReduce#initialValue', function (t) {
     t.end();
 });
 
-test('flattenReduce#previous-feature', function (t) {
-    var features = [];
-    var lastIndex;
-    var lastSubIndex;
-    meta.flattenReduce(multiGeometryCollection, function (previousValue,
-                                                          currentFeature,
-                                                          currentIndex,
-                                                          currentSubIndex) {
-        lastIndex = currentIndex;
-        lastSubIndex = currentSubIndex;
-        features.push(currentFeature);
-        return currentFeature;
+test('flattenReduce#previous-feature', t => {
+    const features = [];
+    let lastIndex;
+    let lastSubIndex;
+    meta.flattenReduce(multiGeometryCollection, (previous, current, index, subIndex) => {
+        lastIndex = index;
+        lastSubIndex = subIndex;
+        features.push(current);
+        return current;
     });
     t.equal(lastIndex, 1);
     t.equal(lastSubIndex, 1);
@@ -386,21 +380,19 @@ test('flattenReduce#previous-feature', function (t) {
     t.end();
 });
 
-test('flattenReduce#previous-feature+initialValue', function (t) {
-    var features = [];
-    var lastIndex;
-    var lastSubIndex;
-    var sum = meta.flattenReduce(multiPointGeometry, function (previousValue,
-                                                               currentFeature,
-                                                               currentIndex,
-                                                               currentSubIndex) {
-        lastIndex = currentIndex;
-        lastSubIndex = currentSubIndex;
-        features.push(currentFeature);
-        return currentFeature;
+test('flattenReduce#previous-feature+initialValue', t => {
+    const features = [];
+    let lastIndex;
+    let lastSubIndex;
+    const sum = meta.flattenReduce(multiPointGeometry, (previous, current, index, subIndex) => {
+        lastIndex = index;
+        lastSubIndex = subIndex;
+        features.push(current);
+        return current;
     }, pointFeature);
     t.equal(lastIndex, 0);
     t.equal(lastSubIndex, 1);
     t.equal(features.length, 2);
+    t.deepEqual(sum, features[features.length - 1]);
     t.end();
 });

--- a/packages/turf-meta/test/types.ts
+++ b/packages/turf-meta/test/types.ts
@@ -1,80 +1,80 @@
+import {
+    point, lineString, polygon,
+    multiPoint, multiLineString, multiPolygon,
+    featureCollection, geometryCollection} from '@turf/helpers'
 import * as meta from '../index'
 
-const pointGeometry: GeoJSON.Point = {
-    type: 'Point',
-    coordinates: [0, 0]
-};
+const pt = point([0, 0])
+const line = lineString([[0, 0], [1, 1]])
+const poly = polygon([[[0, 0], [1, 1], [0, 1], [0, 0]]])
+const multiPoly = multiPolygon([[[[0, 0], [1, 1], [0, 1], [0, 0]]]])
+const geomCollection = geometryCollection([pt.geometry, line.geometry])
+const features = featureCollection([pt, line])
 
-const lineStringGeometry: GeoJSON.LineString = {
-    type: 'LineString',
-    coordinates: [[0, 0], [1, 1]]
-};
-
-const polygonGeometry: GeoJSON.Polygon = {
-    type: 'Polygon',
-    coordinates: [[[0, 0], [1, 1], [0, 1], [0, 0]]]
-};
-
-const multiPolygonGeometry: GeoJSON.MultiPolygon = {
-    type: 'MultiPolygon',
-    coordinates: [[[[0, 0], [1, 1], [0, 1], [0, 0]]]]
-};
-
-const geometryCollection: GeoJSON.GeometryCollection = {
-    type: 'GeometryCollection',
-    geometries: [pointGeometry, lineStringGeometry]
-};
-
-const pointFeature: GeoJSON.Feature<GeoJSON.Point> = {
-    type: 'Feature',
-    properties: { a: 1},
-    geometry: pointGeometry
-};
-
-// pointGeometry
-meta.coordEach(pointGeometry, coords => {
-    const equal: Array<number> = coords
-})
-
-// lineStringGeometry
-meta.coordEach(lineStringGeometry, coords => {
-    const equal: Array<Array<number>> = coords
-})
-
-// polygonGeometry
-meta.coordEach(polygonGeometry, coords => {
-    const equal: Array<Array<Array<number>>> = coords
-})
-
-// multiPolygonGeometry
-meta.coordEach(multiPolygonGeometry, coords => {
-    const equal: Array<Array<Array<number>>> = coords
-})
-
-// geometryCollection
-meta.coordEach(geometryCollection, coords => {
-    const equal: Array<Array<Array<number>>> = coords
-})
-
-// pointFeature
-meta.coordEach(pointFeature, coords => {
-    const equal: Array<number> = coords
-})
+// coordEach
+meta.coordEach(pt, coords => coords)
+meta.coordEach(pt, (coords, index) => coords)
+meta.coordEach(pt, coords => { const equal: number[] = coords })
+meta.coordEach(line, coords => { const equal: number[][] = coords })
+meta.coordEach(poly, coords => { const equal: number[][][] = coords })
+meta.coordEach(multiPoly, coords => { const equal: number[][][][] = coords })
 
 // coordReduce
-meta.coordReduce(pointFeature, (memo, coords) => {
-    const equal: Array<number> = coords
-}, 'foo')
+meta.coordReduce(pt, (previous, coords) => coords)
+meta.coordReduce(pt, (previous, coords, index) => coords)
+meta.coordReduce(pt, (previous, coords, index) => coords, 0)
+meta.coordReduce(pt, (previous, coords) => { const equal: Array<number> = coords })
+
+interface CustomProps {
+    foo: string
+    bar: number
+}
+
+// propReduce
+meta.propReduce(poly, (previous, prop) => prop)
+meta.propReduce(poly, (previous, prop) => prop, 0)
+meta.propReduce(features, (previous, prop) => prop)
+meta.propReduce(poly, (previous, prop, index) => prop)
+meta.propReduce<CustomProps>(poly, (previous, prop) => prop.foo)
 
 // propEach
-meta.propEach(pointFeature, properties => {
-    const equal: any = properties
-})
+meta.propEach(poly, prop => prop)
+meta.propEach(features, prop => prop)
+meta.propEach(poly, (prop, index) => prop)
+meta.propEach<CustomProps>(poly, prop => prop.bar)
 
-// coordAll
-const coords: Array<Array<number>> = meta.coordAll(polygonGeometry)
+// // coordAll
+const coords: Array<Array<number>> = meta.coordAll(poly)
+
+// featureReduce
+meta.featureReduce(poly, (previous, feature) => feature)
+meta.featureReduce(poly, (previous, feature) => feature, 0)
+meta.featureReduce(features, (previous, feature) => feature)
+meta.featureReduce(poly, (previous, feature, index) => feature)
+
+// featureEach
+meta.featureEach(poly, feature => feature)
+meta.featureEach(features, feature => feature)
+meta.featureEach(poly, (feature, index) => feature)
+
+// geomReduce
+meta.geomReduce(poly, (previous, geom) => geom)
+meta.geomReduce(poly, (previous, geom) => geom, 0)
+meta.geomReduce(features, (previous, geom) => geom)
+meta.geomReduce(poly, (previous, geom, index, props) => geom)
 
 // geomEach
-meta.geomEach(polygonGeometry, geom => {
-    const equal: GeoJSON.Polygon = geom
-})
+meta.geomEach(poly, geom => geom)
+meta.geomEach(features, geom => geom)
+meta.geomEach(poly, (geom, index, props) => geom)
+
+// flattenReduce
+meta.flattenReduce(poly, (previous, feature) => feature)
+meta.flattenReduce(poly, (previous, feature) => feature, 0)
+meta.flattenReduce(features, (previous, feature) => feature)
+meta.flattenReduce(poly, (previous, feature, index, props) => feature)
+
+// flattenEach
+meta.flattenEach(poly, feature => feature)
+meta.flattenEach(features, feature => feature)
+meta.flattenEach(poly, (feature, index, props) => feature)


### PR DESCRIPTION

This addresses issue #692. There are a few design choices made that deserve scrutiny:

 - `@turf/helpers` is added as a dependency to `@turf/meta`. Needed to create features as geometries get flattened.
 - The `geomEach` callback function was changed to add an additional third argument that passes the properties of the source feature from which the geometry came. Wasn't sure if adding this to the argument list was a good idea since a geometry doesn't have a property per the GeoJSON spec but since `geomEach` is essentially a flattening function the source will usually be a feature. It's backward compatible as the last argument and existing users can just ignore it.
 - The `flattenEach` and `flattenReduce` callback function returns an `index` argument (increases for each geometry) and an additional `subIndex` argument that increases for each sub-geometry if the geometry being flattened was a multi-geometry (MultiPoint, MultiLineString, MultiPolygon). For example, for a MultiPoint with, say, 3 points each point will have the same `index` but their `subIndex` will be 0, 1, and 2. I'm open to making this a single growing index but I thought this would be helpful if the caller wanted to index back into some property for multi-geometries.

Finally, does Turf have a unit test coverage functionality somewhere? I didn't see any and it would be good to know if the tests are hitting all the right code.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [X] Run `npm test` at the sub modules where changes have occurred.
- [X] Run `npm run lint` to ensure code style at the turf module level.
