### PR TITLE
Fixes 180th meridian crossing for @turf/rhumb-destination

### DIFF
--- a/packages/turf-rhumb-destination/index.js
+++ b/packages/turf-rhumb-destination/index.js
@@ -51,5 +51,8 @@ module.exports = function (origin, distance, bearing, units) {
     var pt = new GeodesyLatLon(coords[1], coords[0]);
     var destination = pt.rhumbDestinationPoint(distanceInMeters, bearing);
 
+    // compensate the crossing of the 180th meridian (https://macwright.org/2016/09/26/the-180th-meridian.html)
+    // solution from https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678
+    destination.lon += (destination.lon - coords[0] > 180) ? -360 : (coords[0] - destination.lon > 180) ? 360 : 0;
     return point([destination.lon, destination.lat]);
 };

--- a/packages/turf-rhumb-destination/test.js
+++ b/packages/turf-rhumb-destination/test.js
@@ -28,10 +28,10 @@ test('turf-rhumb-destination', t => {
         dist = (dist !== undefined) ? dist : 100;
         units = units || 'kilometers';
 
-        const resultPoint = rhumbDestination(inputPoint, dist, bearing, units);
-        const line = truncate(lineString([getCoords(inputPoint), getCoords(resultPoint)], {"stroke": "#F00", "stroke-width": 4}));
+        const destinationPoint = rhumbDestination(inputPoint, dist, bearing, units);
+        const line = truncate(lineString([getCoords(inputPoint), getCoords(destinationPoint)], {"stroke": "#F00", "stroke-width": 4}));
         inputPoint.properties['marker-color'] = '#F00';
-        const result = featureCollection([line, inputPoint, resultPoint]);
+        const result = featureCollection([line, inputPoint, destinationPoint]);
 
         if (process.env.REGEN) write.sync(directories.out + filename, result);
         t.deepEqual(result, load.sync(directories.out + filename), name);

--- a/packages/turf-rhumb-destination/test/in/fiji-east-west.geojson
+++ b/packages/turf-rhumb-destination/test/in/fiji-east-west.geojson
@@ -1,0 +1,14 @@
+{
+	"type": "Feature",
+	"properties": {
+		"bearing": -90,
+		"dist": 100
+	},
+	"geometry": {
+		"type": "Point",
+		"coordinates": [
+			-179.5,
+			-16.5
+		]
+	}
+}

--- a/packages/turf-rhumb-destination/test/in/fiji-west-east.geojson
+++ b/packages/turf-rhumb-destination/test/in/fiji-west-east.geojson
@@ -1,0 +1,14 @@
+{
+	"type": "Feature",
+	"properties": {
+		"bearing": 120,
+		"dist": 150
+	},
+	"geometry": {
+		"type": "Point",
+		"coordinates": [
+			179.5,
+			-16.5
+		]
+	}
+}

--- a/packages/turf-rhumb-destination/test/out/fiji-east-west.geojson
+++ b/packages/turf-rhumb-destination/test/out/fiji-east-west.geojson
@@ -1,0 +1,51 @@
+{
+	"type": "FeatureCollection",
+	"features": [
+		{
+			"type": "Feature",
+			"properties": {
+				"stroke": "#F00",
+				"stroke-width": 4
+			},
+			"geometry": {
+				"type": "LineString",
+				"coordinates": [
+					[
+						-179.5,
+						-16.5
+					],
+					[
+						-180.437946,
+						-16.5
+					]
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+				"bearing": -90,
+				"dist": 100,
+				"marker-color": "#F00"
+			},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+					-179.5,
+					-16.5
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+					-180.43794649110168,
+					-16.5
+				]
+			}
+		}
+	]
+}

--- a/packages/turf-rhumb-destination/test/out/fiji-west-east.geojson
+++ b/packages/turf-rhumb-destination/test/out/fiji-west-east.geojson
@@ -1,0 +1,51 @@
+{
+	"type": "FeatureCollection",
+	"features": [
+		{
+			"type": "Feature",
+			"properties": {
+				"stroke": "#F00",
+				"stroke-width": 4
+			},
+			"geometry": {
+				"type": "LineString",
+				"coordinates": [
+					[
+						179.5,
+						-16.5
+					],
+					[
+						180.720586,
+						-17.174491
+					]
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+				"bearing": 120,
+				"dist": 150,
+				"marker-color": "#F00"
+			},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+					179.5,
+					-16.5
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+					180.7205858123533,
+					-17.17449120443905
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
Fixes #770, returning if necessary longitude greater than 180 degrees.

I'd see this as a bug fix rather than a breaking compatibility with previous version.

Modules depending on `@turf/rhumb-destination`:
- [ ] [`@turf/transform-translate`](https://github.com/Turfjs/turf/tree/master/packages/turf-transform-translate)
- [ ] [`@turf/transform-rotate`](https://github.com/Turfjs/turf/tree/master/packages/turf-transform-rotate)
- [ ] [`@turf/transform-scale`](https://github.com/Turfjs/turf/tree/master/packages/turf-transform-scale) (still under-construction)


@DenisCarriere we might want to mention this behaviour to the README?

Also, I was wondering if we needed now to check if the input has longitude greater than 180 degrees, so that it's normalized between -180..180 before the computation.

Finally, do you think we should add the same correction to `@turf/destination` and other modules?

cc: @dpmcmlxxvi