### PR TITLE
Drop array of features from clusters-dbscan

### DIFF
--- a/packages/turf-clusters-dbscan/index.d.ts
+++ b/packages/turf-clusters-dbscan/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="geojson" />
 
-import {Units, Points, Point} from '@turf/helpers';
+import {Units, Points} from '@turf/helpers';
 
 interface Output {
     type: 'FeatureCollection'
@@ -11,7 +11,7 @@ interface Output {
  * http://turfjs.org/docs/#clustersdbscans
  */
 declare function clustersDbscan(
-    points: Points | Point[],
+    points: Points,
     maxDistance: number,
     units?: Units,
     minPoints?: number): Output;

--- a/packages/turf-clusters-dbscan/index.js
+++ b/packages/turf-clusters-dbscan/index.js
@@ -7,13 +7,12 @@ var turfDistance = require('@turf/distance');
 var coordAll = meta.coordAll;
 var collectionOf = invariant.collectionOf;
 var convertDistance = helpers.convertDistance;
-var featureCollection = helpers.featureCollection;
 
 /**
  * Takes a set of {@link Point|points} and partition them into clusters according to {@link DBSCAN's|https://en.wikipedia.org/wiki/DBSCAN} data clustering algorithm.
  *
  * @name clustersDbscan
- * @param {FeatureCollection|Feature[]} points to be clustered
+ * @param {FeatureCollection<Point>} points to be clustered
  * @param {number} maxDistance Maximum Distance between any point of the cluster to generate the clusters (kilometers only)
  * @param {string} [units=kilometers] in which `maxDistance` is expressed, can be degrees, radians, miles, or kilometers
  * @param {number} [minPoints=3] Minimum number of points to generate a single cluster, points will be excluded if the
@@ -29,12 +28,9 @@ var featureCollection = helpers.featureCollection;
  * var clustered = turf.clustersDbscan(points, distance);
  *
  * //addToMap
- * var addToMap = featureCollection(clustered.points);
+ * var addToMap = clustered;
  */
 module.exports = function (points, maxDistance, units, minPoints) {
-    // Handle Array of Points
-    if (Array.isArray(points)) points = featureCollection(points);
-
     // Input validation
     collectionOf(points, 'Point', 'Input must contain Points');
     if (maxDistance === null || maxDistance === undefined) throw new Error('maxDistance is required');

--- a/packages/turf-clusters-dbscan/test.js
+++ b/packages/turf-clusters-dbscan/test.js
@@ -69,11 +69,6 @@ test('clusters-dbscan -- translate properties', t => {
     t.end();
 });
 
-test('clusters-dbscan -- handle Array of Points', t => {
-    t.assert(clustersDbscan(points.features, 2), 'Support Array of Features input');
-    t.end();
-});
-
 // style result
 function colorize(clustered) {
     const clusters = new Set();

--- a/packages/turf-clusters-dbscan/types.ts
+++ b/packages/turf-clusters-dbscan/types.ts
@@ -1,17 +1,18 @@
 import {featureCollection, point} from '@turf/helpers'
 import * as clustersDbscan from './'
 
-// Default
-const pts = featureCollection([
+// Fixtures
+const points = featureCollection([
     point([0, 0]),
     point([2, 2])
 ]);
 
+// Default
 const maxDistance = 5;
-const clustered = clustersDbscan(pts, maxDistance);
+const clustered = clustersDbscan(points, maxDistance);
 
 // Enforce strict properties when using the dbscan property
-const output = clustersDbscan(pts, maxDistance);
+const output = clustersDbscan(points, maxDistance);
 let {dbscan, cluster} = output.features[0].properties
 dbscan = 'edge'
 dbscan = 'core'
@@ -22,9 +23,6 @@ clustersDbscan(output, maxDistance);
 // Options
 const minPoints = 3;
 const units = 'miles';
-clustersDbscan(pts, maxDistance);
-clustersDbscan(pts, maxDistance, units);
-clustersDbscan(pts, maxDistance, units, minPoints);
-
-// Handle Array of Points
-clustersDbscan(pts.features, maxDistance);
+clustersDbscan(points, maxDistance);
+clustersDbscan(points, maxDistance, units);
+clustersDbscan(points, maxDistance, units, minPoints);


### PR DESCRIPTION
# Updates to `@turfl/clusters-dbscan`

- [x] Dropped array of Features
- [ ] Create centroids & concave polygons using `clusterEach` (for testing purposes only)
