### PR TITLE
Fix for boolean properties not being translated using @turf/clone

### DIFF
--- a/packages/turf-clone/index.js
+++ b/packages/turf-clone/index.js
@@ -69,17 +69,14 @@ function cloneProperties(properties) {
     if (!properties) return cloned;
     Object.keys(properties).forEach(function (key) {
         var value = properties[key];
-        switch (typeof value) {
-        case 'number':
-        case 'string':
-            cloned[key] = value;
-            break;
-        case 'object':
-            // array
-            if (value.length) cloned[key] = value.map(function (item) { return item; });
-            // object
+        if (typeof value === 'object') {
+            // handle Array
+            if (value.length) cloned[key] = value.map(function (item) {
+                return item;
+            });
+            // handle Object
             cloned[key] = cloneProperties(value);
-        }
+        } else cloned[key] = value;
     });
     return cloned;
 }

--- a/packages/turf-clone/test.js
+++ b/packages/turf-clone/test.js
@@ -122,25 +122,48 @@ test('turf-clone -- Preserve Foreign Members -- FeatureCollection', t => {
 test('turf-clone -- Preserve all properties -- Feature', t => {
     const id = 12345;
     const bbox = [0, 20, 0, 20];
-    const properties = {foo: 'bar', object: {property: 1}, array: [0, 1, 2]};
+    const properties = {
+        foo: 'bar',
+        object: {property: 1},
+        array: [0, 1, 2],
+        number: 1,
+        boolean: true
+    };
     const pt = point([0, 20], properties, bbox, id);
     pt.hello = 'world'; // Foreign member
 
     // Clone and mutate
     const cloned = clone(pt);
+
+    // Clone properly translated all properties
+    t.equal(cloned.hello, 'world');
+    t.equal(cloned.properties.foo, 'bar');
+    t.equal(cloned.id, 12345);
+    t.deepEqual(cloned.bbox, [0, 20, 0, 20]);
+    t.equal(cloned.properties.object.property, 1);
+    t.deepEqual(cloned.properties.array, [0, 1, 2]);
+    t.equal(cloned.properties.number, 1);
+    t.equal(cloned.properties.boolean, true);
+
+    // Mutate clone properties
     cloned['hello'] = 'universe';
     cloned.properties['foo'] = 'foo';
     cloned['id'] = 54321;
     cloned['bbox'] = [30, 40, 30, 40];
     cloned.properties.object['property'] = 2;
     cloned.properties.array[0] = 500;
+    cloned.properties.number = -99;
+    cloned.properties.boolean = false;
 
+    // Test if original point hasn't been mutated
     t.equal(pt.hello, 'world');
     t.equal(pt.properties.foo, 'bar');
     t.equal(pt.id, 12345);
     t.deepEqual(pt.bbox, [0, 20, 0, 20]);
     t.equal(pt.properties.object.property, 1);
     t.deepEqual(pt.properties.array, [0, 1, 2]);
+    t.equal(pt.properties.number, 1);
+    t.equal(pt.properties.boolean, true);
     t.end();
 });
 


### PR DESCRIPTION
## Quickfix to `@turf/clone`

Properties with `typeof==="boolean"` wasn't being cloned 🤦‍♂️ .

- [x] Handles properties with `boolean` values
- [x] Added test cases for issue