### PR TITLE
Fixed calculation of @turf/rhumb-distance for points around 180th meridian

### DIFF
--- a/packages/turf-rhumb-distance/index.js
+++ b/packages/turf-rhumb-distance/index.js
@@ -51,6 +51,10 @@ module.exports = function (from, to, units) {
     var coordsTo = getCoord(to);
     var origin = new GeodesyLatLon(coordsFrom[1], coordsFrom[0]);
     var destination = new GeodesyLatLon(coordsTo[1], coordsTo[0]);
+
+    // compensate the crossing of the 180th meridian (https://macwright.org/2016/09/26/the-180th-meridian.html)
+    // solution from https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678
+    destination[0] += (destination[0] - origin[0] > 180) ? -360 : (origin[0] - destination[0] > 180) ? 360 : 0;
     var distanceInMeters = origin.rhumbDistanceTo(destination);
     var distance = radiansToDistance(distanceToRadians(distanceInMeters, 'meters'), units);
     return distance;

--- a/packages/turf-rhumb-distance/test.js
+++ b/packages/turf-rhumb-distance/test.js
@@ -30,18 +30,20 @@ test('rhumb-distance', t => {
             greatCircleDistance: round(distance(pt1, pt2, 'kilometers'), 6),
             radians: round(rhumbDistance(pt1, pt2, 'radians'), 6),
             degrees: round(rhumbDistance(pt1, pt2, 'degrees'), 6)
-        }
+        };
 
         if (process.env.REGEN) write.sync(directories.out + name + '.json', distances);
         t.deepEqual(distances, load.sync(directories.out + name + '.json'), name);
 
-        // Now fails due to approximation error
-        // TODO: to be added once earth radius is updated to 6371km
-        // t.ok(distances.kilometers > distances.greatCircleDistance, name + ' distance comparison');
-
-        t.throws(() => rhumbDistance(pt1, pt2, 'blah'), 'unknown option given to units');
-        t.throws(() => rhumbDistance(null, pt2), 'null point');
-        t.throws(() => rhumbDistance(pt1, 'point', 'miles'), 'invalid point');
     }
+
+    // Now fails due to approximation error
+    // TODO: to be added once earth radius is updated to 6371km
+    // t.ok(distances.kilometers > distances.greatCircleDistance, name + ' distance comparison');
+
+    t.throws(() => rhumbDistance(pt1, pt2, 'blah'), 'unknown option given to units');
+    t.throws(() => rhumbDistance(null, pt2), 'null point');
+    t.throws(() => rhumbDistance(pt1, 'point', 'miles'), 'invalid point');
+
     t.end();
 });

--- a/packages/turf-rhumb-distance/test/in/fiji-539-lng.geojson
+++ b/packages/turf-rhumb-distance/test/in/fiji-539-lng.geojson
@@ -1,0 +1,28 @@
+{
+	"type": "FeatureCollection",
+	"features": [
+		{
+			"type": "Feature",
+			"properties": {},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+					-539.5,
+					-16.5
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+			},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+					-541.5,
+					-18.5
+				]
+			}
+		}
+	]
+}

--- a/packages/turf-rhumb-distance/test/in/points-fiji.geojson
+++ b/packages/turf-rhumb-distance/test/in/points-fiji.geojson
@@ -1,0 +1,28 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -179.5,
+          -16.5
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          178.5,
+          -16.5
+        ]
+      }
+    }
+  ]
+}

--- a/packages/turf-rhumb-distance/test/out/fiji-539-lng.json
+++ b/packages/turf-rhumb-distance/test/out/fiji-539-lng.json
@@ -1,0 +1,8 @@
+{
+	"miles": 190.951081,
+	"nauticalmiles": 165.931908,
+	"kilometers": 307.305868,
+	"greatCircleDistance": 307.400927,
+	"radians": 0.04822,
+	"degrees": 2.762801
+}

--- a/packages/turf-rhumb-distance/test/out/points-fiji.json
+++ b/packages/turf-rhumb-distance/test/out/points-fiji.json
@@ -1,0 +1,8 @@
+{
+	"miles": 132.496132,
+	"nauticalmiles": 115.13596,
+	"kilometers": 213.23178,
+	"greatCircleDistance": 213.297845,
+	"radians": 0.033459,
+	"degrees": 1.917038
+}

--- a/packages/turf-rhumb-distance/yarn.lock
+++ b/packages/turf-rhumb-distance/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+"@turf/distance@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-4.3.0.tgz#b533ba75936fea897ee1987824714b803df9061c"
+  dependencies:
+    "@turf/helpers" "^4.3.0"
+    "@turf/invariant" "^4.3.0"
+
+"@turf/helpers@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.3.0.tgz#7b2f733aa0eb3ea1f07d467ac02ede00cc6cde0d"
+
+"@turf/invariant@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-4.3.0.tgz#5bd1ce6ae51b1229dc0dc7d09d973fabae49af89"
+
 balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"


### PR DESCRIPTION
Ref: #770 

`@turf/rhumb-distance` now returns the right distance between points across 180th meridian, using @mourner elegant [fix implementation](https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678)

Modules depending on `@turf/rhumb-distance`:
- `@turf/transform-translate`
- `@turf/transform-rotate`
- `@turf/transform-scale`