### PR TITLE
Bump `polygonize` dependency in @turf/polygonize

### DIFF
--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -41,6 +41,6 @@
     "write-json-file": "2.2.0"
   },
   "dependencies": {
-    "polygonize": "1.0.1"
+    "polygonize": "1.0.2"
   }
 }

--- a/packages/turf-polygonize/yarn.lock
+++ b/packages/turf-polygonize/yarn.lock
@@ -252,9 +252,9 @@ platform@^1.3.3:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.4.tgz#6f0fb17edaaa48f21442b3a975c063130f1c3ebd"
 
-polygonize@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/polygonize/-/polygonize-1.0.1.tgz#51fb7040914be0fbc43b0bd54d421d75fc2ae7a6"
+polygonize@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/polygonize/-/polygonize-1.0.2.tgz#bf92c0f52edd2191563e22b101727286e1453984"
   dependencies:
     "@turf/envelope" "^4.3.0"
     "@turf/helpers" "^4.3.0"


### PR DESCRIPTION
This allows pulling in this fix https://github.com/NickCis/polygonize/pull/1 which would allow us to use @turfjs in React Native apps.