### PR TITLE
Add coverage functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.nyc_output
+coverage
 lib-cov
 *.seed
 *.log

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -9,7 +9,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "test": "node test.js",
+    "test": "tap test.js --cov",
     "bench": "node bench.js"
   },
   "keywords": [
@@ -33,7 +33,7 @@
     "benchmark": "^2.1.3",
     "eslint": "^3.14.1",
     "eslint-config-mourner": "^2.0.1",
-    "tape": "^3.4.0"
+    "tap": "^10.3.2"
   },
   "dependencies": {}
 }

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const {test} = require('tap');
 const {lineString} = require('@turf/helpers');
 const meta = require('./');
 


### PR DESCRIPTION
Adding coverage functionality to Turf would allow for better tests.

Ref Article: [Testing `tape` vs `tap`](https://remysharp.com/2016/02/08/testing-tape-vs-tap)

## Proposal

- Replace `tape` for `tap` (no change in test code)
- Minimal effort to implement (1 LOC change)
- Easy to switch back to `tape`
- Generates easy to understand web report with coverage
- **Fallbacks**:  source code mapping is off since it gets compiled with [`nyc`](https://github.com/istanbuljs/nyc) (might need some extra configuration to get it working).

```bash
$ npm t
```

![image](https://cloud.githubusercontent.com/assets/550895/25714351/b4884904-30c5-11e7-9641-392d832186d8.png)


Also, for more in depth coverage reports you can use:

```bash
$ tap test.js --cov --coverage-report=lcov
```

![image](https://cloud.githubusercontent.com/assets/550895/25714371/c41056be-30c5-11e7-9d68-0cd8af724993.png)


![image](https://cloud.githubusercontent.com/assets/550895/25714313/8e73a678-30c5-11e7-9fe7-d8d06dde9c44.png)


Ref: https://github.com/Turfjs/turf/pull/712 https://github.com/Turfjs/turf/issues/328
Looking to hear your feedback: @morganherlocker @dpmcmlxxvi @tmcw 