### PR TITLE
Re-enabling negative buffers

### DIFF
--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -38,8 +38,8 @@ var distanceToRadians = helpers.distanceToRadians;
 module.exports = function (geojson, radius, units, steps) {
     // validation
     if (!geojson) throw new Error('geojson is required');
-    if (!radius) throw new Error('radius is required');
-    if (radius <= 0) throw new Error('radius must be greater than 0');
+    // Allow negative buffers ("erosion") or zero-sized buffers ("repair geometry")
+    if (radius === undefined) throw new Error('radius is required');
     if (steps <= 0) throw new Error('steps must be greater than 0');
 
     // prevent input mutation


### PR DESCRIPTION
Pull Request #718 introduced a very welcome improvement in the `turf-buffer` module with buffered polygons being equidistant in all directions.

However, one particular change, which I've traced exactly to the line https://github.com/Turfjs/turf/pull/718/commits/ce8bac807b10ce0b556469a092a24cc97d7990c0#diff-dfff186196a7762bb1ab6352156dd94fR42, removes the ability to do negative buffers directly at API entrypoint level.

As I understand it, `turf` uses the `jsts` module to really compute the buffer. I have inspected this module and it does seem to support negative buffers without any problem, so I see no reason to restrict `turf-buffer` from calculating negative buffers.

This change actually broke some production code which had been running for a couple weeks with no issues, which did two buffer operations to do a [morphological closing](https://en.wikipedia.org/wiki/Closing_(morphology)) (a dilation followed by an erosion).

Besides, negative buffers are important morphological operations in GIS, to the point of Wikipedia plain mentioning their existence in the relevant entry: https://en.wikipedia.org/wiki/Buffer_(GIS)

I've also took the liberty of also allowing zero-sized buffers, which can be used as a 'repair geometry' operation (see [this SO link](http://stackoverflow.com/questions/20833344/fix-invalid-polygon-python-shapely/20873812) for example - it's related to a Python lib, but this trick works with other buffer implementations as well).

I removed the line and ran the tests again. Since all pass, I'm submitting this Pull Request for the community to evaluate.