### PR TITLE
Improve flattenEach/reduce coverage.

### DIFF
--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -716,8 +716,6 @@ function flattenEach(layer, callback) {
         case 'MultiPolygon':
             geomType = 'Polygon';
             break;
-        default:
-            throw new Error('geometry ' + geometry.type + ' type not supported');
         }
 
         geometry.coordinates.forEach(function (coordinate, subindex) {

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -27,9 +27,14 @@ const multiPointGeometry = {
     coordinates: [pointGeometry.coordinates, point2Geometry.coordinates]
 };
 
+const multiLineStringGeometry = {
+    type: 'MultiLineString',
+    coordinates: [lineStringGeometry.coordinates]
+};
+
 const multiPolygonGeometry = {
     type: 'MultiPolygon',
-    coordinates: [[[[0, 0], [1, 1], [0, 1], [0, 0]]]]
+    coordinates: [polygonGeometry.coordinates]
 };
 
 const geometryCollection = {
@@ -39,7 +44,10 @@ const geometryCollection = {
 
 const multiGeometryCollection = {
     type: 'GeometryCollection',
-    geometries: [lineStringGeometry, multiPointGeometry]
+    geometries: [lineStringGeometry,
+                 multiLineStringGeometry,
+                 multiPolygonGeometry,
+                 multiPointGeometry]
 };
 
 const pointFeature = {
@@ -323,7 +331,11 @@ test('flattenEach#MultiGeometryCollection', t => {
         meta.flattenEach(input, feature => {
             output.push(feature.geometry);
         });
-        t.deepEqual(output, [lineStringGeometry, pointGeometry, point2Geometry]);
+        t.deepEqual(output, [lineStringGeometry,
+                             lineStringGeometry,
+                             polygonGeometry,
+                             pointGeometry,
+                             point2Geometry]);
     });
     t.end();
 });
@@ -374,9 +386,9 @@ test('flattenReduce#previous-feature', t => {
         features.push(current);
         return current;
     });
-    t.equal(lastIndex, 1);
+    t.equal(lastIndex, 3);
     t.equal(lastSubIndex, 1);
-    t.equal(features.length, 2);
+    t.equal(features.length, 4);
     t.end();
 });
 


### PR DESCRIPTION
A few updates to improve coverage of flattenEach function:
 -  Added MultiLineString and MultiPolygon test cases.
 - Removed exception being thrown which was unreachable code. The enclosing `geomEach` already performs that check and throws so an unknown geometry can't be reached in flattenEach.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [X] Run `npm test` at the sub modules where changes have occurred.
- [X] Run `npm run lint` to ensure code style at the turf module level.
