### PR TITLE
Implement allowNull options to @turf/meta fixes #946

### DIFF
--- a/packages/turf-concave/test/out/support-null-geometry.geojson
+++ b/packages/turf-concave/test/out/support-null-geometry.geojson
@@ -3,10 +3,7 @@
 	"features": [
 		{
 			"type": "Feature",
-			"properties": {
-				"marker-color": "#f0f",
-				"marker-size": "small"
-			},
+			"properties": {},
 			"geometry": null
 		},
 		{

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -138,6 +138,34 @@ Callback for propEach
 -   `geojson`  
 -   `callback`  
 
+# propReduceCallback
+
+Callback for propReduce
+
+The first time the callback function is called, the values provided as arguments depend
+on whether the reduce method has an initialValue argument.
+
+If an initialValue is provided to the reduce method:
+
+-   The previousValue argument is initialValue.
+-   The currentValue argument is the value of the first element present in the array.
+
+If an initialValue is not provided:
+
+-   The previousValue argument is the value of the first element present in the array.
+-   The currentValue argument is the value of the second element present in the array.
+
+**Parameters**
+
+-   `previousValue` **Any** The accumulated value previously returned in the last invocation
+    of the callback, or initialValue, if supplied.
+-   `currentProperties` **Any** The current properties being processed.
+-   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The index of the current element being processed in the
+    array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
+-   `geojson`  
+-   `callback`  
+-   `initialValue`  
+
 # propReduce
 
 Reduce properties in any GeoJSON object into a single value,
@@ -168,33 +196,18 @@ turf.propReduce(features, function (previousValue, currentProperties, featureInd
 
 Returns **Any** The value that results from the reduction.
 
-# propReduceCallback
+# featureEachCallback
 
-Callback for propReduce
-
-The first time the callback function is called, the values provided as arguments depend
-on whether the reduce method has an initialValue argument.
-
-If an initialValue is provided to the reduce method:
-
--   The previousValue argument is initialValue.
--   The currentValue argument is the value of the first element present in the array.
-
-If an initialValue is not provided:
-
--   The previousValue argument is the value of the first element present in the array.
--   The currentValue argument is the value of the second element present in the array.
+Callback for featureEach
 
 **Parameters**
 
--   `previousValue` **Any** The accumulated value previously returned in the last invocation
-    of the callback, or initialValue, if supplied.
--   `currentProperties` **Any** The current properties being processed.
+-   `currentFeature` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;any>** The current feature being processed.
 -   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The index of the current element being processed in the
     array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
 -   `geojson`  
+-   `options`  
 -   `callback`  
--   `initialValue`  
 
 # featureEach
 
@@ -204,6 +217,8 @@ Array.forEach.
 **Parameters**
 
 -   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Extra options, if not provided, this param defaults as callback.
+    -   `options.allowNull` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** exclude or include null geometries from callback (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentFeature, featureIndex)
 
 **Examples**
@@ -219,18 +234,6 @@ turf.featureEach(features, function (currentFeature, featureIndex) {
   //=featureIndex
 });
 ```
-
-# featureEachCallback
-
-Callback for featureEach
-
-**Parameters**
-
--   `currentFeature` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;any>** The current feature being processed.
--   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The index of the current element being processed in the
-    array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
--   `geojson`  
--   `callback`  
 
 # featureReduceCallback
 
@@ -257,6 +260,7 @@ If an initialValue is not provided:
 -   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The index of the current element being processed in the
     array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
 -   `geojson`  
+-   `options`  
 -   `callback`  
 -   `initialValue`  
 
@@ -267,6 +271,8 @@ Reduce features in any GeoJSON object, similar to Array.reduce().
 **Parameters**
 
 -   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Extra options, if not provided, this param defaults as callback.
+    -   `options.allowNull` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** exclude or include null geometries from callback (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentFeature, featureIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
@@ -321,6 +327,7 @@ Callback for geomEach
     array. Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
 -   `currentProperties` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The current feature properties being processed.
 -   `geojson`  
+-   `options`  
 -   `callback`  
 
 # geomEach
@@ -330,6 +337,8 @@ Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
 **Parameters**
 
 -   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Extra options, if not provided, this param defaults as callback.
+    -   `options.allowNull` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** exclude or include null geometries from callback (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentGeometry, featureIndex, currentProperties)
 
 **Examples**
@@ -373,6 +382,7 @@ If an initialValue is not provided:
     array.Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
 -   `currentProperties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The current feature properties being processed.
 -   `geojson`  
+-   `options`  
 -   `callback`  
 -   `initialValue`  
 
@@ -383,6 +393,8 @@ Reduce geometry in any GeoJSON object, similar to Array.reduce().
 **Parameters**
 
 -   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Extra options, if not provided, this param defaults as callback.
+    -   `options.allowNull` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** exclude or include null geometries from callback (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentGeometry, featureIndex, currentProperties)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 
@@ -417,6 +429,7 @@ Callback for flattenEach
 -   `featureSubIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The subindex of the current element being processed in the
     array. Starts at index 0 and increases if the flattened feature was a multi-geometry.
 -   `geojson`  
+-   `options`  
 -   `callback`  
 
 # flattenEach
@@ -427,6 +440,8 @@ Array.forEach.
 **Parameters**
 
 -   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Extra options, if not provided, this param defaults as callback.
+    -   `options.allowNull` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** exclude or include null geometries from callback (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (currentFeature, featureIndex, featureSubIndex)
 
 **Examples**
@@ -471,6 +486,7 @@ If an initialValue is not provided:
 -   `featureSubIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The subindex of the current element being processed in the
     array. Starts at index 0 and increases if the flattened feature was a multi-geometry.
 -   `geojson`  
+-   `options`  
 -   `callback`  
 -   `initialValue`  
 
@@ -481,6 +497,8 @@ Reduce flattened features in any GeoJSON object, similar to Array.reduce().
 **Parameters**
 
 -   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Extra options, if not provided, this param defaults as callback.
+    -   `options.allowNull` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** exclude or include null geometries from callback (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** a method that takes (previousValue, currentFeature, featureIndex, featureSubIndex)
 -   `initialValue` **\[Any]** Value to use as the first argument to the first call of the callback.
 

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -45,7 +45,7 @@ export function coordEach(
  * http://turfjs.org/docs/#propeach
  */
 export function propEach<Props extends any>(
-  geojson: Feature<any> | Features<any>,
+  geojson: Feature<any> | FeatureCollection<any>,
   callback: (currentProperties: Props, featureIndex: number) => void
 ): void;
 
@@ -53,7 +53,7 @@ export function propEach<Props extends any>(
  * http://turfjs.org/docs/#propreduce
  */
 export function propReduce<Reducer extends any, Props extends any>(
-  geojson: Feature<any> | Features<any>,
+  geojson: Feature<any> | FeatureCollection<any>,
   callback: (previousValue: Reducer, currentProperties: Props, featureIndex: number) => Reducer,
   initialValue?: Reducer
 ): Reducer;
@@ -151,7 +151,7 @@ export function flattenEach<Geom extends GeometryObject>(
  * http://turfjs.org/docs/#segmentreduce
  */
 export function segmentReduce<Reducer extends any>(
-  geojson: Feature<any> | Features<any> | GeometryObject | FeatureGeometryCollection,
+  geojson: Feature<any> | FeatureCollection<any> | GeometryObject | FeatureGeometryCollection,
   callback: (previousValue?: Reducer, currentSegment?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number) => Reducer,
   initialValue?: Reducer
 ): Reducer;
@@ -160,7 +160,7 @@ export function segmentReduce<Reducer extends any>(
  * http://turfjs.org/docs/#segmenteach
  */
 export function segmentEach(
-  geojson: Feature<any> | Features<any> | GeometryObject | FeatureGeometryCollection,
+  geojson: Feature<any> | FeatureCollection<any> | GeometryObject | FeatureGeometryCollection,
   allback: (currentSegment?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number) => void
 ): void;
 

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -6,13 +6,23 @@ export type Polygon = GeoJSON.Polygon;
 export type MultiPoint = GeoJSON.MultiPoint;
 export type MultiLineString = GeoJSON.MultiLineString;
 export type MultiPolygon = GeoJSON.MultiPolygon;
-export type Features<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
+export type FeatureCollection<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
 export type Feature<Geom extends GeometryObject> = GeoJSON.Feature<Geom>;
 export type GeometryObject = GeoJSON.GeometryObject;
 export type GeometryCollection = GeoJSON.GeometryCollection;
 export type Geoms = Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon;
 export type Lines = LineString | Polygon | MultiLineString | MultiPolygon;
-export type AllGeoJSON = Feature<any> | Features<any> | GeometryObject | GeometryCollection;
+export type AllGeoJSON = Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection;
+export interface FeatureGeometryCollection extends GeoJSON.Feature<any> {
+  geometry: GeometryCollection
+}
+
+interface MetaOptions {
+  /**
+   * exclude or include null geometries from callback
+   */
+  allowNull?: boolean
+}
 
 /**
  * http://turfjs.org/docs/#coordreduce
@@ -52,7 +62,13 @@ export function propReduce<Reducer extends any, Props extends any>(
  * http://turfjs.org/docs/#featurereduce
  */
 export function featureReduce<Reducer extends any, Geom extends GeometryObject>(
-  geojson: Feature<Geom> | Features<Geom>,
+  geojson: Feature<Geom> | FeatureCollection<Geom> | FeatureGeometryCollection,
+  callback: (previousValue: Reducer, currentFeature: Feature<Geom>, featureIndex: number) => Reducer,
+  initialValue?: Reducer
+): Reducer;
+export function featureReduce<Reducer extends any, Geom extends GeometryObject>(
+  geojson: Feature<Geom> | FeatureCollection<Geom> | FeatureGeometryCollection,
+  options: MetaOptions,
   callback: (previousValue: Reducer, currentFeature: Feature<Geom>, featureIndex: number) => Reducer,
   initialValue?: Reducer
 ): Reducer;
@@ -61,7 +77,12 @@ export function featureReduce<Reducer extends any, Geom extends GeometryObject>(
  * http://turfjs.org/docs/#featureeach
  */
 export function featureEach<Geom extends GeometryObject>(
-  geojson: Feature<Geom> | Features<Geom>,
+  geojson: Feature<Geom> | FeatureCollection<Geom> | FeatureGeometryCollection,
+  callback: (currentFeature: Feature<Geom>, featureIndex: number) => void
+): void;
+export function featureEach<Geom extends GeometryObject>(
+  geojson: Feature<Geom> | FeatureCollection<Geom> | FeatureGeometryCollection,
+  options: MetaOptions,
   callback: (currentFeature: Feature<Geom>, featureIndex: number) => void
 ): void;
 
@@ -74,7 +95,13 @@ export function coordAll(geojson: AllGeoJSON): number[][];
  * http://turfjs.org/docs/#geomreduce
  */
 export function geomReduce<Reducer extends any, Geom extends GeometryObject>(
-  geojson: Feature<Geom> | Features<Geom> | Geom | GeometryCollection,
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  callback: (previousValue: Reducer, currentGeometry: Geom, featureIndex: number, currentProperties: any) => Reducer,
+  initialValue?: Reducer
+): Reducer;
+export function geomReduce<Reducer extends any, Geom extends GeometryObject>(
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  options: MetaOptions,
   callback: (previousValue: Reducer, currentGeometry: Geom, featureIndex: number, currentProperties: any) => Reducer,
   initialValue?: Reducer
 ): Reducer;
@@ -83,7 +110,12 @@ export function geomReduce<Reducer extends any, Geom extends GeometryObject>(
  * http://turfjs.org/docs/#geomeach
  */
 export function geomEach<Geom extends GeometryObject>(
-  geojson: Feature<Geom> | Features<Geom> | Geom | GeometryCollection,
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  callback: (currentGeometry: Geom, featureIndex: number, currentProperties: any) => void
+): void;
+export function geomEach<Geom extends GeometryObject>(
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  options: MetaOptions,
   callback: (currentGeometry: Geom, featureIndex: number, currentProperties: any) => void
 ): void;
 
@@ -91,7 +123,13 @@ export function geomEach<Geom extends GeometryObject>(
  * http://turfjs.org/docs/#flattenreduce
  */
 export function flattenReduce<Reducer extends any, Geom extends GeometryObject>(
-  geojson: Feature<Geom> | Features<Geom> | Geom | GeometryCollection,
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  callback: (previousValue: Reducer, currentFeature: Feature<Geom>, featureIndex: number, featureSubIndex: number) => Reducer,
+  initialValue?: Reducer
+): Reducer;
+export function flattenReduce<Reducer extends any, Geom extends GeometryObject>(
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  options: MetaOptions,
   callback: (previousValue: Reducer, currentFeature: Feature<Geom>, featureIndex: number, featureSubIndex: number) => Reducer,
   initialValue?: Reducer
 ): Reducer;
@@ -100,7 +138,12 @@ export function flattenReduce<Reducer extends any, Geom extends GeometryObject>(
  * http://turfjs.org/docs/#flatteneach
  */
 export function flattenEach<Geom extends GeometryObject>(
-  geojson: Feature<Geom> | Features<Geom> | Geom | GeometryCollection,
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  callback: (currentFeature: Feature<Geom>, featureIndex: number, featureSubIndex: number) => void
+): void;
+export function flattenEach<Geom extends GeometryObject>(
+  geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | FeatureGeometryCollection,
+  options: MetaOptions,
   callback: (currentFeature: Feature<Geom>, featureIndex: number, featureSubIndex: number) => void
 ): void;
 
@@ -108,7 +151,7 @@ export function flattenEach<Geom extends GeometryObject>(
  * http://turfjs.org/docs/#segmentreduce
  */
 export function segmentReduce<Reducer extends any>(
-  geojson: Feature<any> | Features<any> | GeometryObject | GeometryCollection,
+  geojson: Feature<any> | Features<any> | GeometryObject | FeatureGeometryCollection,
   callback: (previousValue?: Reducer, currentSegment?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number) => Reducer,
   initialValue?: Reducer
 ): Reducer;
@@ -117,7 +160,7 @@ export function segmentReduce<Reducer extends any>(
  * http://turfjs.org/docs/#segmenteach
  */
 export function segmentEach(
-  geojson: Feature<any> | Features<any> | GeometryObject | GeometryCollection,
+  geojson: Feature<any> | Features<any> | GeometryObject | FeatureGeometryCollection,
   allback: (currentSegment?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number) => void
 ): void;
 

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -417,16 +417,22 @@ test('null geometries', t => {
     ]);
 
     // Each operations
-    meta.featureEach(fc, feature => t.equal(feature.geometry, null, 'featureEach'));
-    meta.geomEach(fc, geometry => t.equal(geometry, null), 'geomEach');
-    meta.flattenEach(fc, feature => t.equal(feature.geometry, null, 'flattenEach'));
+    meta.featureEach(fc, () => t.fail('no features should be found -- featureEach'));
+    meta.geomEach(fc, () => t.fail('no features should be found -- geomEach'));
+    meta.flattenEach(fc, () => t.fail('no features should be found -- flattenEach'));
     meta.coordEach(fc, () => t.fail('no coordinates should be found'));
+
+    // Allow Null
+    meta.featureEach(fc, {allowNull: true}, feature => t.equal(feature.geometry, null, 'featureEach'));
+    meta.geomEach(fc, {allowNull: true}, geometry => t.equal(geometry, null), 'geomEach');
+    meta.flattenEach(fc, {allowNull: true}, feature => t.equal(feature.geometry, null, 'flattenEach'));
+    meta.coordEach(fc, {allowNull: true}, () => t.fail('no coordinates should be found'));
 
     // Reduce operations
     /* eslint-disable no-return-assign */
-    t.equal(meta.featureReduce(fc, prev => prev += 1, 0), 2, 'featureReduce');
-    t.equal(meta.geomReduce(fc, prev => prev += 1, 0), 2, 'geomReduce');
-    t.equal(meta.flattenReduce(fc, prev => prev += 1, 0), 2, 'flattenReduce');
+    t.equal(meta.featureReduce(fc, prev => prev += 1, 0), 0, 'featureReduce');
+    t.equal(meta.geomReduce(fc, prev => prev += 1, 0), 0, 'geomReduce');
+    t.equal(meta.flattenReduce(fc, prev => prev += 1, 0), 0, 'flattenReduce');
     t.equal(meta.coordReduce(fc, prev => prev += 1, 0), 0, 'coordReduce');
     /* eslint-enable no-return-assign */
     t.end();
@@ -440,8 +446,8 @@ test('null geometries -- index', t => {
         lineString([[1, 1], [0, 0]]) // index 3
     ]);
     t.deepEqual(meta.coordReduce(fc, (prev, coords, coordIndex) => prev.concat(coordIndex), []), [0, 1, 2], 'coordReduce');
-    t.deepEqual(meta.geomReduce(fc, (prev, geom, featureIndex) => prev.concat(featureIndex), []), [0, 1, 2, 3], 'geomReduce');
-    t.deepEqual(meta.flattenReduce(fc, (prev, feature, featureIndex) => prev.concat(featureIndex), []), [0, 1, 2, 3], 'flattenReduce');
+    t.deepEqual(meta.geomReduce(fc, (prev, geom, featureIndex) => prev.concat(featureIndex), []), [1, 3], 'geomReduce');
+    t.deepEqual(meta.flattenReduce(fc, (prev, feature, featureIndex) => prev.concat(featureIndex), []), [1, 3], 'flattenReduce');
     t.end();
 });
 

--- a/packages/turf-meta/types.ts
+++ b/packages/turf-meta/types.ts
@@ -59,14 +59,16 @@ function featureReduce() {
     meta.featureReduce(poly, (previous, feature) => 1 + 1, 0)
     meta.featureReduce(features, (previous, feature) => feature)
     meta.featureReduce(poly, (previous, feature, index) => feature)
-    // meta.featureReduce(geomCollection, (previous, feature, index) => feature)
+    meta.featureReduce(poly, {allowNull: true}, (previous, feature, index) => feature)
+    meta.featureReduce(geomCollection, (previous, feature, index) => feature)
 }
 
 function featureEach() {
     const value: void = meta.featureEach(poly, feature => feature)
     meta.featureEach(features, feature => feature)
     meta.featureEach(poly, (feature, index) => feature)
-    // meta.featureEach(geomCollection, (feature, index) => feature)
+    meta.featureEach(poly, {allowNull: true}, (feature, index) => feature)
+    meta.featureEach(geomCollection, (feature, index) => feature)
 }
 
 function geomReduce() {
@@ -74,14 +76,16 @@ function geomReduce() {
     meta.geomReduce(poly, (previous, geom) => 1 + 1, 0)
     meta.geomReduce(features, (previous, geom) => geom)
     meta.geomReduce(poly, (previous, geom, index, props) => geom)
-    // meta.geomReduce(geomCollection, (previous, geom, index, props) => geom)
+    meta.geomReduce(poly, {allowNull: true}, (previous, geom, index, props) => geom)
+    meta.geomReduce(geomCollection, (previous, geom, index, props) => geom)
 }
 
 function geomEach() {
     const value: void = meta.geomEach(poly, geom => geom)
     meta.geomEach(features, geom => geom)
     meta.geomEach(poly, (geom, index, props) => geom)
-    // meta.geomEach(geomCollection, (geom, index, props) => geom)
+    meta.geomEach(poly, {allowNull: true}, (geom, index, props) => geom)
+    meta.geomEach(geomCollection, (geom, index, props) => geom)
 }
 
 function flattenReduce() {
@@ -89,14 +93,16 @@ function flattenReduce() {
     meta.flattenReduce(poly, (previous, feature) => 1 + 1, 0)
     meta.flattenReduce(features, (previous, feature) => feature)
     meta.flattenReduce(poly, (previous, feature, index, props) => feature)
-    // meta.flattenReduce(geomCollection, (previous, feature, index, props) => feature)
+    meta.flattenReduce(poly, {allowNull: true}, (previous, feature, index, props) => feature)
+    meta.flattenReduce(geomCollection, (previous, feature, index, props) => feature)
 }
 
 function flattenEach() {
     const value: void = meta.flattenEach(poly, feature => feature)
     meta.flattenEach(features, feature => feature)
     meta.flattenEach(poly.geometry, (feature, index, props) => feature)
-    // meta.flattenEach(geomCollection, (feature, index, props) => feature)
+    meta.flattenEach(poly.geometry, {allowNull: true}, (feature, index, props) => feature)
+    meta.flattenEach(geomCollection, (feature, index, props) => feature)
 }
 
 function segmentReduce() {

--- a/packages/turf-meta/yarn.lock
+++ b/packages/turf-meta/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@turf/helpers@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.7.3.tgz#bc312ac43cab3c532a483151c4c382c5649429e9"
+
+"@turf/random@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/random/-/random-4.7.3.tgz#0a8a3b84a1f15b8916d4dce43566beb2e2bda522"
+  dependencies:
+    geojson-random "^0.2.2"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -73,6 +83,10 @@ fs.realpath@^1.0.0:
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
+geojson-random@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/geojson-random/-/geojson-random-0.2.2.tgz#ab4838f126adc5e16f8f94e655def820f9119dbc"
 
 glob@~7.1.2:
   version "7.1.2"


### PR DESCRIPTION
Implements: #946
Ref Issues: #940 

## JS Example

```js
var features = turf.featureCollection([
  turf.point([26, 37], {foo: 'bar'}),
  turf.point([36, 53], {hello: 'world'}),
  turf.feature(null)
]);

turf.featureEach(features, {allowNull: false}, feature => {
  // Callbacks 2 features
});

turf.featureEach(features, {allowNull: true}, feature => {
  // Callbacks 3 features
});

// Backwards compatible with TurfJS v4.0
// allowNull defaults to `false`
// most common errors in TurfJS are related to null geometries being contained in FeatureCollections
turf.featureEach(features, feature => {
  // Callbacks 2 features
});
```

## Up for debate

`allowNull` currently defaults to `false`, there could be an argument to set this default as `true`. My personal preference is `allowNull=false`.