### PR TITLE
Update Generate Readmes script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,12 @@ turf-<module>
 │   index.d.ts
 │   bench.js
 │   test.js
+|   types.ts
 │   package.json
 │   README.md
 │   LICENSE
 │
 └───tests
-    │   types.ts
     │
     ├───in
     │   points.geojson

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "npm run lint && lerna bootstrap && tap packages/*/test.js && npm run types",
     "lint": "eslint packages",
     "types": "tsc",
-    "prepublish": "node ./scripts/generate-readmes"
+    "docs": "node ./scripts/generate-readmes"
   },
   "repository": {
     "type": "git",
@@ -53,6 +53,8 @@
     "eslint": "^2.0.0",
     "eslint-config-mourner": "^2.0.0",
     "lerna": "2.0.0-beta.34",
+    "load-json-file": "^2.0.0",
+    "progress": "^2.0.0",
     "tap": "^10.3.2",
     "typescript": "^2.2.1",
     "uglify-js": "~2.4.16"

--- a/scripts/generate-readmes
+++ b/scripts/generate-readmes
@@ -1,45 +1,56 @@
 #!/usr/bin/env node
 
-var documentation = require('documentation');
-var fs = require('fs');
-var d3 = require('d3-queue');
-var path = require('path');
+const fs = require('fs');
+const d3 = require('d3-queue');
+const path = require('path');
+const load = require('load-json-file');
+const ProgressBar = require('progress');
+const documentation = require('documentation');
 
-var q = d3.queue(1);
-
-var postfix = fs.readFileSync(path.join(__dirname, 'postfix.md'), 'utf8');
-
-fs.readdirSync('./packages').forEach(function(dir) {
-  q.defer(generateDocs, dir);
+const q = d3.queue(1);
+const postfix = fs.readFileSync(path.join(__dirname, 'postfix.md'), 'utf8');
+const packages = path.join(__dirname, '..', 'packages') + path.sep;
+const bar = new ProgressBar('  progress [:bar] :rate/bps :percent :etas', {
+    complete: '=',
+    incomplete: ' ',
+    width: 20,
+    total: fs.readdirSync(packages).length
 });
 
-var geojsonPaths = {
-  GeoJSON: 'http://geojson.org/geojson-spec.html#geojson-objects',
-  GeometryCollection: 'http://geojson.org/geojson-spec.html#geometrycollection',
-  Point: 'http://geojson.org/geojson-spec.html#point',
-  MultiPoint: 'http://geojson.org/geojson-spec.html#multipoint',
-  LineString: 'http://geojson.org/geojson-spec.html#linestring',
-  MultiLineString: 'http://geojson.org/geojson-spec.html#multilinestring',
-  Polygon: 'http://geojson.org/geojson-spec.html#polygon',
-  MultiPolygon: 'http://geojson.org/geojson-spec.html#multipolygon',
-  Geometry: 'http://geojson.org/geojson-spec.html#geometry',
-  Feature: 'http://geojson.org/geojson-spec.html#feature-objects',
-  FeatureCollection: 'http://geojson.org/geojson-spec.html#feature-collection-objects'
+fs.readdirSync(packages).forEach(directory => {
+    q.defer(generateDocs, packages + directory);
+});
+
+const paths = {
+    GeoJSON: 'http://geojson.org/geojson-spec.html#geojson-objects',
+    GeometryCollection: 'http://geojson.org/geojson-spec.html#geometrycollection',
+    Point: 'http://geojson.org/geojson-spec.html#point',
+    MultiPoint: 'http://geojson.org/geojson-spec.html#multipoint',
+    LineString: 'http://geojson.org/geojson-spec.html#linestring',
+    MultiLineString: 'http://geojson.org/geojson-spec.html#multilinestring',
+    Polygon: 'http://geojson.org/geojson-spec.html#polygon',
+    MultiPolygon: 'http://geojson.org/geojson-spec.html#multipolygon',
+    Geometry: 'http://geojson.org/geojson-spec.html#geometry',
+    Feature: 'http://geojson.org/geojson-spec.html#feature-objects',
+    FeatureCollection: 'http://geojson.org/geojson-spec.html#feature-collection-objects'
 };
 
 function generateDocs(directory, callback) {
-  var pkg = JSON.parse(fs.readFileSync(path.join('./packages/', directory, '/package.json')));
-  var pkgMain = path.join('./packages/', directory, pkg.main);
-  documentation.build(pkgMain, { }, function(err, res) {
-    if (err) throw err;
-    if (res == undefined) { console.log(directory); }
-    documentation.formats.md(res, {
-      paths: geojsonPaths
-    }, function(err, md) {
-      fs.writeFileSync(
-        path.join('./packages/', directory, '/README.md'),
-        '# ' + pkg.name + '\n\n' + md + postfix.replace('{module}', pkg.name));
-      callback();
+    const {name, main} = load.sync(path.join(directory, 'package.json'));
+    const pkgMain = path.join(directory, main);
+
+    // Build Documentation
+    documentation.build(pkgMain, { }, (error, res) => {
+        if (error) throw new Error(error);
+        if (res === undefined) { console.log(directory); }
+
+        // Format Markdown
+        documentation.formats.md(res, {paths}, (error, markdown) => {
+            if (error) throw new Error(error);
+            markdown = `# ${name}\n\n${markdown}${postfix.replace(/{module}/, name)}`;
+            fs.writeFileSync(path.join(directory, 'README.md'), markdown);
+            bar.tick();
+            callback(null);
+        });
     });
-  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,15 +1351,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.0.0, concat-stream@^1.4.6, concat-stream@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@~1.5.0, concat-stream@~1.5.1:
+concat-stream@^1.0.0, concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@~1.5.0, concat-stream@~1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -2394,7 +2386,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2882,6 +2874,15 @@ load-json-file@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
+
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
@@ -3529,6 +3530,10 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.5.tgz#21de1f441c4ef7094408ed9f1c94f7a114b87557"
@@ -3643,7 +3648,7 @@ read-pkg@^1.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.6:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
   dependencies:
@@ -4205,6 +4210,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -4478,7 +4487,7 @@ type-is@~1.6.10:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typedarray@^0.0.6, typedarray@~0.0.5:
+typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 


### PR DESCRIPTION
## Update Generate Readmes script

- Windows compatible
- Can be executed from anywhere
- Added progress bar

@stebogit @rowanwins Can you try out the new `generate-readme` script or use `npm run docs` in the root directory. The big change is making this script cross-platform.

Added progress bar for progress status:

![image](https://cloud.githubusercontent.com/assets/550895/26532529/d6fc7e9c-43d0-11e7-9a39-e852de018fc2.png)


@tmcw ❤️ [DocumentationJS](https://github.com/documentationjs/documentation) 👍 