### PR TITLE
Renamed `cellSize` param in grid modules

### DIFF
--- a/packages/turf-hex-grid/README.md
+++ b/packages/turf-hex-grid/README.md
@@ -2,25 +2,25 @@
 
 # hexGrid
 
-Takes a bounding box and a cell size in degrees and returns a [FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) of flat-topped
-hexagons ([Polygon](http://geojson.org/geojson-spec.html#polygon) features) aligned in an "odd-q" vertical grid as
+Takes a bounding box and the cell side length and returns a [FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) of flat-topped
+hexagons or triangles ([Polygon](http://geojson.org/geojson-spec.html#polygon) features) aligned in an "odd-q" vertical grid as
 described in [Hexagonal Grids](http://www.redblobgames.com/grids/hexagons/).
 
 **Parameters**
 
 -   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** extent in [minX, minY, maxX, maxY] order
--   `cellSize` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** dimension of cell in specified units
--   `units` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** used in calculating cellSize, can be degrees, radians, miles, or kilometers (optional, default `kilometers`)
+-   `cellSide` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** length of the hexagon or triangle sides in specified units
+-   `units` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** used in calculating cellSide, can be degrees, radians, miles, or kilometers (optional, default `kilometers`)
 -   `triangles` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether to return as triangles instead of hexagons (optional, default `false`)
 
 **Examples**
 
 ```javascript
 var bbox = [-96,31,-84,40];
-var cellSize = 50;
+var cellSide = 50;
 var units = 'miles';
 
-var hexgrid = turf.hexGrid(bbox, cellSize, units);
+var hexgrid = turf.hexGrid(bbox, cellSide, units);
 
 //addToMap
 var addToMap = [hexgrid]

--- a/packages/turf-hex-grid/README.md
+++ b/packages/turf-hex-grid/README.md
@@ -2,25 +2,25 @@
 
 # hexGrid
 
-Takes a bounding box and the cell side length and returns a [FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) of flat-topped
+Takes a bounding box and the diameter of the cell and returns a [FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) of flat-topped
 hexagons or triangles ([Polygon](http://geojson.org/geojson-spec.html#polygon) features) aligned in an "odd-q" vertical grid as
 described in [Hexagonal Grids](http://www.redblobgames.com/grids/hexagons/).
 
 **Parameters**
 
 -   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** extent in [minX, minY, maxX, maxY] order
--   `cellSide` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** length of the hexagon or triangle sides in specified units
--   `units` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** used in calculating cellSide, can be degrees, radians, miles, or kilometers (optional, default `kilometers`)
+-   `cellDiameter` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** diameter of the circumcircle of the hexagons in specified units
+-   `units` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** used in calculating cell size, can be degrees, radians, miles, or kilometers (optional, default `kilometers`)
 -   `triangles` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** whether to return as triangles instead of hexagons (optional, default `false`)
 
 **Examples**
 
 ```javascript
 var bbox = [-96,31,-84,40];
-var cellSide = 50;
+var cellDiameter = 50;
 var units = 'miles';
 
-var hexgrid = turf.hexGrid(bbox, cellSide, units);
+var hexgrid = turf.hexGrid(bbox, cellDiameter, units);
 
 //addToMap
 var addToMap = [hexgrid]

--- a/packages/turf-hex-grid/index.d.ts
+++ b/packages/turf-hex-grid/index.d.ts
@@ -3,6 +3,6 @@ import {Units, BBox, Polygons} from '@turf/helpers'
 /**
  * http://turfjs.org/docs/#hexgrid
  */
-declare function hexGrid(bbox: BBox, cellSide: number, units?: Units, triangles?: boolean): Polygons;
+declare function hexGrid(bbox: BBox, cellDiameter: number, units?: Units, triangles?: boolean): Polygons;
 declare namespace hexGrid { }
 export = hexGrid;

--- a/packages/turf-hex-grid/index.d.ts
+++ b/packages/turf-hex-grid/index.d.ts
@@ -3,6 +3,6 @@ import {Units, BBox, Polygons} from '@turf/helpers'
 /**
  * http://turfjs.org/docs/#hexgrid
  */
-declare function hexGrid(bbox: BBox, cellSize: number, units?: Units, triangles?: boolean): Polygons;
+declare function hexGrid(bbox: BBox, cellSide: number, units?: Units, triangles?: boolean): Polygons;
 declare namespace hexGrid { }
 export = hexGrid;

--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -15,27 +15,27 @@ for (var i = 0; i < 6; i++) {
 }
 
 /**
- * Takes a bounding box and a cell size in degrees and returns a {@link FeatureCollection} of flat-topped
- * hexagons ({@link Polygon} features) aligned in an "odd-q" vertical grid as
+ * Takes a bounding box and the cell side length and returns a {@link FeatureCollection} of flat-topped
+ * hexagons or triangles ({@link Polygon} features) aligned in an "odd-q" vertical grid as
  * described in [Hexagonal Grids](http://www.redblobgames.com/grids/hexagons/).
  *
  * @name hexGrid
  * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
- * @param {number} cellSize dimension of cell in specified units
- * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
+ * @param {number} cellSide length of the hexagon or triangle sides in specified units
+ * @param {string} [units=kilometers] used in calculating cellSide, can be degrees, radians, miles, or kilometers
  * @param {boolean} [triangles=false] whether to return as triangles instead of hexagons
  * @returns {FeatureCollection<Polygon>} a hexagonal grid
  * @example
  * var bbox = [-96,31,-84,40];
- * var cellSize = 50;
+ * var cellSide = 50;
  * var units = 'miles';
  *
- * var hexgrid = turf.hexGrid(bbox, cellSize, units);
+ * var hexgrid = turf.hexGrid(bbox, cellSide, units);
  *
  * //addToMap
  * var addToMap = [hexgrid]
  */
-module.exports = function hexGrid(bbox, cellSize, units, triangles) {
+module.exports = function hexGrid(bbox, cellSide, units, triangles) {
     var west = bbox[0];
     var south = bbox[1];
     var east = bbox[2];
@@ -44,9 +44,9 @@ module.exports = function hexGrid(bbox, cellSize, units, triangles) {
     var centerX = (west + east) / 2;
 
     // https://github.com/Turfjs/turf/issues/758
-    var xFraction = cellSize / (distance(point([west, centerY]), point([east, centerY]), units));
+    var xFraction = cellSide / (distance(point([west, centerY]), point([east, centerY]), units));
     var cellWidth = xFraction * (east - west);
-    var yFraction = cellSize / (distance(point([centerX, south]), point([centerX, north]), units));
+    var yFraction = cellSide / (distance(point([centerX, south]), point([centerX, north]), units));
     var cellHeight = yFraction * (north - south);
     var radius = cellWidth / 2;
 

--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -15,27 +15,27 @@ for (var i = 0; i < 6; i++) {
 }
 
 /**
- * Takes a bounding box and the cell side length and returns a {@link FeatureCollection} of flat-topped
+ * Takes a bounding box and the diameter of the cell and returns a {@link FeatureCollection} of flat-topped
  * hexagons or triangles ({@link Polygon} features) aligned in an "odd-q" vertical grid as
  * described in [Hexagonal Grids](http://www.redblobgames.com/grids/hexagons/).
  *
  * @name hexGrid
  * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
- * @param {number} cellSide length of the hexagon or triangle sides in specified units
- * @param {string} [units=kilometers] used in calculating cellSide, can be degrees, radians, miles, or kilometers
+ * @param {number} cellDiameter diameter of the circumcircle of the hexagons, in specified units
+ * @param {string} [units=kilometers] used in calculating cell size, can be degrees, radians, miles, or kilometers
  * @param {boolean} [triangles=false] whether to return as triangles instead of hexagons
  * @returns {FeatureCollection<Polygon>} a hexagonal grid
  * @example
  * var bbox = [-96,31,-84,40];
- * var cellSide = 50;
+ * var cellDiameter = 50;
  * var units = 'miles';
  *
- * var hexgrid = turf.hexGrid(bbox, cellSide, units);
+ * var hexgrid = turf.hexGrid(bbox, cellDiameter, units);
  *
  * //addToMap
  * var addToMap = [hexgrid]
  */
-module.exports = function hexGrid(bbox, cellSide, units, triangles) {
+module.exports = function hexGrid(bbox, cellDiameter, units, triangles) {
     var west = bbox[0];
     var south = bbox[1];
     var east = bbox[2];
@@ -44,9 +44,9 @@ module.exports = function hexGrid(bbox, cellSide, units, triangles) {
     var centerX = (west + east) / 2;
 
     // https://github.com/Turfjs/turf/issues/758
-    var xFraction = cellSide / (distance(point([west, centerY]), point([east, centerY]), units));
+    var xFraction = cellDiameter / (distance(point([west, centerY]), point([east, centerY]), units));
     var cellWidth = xFraction * (east - west);
-    var yFraction = cellSide / (distance(point([centerX, south]), point([centerX, north]), units));
+    var yFraction = cellDiameter / (distance(point([centerX, south]), point([centerX, north]), units));
     var cellHeight = yFraction * (north - south);
     var radius = cellWidth / 2;
 

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
+    "@turf/centroid": "^4.4.0",
     "@turf/truncate": "^4.4.0",
     "benchmark": "^2.1.4",
     "load-json-file": "^2.0.0",

--- a/packages/turf-hex-grid/test.js
+++ b/packages/turf-hex-grid/test.js
@@ -2,6 +2,8 @@ const test = require('tape');
 const path = require('path');
 const load = require('load-json-file');
 const write = require('write-json-file');
+const centroid = require('@turf/centroid');
+const distance = require('@turf/distance');
 const truncate = require('@turf/truncate');
 const grid = require('./');
 
@@ -78,7 +80,7 @@ test('hex-tri-grid', t => {
     t.end();
 });
 
-test('longitude (13141439571036224) issue #758', t => {
+test('longitude (13141439571036224) - issue #758', t => {
     const bbox = [-179, -90, 179, 90];
     const hexgrid = grid(bbox, 500, 'kilometers');
 
@@ -93,3 +95,23 @@ test('longitude (13141439571036224) issue #758', t => {
     }
     t.end();
 });
+
+test('hexagon size - issue #623', t => {
+    const bbox = [9.244, 45.538, 9.115, 45.439];
+    const cellDiameter = 1;
+    const hexgrid = grid(bbox, 1, 'kilometers');
+
+    const tile1 = hexgrid.features[0];
+    const tile2 = hexgrid.features[1];
+    var dist = distance(centroid(tile1), centroid(tile2), "kilometers");
+
+    t.equal(round(dist, 10), round(Math.sqrt(3) * cellDiameter / 2, 10));
+
+    t.end();
+});
+
+
+function round(value, places) {
+    var multiplier = Math.pow(10, places);
+    return (Math.round(value * multiplier) / multiplier);
+}

--- a/packages/turf-point-grid/README.md
+++ b/packages/turf-point-grid/README.md
@@ -7,8 +7,8 @@ Creates a [Point](http://geojson.org/geojson-spec.html#point) grid from a boundi
 **Parameters**
 
 -   `bbox` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;any>)** extent in [minX, minY, maxX, maxY] order
--   `cellSize` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** the distance across each cell
--   `units` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** used in calculating cellSize, can be degrees, radians, miles, or kilometers (optional, default `kilometers`)
+-   `cellSide` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** the distance between points
+-   `units` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** used in calculating cellSide, can be degrees, radians, miles, or kilometers (optional, default `kilometers`)
 -   `centered` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** adjust points position to center the grid into bbox (optional, default `false`)
 -   `bboxIsMask` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** if true, and bbox is a Polygon or MultiPolygon, the grid Point will be created only if inside the bbox Polygon(s) (optional, default `false`)
 
@@ -16,10 +16,10 @@ Creates a [Point](http://geojson.org/geojson-spec.html#point) grid from a boundi
 
 ```javascript
 var extent = [-70.823364, -33.553984, -70.473175, -33.302986];
-var cellSize = 3;
+var cellSide = 3;
 var units = 'miles';
 
-var grid = turf.pointGrid(extent, cellSize, units);
+var grid = turf.pointGrid(extent, cellSide, units);
 
 //addToMap
 var addToMap = [grid];

--- a/packages/turf-point-grid/index.d.ts
+++ b/packages/turf-point-grid/index.d.ts
@@ -3,6 +3,6 @@ import {BBox, Points, Units, Feature, Features} from '@turf/helpers';
 /**
  * http://turfjs.org/docs/#pointgrid
  */
-declare function pointGrid(bbox: BBox | Feature<any> | Features<any>, cellSize: number, units?: Units, centered?: boolean, bboxIsMask?: boolean): Points;
+declare function pointGrid(bbox: BBox | Feature<any> | Features<any>, cellSide: number, units?: Units, centered?: boolean, bboxIsMask?: boolean): Points;
 declare namespace pointGrid { }
 export = pointGrid;

--- a/packages/turf-point-grid/index.js
+++ b/packages/turf-point-grid/index.js
@@ -12,23 +12,23 @@ var featureCollection = helpers.featureCollection;
  *
  * @name pointGrid
  * @param {Array<number>|FeatureCollection|Feature<any>} bbox extent in [minX, minY, maxX, maxY] order
- * @param {number} cellSize the distance across each cell
- * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
+ * @param {number} cellSide the distance between points
+ * @param {string} [units=kilometers] used in calculating cellSide, can be degrees, radians, miles, or kilometers
  * @param {boolean} [centered=false] adjust points position to center the grid into bbox
  * @param {boolean} [bboxIsMask=false] if true, and bbox is a Polygon or MultiPolygon, the grid Point will be created
  * only if inside the bbox Polygon(s)
  * @returns {FeatureCollection<Point>} grid of points
  * @example
  * var extent = [-70.823364, -33.553984, -70.473175, -33.302986];
- * var cellSize = 3;
+ * var cellSide = 3;
  * var units = 'miles';
  *
- * var grid = turf.pointGrid(extent, cellSize, units);
+ * var grid = turf.pointGrid(extent, cellSide, units);
  *
  * //addToMap
  * var addToMap = [grid];
  */
-module.exports = function (bbox, cellSize, units, centered, bboxIsMask) {
+module.exports = function (bbox, cellSide, units, centered, bboxIsMask) {
     var results = [];
 
     var bboxMask = bbox;
@@ -42,9 +42,9 @@ module.exports = function (bbox, cellSize, units, centered, bboxIsMask) {
     var east = bbox[2];
     var north = bbox[3];
 
-    var xFraction = cellSize / (distance(point([west, south]), point([east, south]), units));
+    var xFraction = cellSide / (distance(point([west, south]), point([east, south]), units));
     var cellWidth = xFraction * (east - west);
-    var yFraction = cellSize / (distance(point([west, south]), point([west, north]), units));
+    var yFraction = cellSide / (distance(point([west, south]), point([west, north]), units));
     var cellHeight = yFraction * (north - south);
 
     if (centered === true) {


### PR DESCRIPTION
- renamed `cellSize` parameter to `cellSide` in `@turf/point-grid`;
- renamed `cellSize` parameter to `cellDiameter` in `@turf/hex-grid`
- added distance between  hexagon centroids
- modified docs

Fixes #623