### PR TITLE
Change default param coordinates to 3 @turf/truncate

### DIFF
--- a/packages/turf-truncate/bench.js
+++ b/packages/turf-truncate/bench.js
@@ -1,7 +1,7 @@
-const Benchmark = require('benchmark');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const load = require('load-json-file');
+const Benchmark = require('benchmark');
 const truncate = require('./');
 
 const directory = path.join(__dirname, 'test', 'in') + path.sep;
@@ -13,6 +13,24 @@ let fixtures = fs.readdirSync(directory).map(filename => {
     };
 });
 // fixtures = fixtures.filter(fixture => fixture.name === 'polygons');
+
+/**
+ * Single Process Benchmark
+ *
+ * geometry-collection: 0.563ms
+ * linestring-geometry: 0.076ms
+ * point-elevation: 0.046ms
+ * point-geometry: 0.012ms
+ * point: 0.022ms
+ * points: 0.028ms
+ * polygon: 0.030ms
+ * polygons: 0.030ms
+ */
+for (const {name, geojson} of fixtures) {
+    console.time(name);
+    truncate(geojson, 6, 2, true);
+    console.timeEnd(name);
+}
 
 /**
  * Benchmark Results

--- a/packages/turf-truncate/index.d.ts
+++ b/packages/turf-truncate/index.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="geojson" />
 
-type Feature = GeoJSON.Feature<any>;
-type Features = GeoJSON.FeatureCollection<any>;
-type Geometry = GeoJSON.GeometryObject;
-type Geometries = GeoJSON.GeometryCollection;
-type Truncate = Feature | Features | Geometry | Geometries;
+type Geoms = GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryObject | GeoJSON.GeometryCollection;
 
 /**
  * http://turfjs.org/docs/#truncate
  */
-declare function truncate<Input extends Truncate>(geojson: Input, precision?: number, coordinates?: number, mutate?: boolean): Input;
+declare function truncate<Geom extends Geoms>(
+    geojson: Geom,
+    precision?: number,
+    coordinates?: number,
+    mutate?: boolean): Geom;
+
 declare namespace truncate { }
 export = truncate;

--- a/packages/turf-truncate/index.js
+++ b/packages/turf-truncate/index.js
@@ -6,7 +6,7 @@ var coordEach = require('@turf/meta').coordEach;
  * @name truncate
  * @param {FeatureCollection|Feature<any>} geojson any GeoJSON Feature, FeatureCollection, Geometry or GeometryCollection.
  * @param {number} [precision=6] coordinate decimal precision
- * @param {number} [coordinates=2] maximum number of coordinates (primarly used to remove z coordinates)
+ * @param {number} [coordinates=3] maximum number of coordinates (primarly used to remove z coordinates)
  * @param {boolean} [mutate=false] allows GeoJSON input to be mutated (significant performance increase if true)
  * @returns {FeatureCollection|Feature<any>} layer with truncated geometry
  * @example
@@ -29,8 +29,8 @@ var coordEach = require('@turf/meta').coordEach;
  */
 module.exports = function (geojson, precision, coordinates, mutate) {
     // default params
-    precision = (precision !== undefined) ? precision : 6;
-    coordinates = (coordinates !== undefined) ? coordinates : 2;
+    precision = (precision === undefined || precision === null || isNaN(precision)) ? 6 : precision;
+    coordinates = (coordinates === undefined || coordinates === null || isNaN(coordinates)) ? 3 : coordinates;
 
     // validation
     if (!geojson) throw new Error('<geojson> is required');

--- a/packages/turf-truncate/test.js
+++ b/packages/turf-truncate/test.js
@@ -3,7 +3,7 @@ const test = require('tape');
 const path = require('path');
 const load = require('load-json-file');
 const write = require('write-json-file');
-const point = require('@turf/helpers').point;
+const {point} = require('@turf/helpers');
 const truncate = require('./');
 
 const directories = {
@@ -34,15 +34,19 @@ test('turf-truncate', t => {
 test('turf-truncate - precision & coordinates', t => {
     t.deepEqual(truncate(point([50.1234567, 40.1234567]), 3).geometry.coordinates, [50.123, 40.123], 'precision 3');
     t.deepEqual(truncate(point([50.1234567, 40.1234567]), 0).geometry.coordinates, [50, 40], 'precision 0');
+    t.deepEqual(truncate(point([50, 40, 1100]), 6).geometry.coordinates, [50, 40, 1100], 'coordinates default to 3');
     t.deepEqual(truncate(point([50, 40, 1100]), 6, 2).geometry.coordinates, [50, 40], 'coordinates 2');
     t.end();
 });
 
-test('turf-truncate - handle input mutation', t => {
-    const geojson = point([120.123, 40.123, 3000]);
-    truncate(geojson, 0);
-    t.deepEqual(geojson, point([120.123, 40.123, 3000]), 'does not mutate input');
-    truncate(geojson, 0, 2, true);
-    t.deepEqual(geojson, point([120, 40]), 'does mutate input');
+test('turf-truncate - prevent input mutation', t => {
+    const pt = point([120.123, 40.123, 3000]);
+    const ptBefore = JSON.parse(JSON.stringify(pt));
+
+    truncate(pt, 0);
+    t.deepEqual(ptBefore, pt, 'does not mutate input');
+
+    truncate(pt, 0, 2, true);
+    t.deepEqual(pt, point([120, 40]), 'does mutate input');
     t.end();
 });


### PR DESCRIPTION
## `@turf/truncate` coordinate param to 3

Change the default `coordinates` param from 2 to 3.

The GeoJSON spec suggests using 6 decimals & no more than 3 coordinates (z coordinate optional). This change prevents the "accident" (@stebogit) removal of the z coordinate.

http://geojson.org/geojson-spec.html#positions

> A position is represented by an array of numbers. There must be at least two elements, and may be more. The order of elements must follow x, y, z order (easting, northing, altitude for coordinates in a projected coordinate reference system, or longitude, latitude, altitude for coordinates in a geographic coordinate reference system). Any number of additional elements are allowed -- interpretation and meaning of additional elements is beyond the scope of this specification.

### Example
```javascript
const pt = point([50, 40, 1100, 3000]);
//= [x, y, z, m]
```

### Before
```javascript
truncate(pt);
//= [x, y]
//= [50, 40]
```
### Now
```javascript
truncate(pt);
//= [x, y, z]
//= [50, 40, 1100]
```