### PR TITLE
Validation for unused dependencies not required by index.js

### DIFF
--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@turf/distance": "^4.3.0",
-    "@turf/meta": "^4.3.0",
     "@turf/tin": "^4.3.0",
     "@turf/union": "^4.3.0"
   }

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@turf/bbox": "^4.3.0",
-    "@turf/helpers": "^4.3.0",
     "@turf/union": "^4.3.0",
     "geojson-utils": "^1.1.0",
     "get-closest": "^0.0.4",

--- a/packages/turf-great-circle/arc.js
+++ b/packages/turf-great-circle/arc.js
@@ -239,6 +239,8 @@ GreatCircle.prototype.Arc = function (npoints, options) {
     return arc;
 };
 
-module.exports.Coord = Coord;
-module.exports.Arc = Arc;
-module.exports.GreatCircle = GreatCircle;
+module.exports = {
+    Coord: Coord,
+    Arc: Arc,
+    GreatCircle: GreatCircle
+};

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -44,7 +44,6 @@
     "write-json-file": "^2.0.0"
   },
   "dependencies": {
-    "@turf/invariant": "^4.3.0",
-    "arc": "^0.1.0"
+    "@turf/invariant": "^4.3.0"
   }
 }

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -26,10 +26,12 @@
   ],
   "author": "Turf Authors",
   "contributors": [
-    "jseppi",
-    "jvail",
+    "James Seppi <@jseppi>",
+    "Morgan Herlocker <@morganherlocker>",
+    "Tom MacWright <@tmcw>",
+    "Jan Vaillant <@jvail>",
     "Lyzi Diamond <@lyzidiamond>",
-    "Tom MacWright <@tmcw>"
+    "Denis Carriere <@DenisCarriere>"
   ],
   "license": "MIT",
   "bugs": {

--- a/packages/turf-idw/package.json
+++ b/packages/turf-idw/package.json
@@ -30,7 +30,6 @@
     "@turf/bbox": "^4.3.0",
     "@turf/centroid": "^4.3.0",
     "@turf/distance": "^4.3.0",
-    "@turf/helpers": "^4.3.0",
     "@turf/square-grid": "^4.3.0"
   }
 }

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@turf/circle": "^4.3.0",
     "@turf/destination": "^4.3.0",
-    "@turf/helpers": "^4.3.0",
-    "@turf/meta": "^4.3.0"
+    "@turf/helpers": "^4.3.0"
   }
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@turf/bearing": "^4.3.0",
     "@turf/destination": "^4.3.0",
-    "@turf/distance": "^4.3.0",
-    "@turf/invariant": "^4.3.0"
+    "@turf/distance": "^4.3.0"
   }
 }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -33,7 +33,6 @@
     "tape": "^4.6.3"
   },
   "dependencies": {
-    "@turf/distance": "^4.3.0",
-    "@turf/helpers": "^4.3.0"
+    "@turf/distance": "^4.3.0"
   }
 }

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -26,8 +26,10 @@
   ],
   "author": "Turf Authors",
   "contributors": [
+    "Abel Vázquez <@AbelVM>",
     "Morgan Herlocker <@morganherlocker>",
-    "Abel Vázquez"
+    "Tom MacWright <@tmcw>",
+    "Vladimir Agafonkin <@mourner>"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
An error will now occur if you have extra `dependencies` that are not being required in `index.js`.

## Error example

```
not ok 2 turf-concave @turf/meta is not required in index.js
  ---
    operator: fail
    at: Test.t (/Users/mac/Github/turf-tests/packages/turf/test.js:124:54)
  ...

1..2
```