### PR TITLE
Add tests for missing modules in @turf/turf

### DIFF
--- a/packages/turf-clusters/index.js
+++ b/packages/turf-clusters/index.js
@@ -1,5 +1,8 @@
 var featureEach = require('@turf/meta').featureEach;
 var featureCollection = require('@turf/helpers').featureCollection;
+var utils = require('./utils');
+var applyFilter = utils.applyFilter;
+var createBins = utils.createBins;
 
 /**
  * Get Cluster
@@ -186,114 +189,8 @@ function clusterReduce(geojson, property, callback, initialValue) {
     return previousValue;
 }
 
-/**
- * Create Bins
- *
- * @private
- * @param {FeatureCollection} geojson GeoJSON Features
- * @param {string|number} property Property values are used to create bins
- * @returns {Object} bins with Feature IDs
- * @example
- * const geojson = turf.featureCollection([
- *     turf.point([0, 0], {cluster: 0, foo: 'null'}),
- *     turf.point([2, 4], {cluster: 1, foo: 'bar'}),
- *     turf.point([5, 1], {0: 'foo'}),
- *     turf.point([3, 6], {cluster: 1}),
- * ]);
- * createBins(geojson, 'cluster');
- * //= { '0': [ 0 ], '1': [ 1, 3 ] }
- */
-function createBins(geojson, property) {
-    var bins = {};
-
-    featureEach(geojson, function (feature, i) {
-        var properties = feature.properties || {};
-        if (properties.hasOwnProperty(property)) {
-            var value = properties[property];
-            if (bins.hasOwnProperty(value)) bins[value].push(i);
-            else bins[value] = [i];
-        }
-    });
-    return bins;
-}
-
-/**
- * Apply Filter
- *
- * @private
- * @param {*} properties Properties
- * @param {*} filter Filter
- * @returns {Boolean} applied Filter to properties
- */
-function applyFilter(properties, filter) {
-    if (properties === undefined) return false;
-    var filterType = typeof filter;
-
-    // String & Number
-    if (filterType === 'number' || filterType === 'string') return properties.hasOwnProperty(filter);
-    // Array
-    else if (Array.isArray(filter)) {
-        for (var i = 0; i < filter.length; i++) {
-            if (!applyFilter(properties, filter[i])) return false;
-        }
-        return true;
-    // Object
-    } else {
-        return propertiesContainsFilter(properties, filter);
-    }
-}
-
-/**
- * Properties contains filter (does not apply deepEqual operations)
- *
- * @private
- * @param {*} properties Properties
- * @param {Object} filter Filter
- * @returns {Boolean} does filter equal Properties
- * @example
- * propertiesContainsFilter({foo: 'bar', cluster: 0}, {cluster: 0})
- * //= true
- * propertiesContainsFilter({foo: 'bar', cluster: 0}, {cluster: 1})
- * //= false
- */
-function propertiesContainsFilter(properties, filter) {
-    var keys = Object.keys(filter);
-    for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
-        if (properties[key] !== filter[key]) return false;
-    }
-    return true;
-}
-
-/**
- * Filter Properties
- *
- * @private
- * @param {*} properties Properties
- * @param {string[]} keys Used to filter Properties
- * @returns {*} filtered Properties
- * @example
- * filterProperties({foo: 'bar', cluster: 0}, ['cluster'])
- * //= {cluster: 0}
- */
-function filterProperties(properties, keys) {
-    if (!keys) return {};
-    if (!keys.length) return {};
-
-    var newProperties = {};
-    for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
-        if (properties.hasOwnProperty(key)) newProperties[key] = properties[key];
-    }
-    return newProperties;
-}
-
 module.exports = {
     getCluster: getCluster,
     clusterEach: clusterEach,
-    clusterReduce: clusterReduce,
-    createBins: createBins, // Not exposed in @turf/turf - Internal purposes only
-    applyFilter: applyFilter, // Not exposed in @turf/turf - Internal purposes only
-    propertiesContainsFilter: propertiesContainsFilter, // Not exposed in @turf/turf - Internal purposes only
-    filterProperties: filterProperties // Not exposed in @turf/turf - Internal purposes only
+    clusterReduce: clusterReduce
 };

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "utils.js"
   ],
   "scripts": {
     "test": "node test.js",

--- a/packages/turf-clusters/test.js
+++ b/packages/turf-clusters/test.js
@@ -1,7 +1,14 @@
 const test = require('tape');
 const {featureCollection, point} = require('@turf/helpers');
-const {propertiesContainsFilter, filterProperties, applyFilter, createBins} = require('./'); // Testing Purposes
-const {getCluster, clusterEach, clusterReduce} = require('./');
+const {
+    propertiesContainsFilter,
+    filterProperties,
+    applyFilter,
+    createBins} = require('./utils');
+const {
+    getCluster,
+    clusterEach,
+    clusterReduce} = require('./');
 
 const properties = {foo: 'bar', cluster: 0};
 const geojson = featureCollection([
@@ -51,8 +58,7 @@ test('clusters -- clusterReduce', t => {
     t.end();
 });
 
-// Internal purposes only
-test('clusters -- applyFilter', t => {
+test('clusters.utils -- applyFilter', t => {
     t.true(applyFilter(properties, 'cluster'));
     t.true(applyFilter(properties, ['cluster']));
     t.false(applyFilter(properties, {cluster: 1}));
@@ -61,24 +67,21 @@ test('clusters -- applyFilter', t => {
     t.end();
 });
 
-// Internal purposes only
-test('clusters -- filterProperties', t => {
+test('clusters.utils -- filterProperties', t => {
     t.deepEqual(filterProperties(properties, ['cluster']), {cluster: 0});
     t.deepEqual(filterProperties(properties, []), {});
     t.deepEqual(filterProperties(properties, undefined), {});
     t.end();
 });
 
-// Internal purposes only
-test('clusters -- propertiesContainsFilter', t => {
+test('clusters.utils -- propertiesContainsFilter', t => {
     t.deepEqual(propertiesContainsFilter(properties, {cluster: 0}), true);
     t.deepEqual(propertiesContainsFilter(properties, {cluster: 1}), false);
     t.deepEqual(propertiesContainsFilter(properties, {bar: 'foo'}), false);
     t.end();
 });
 
-// Internal purposes only
-test('clusters -- propertiesContainsFilter', t => {
+test('clusters.utils -- propertiesContainsFilter', t => {
     t.deepEqual(createBins(geojson, 'cluster'), {'0': [0], '1': [1, 2]});
     t.end();
 });

--- a/packages/turf-clusters/utils.js
+++ b/packages/turf-clusters/utils.js
@@ -1,0 +1,110 @@
+var featureEach = require('@turf/meta').featureEach;
+
+/**
+ * Create Bins
+ *
+ * @private
+ * @param {FeatureCollection} geojson GeoJSON Features
+ * @param {string|number} property Property values are used to create bins
+ * @returns {Object} bins with Feature IDs
+ * @example
+ * const geojson = turf.featureCollection([
+ *     turf.point([0, 0], {cluster: 0, foo: 'null'}),
+ *     turf.point([2, 4], {cluster: 1, foo: 'bar'}),
+ *     turf.point([5, 1], {0: 'foo'}),
+ *     turf.point([3, 6], {cluster: 1}),
+ * ]);
+ * createBins(geojson, 'cluster');
+ * //= { '0': [ 0 ], '1': [ 1, 3 ] }
+ */
+function createBins(geojson, property) {
+    var bins = {};
+
+    featureEach(geojson, function (feature, i) {
+        var properties = feature.properties || {};
+        if (properties.hasOwnProperty(property)) {
+            var value = properties[property];
+            if (bins.hasOwnProperty(value)) bins[value].push(i);
+            else bins[value] = [i];
+        }
+    });
+    return bins;
+}
+
+/**
+* Apply Filter
+*
+* @private
+* @param {*} properties Properties
+* @param {*} filter Filter
+* @returns {Boolean} applied Filter to properties
+*/
+function applyFilter(properties, filter) {
+    if (properties === undefined) return false;
+    var filterType = typeof filter;
+
+    // String & Number
+    if (filterType === 'number' || filterType === 'string') return properties.hasOwnProperty(filter);
+    // Array
+    else if (Array.isArray(filter)) {
+        for (var i = 0; i < filter.length; i++) {
+            if (!applyFilter(properties, filter[i])) return false;
+        }
+        return true;
+    // Object
+    } else {
+        return propertiesContainsFilter(properties, filter);
+    }
+}
+
+/**
+* Properties contains filter (does not apply deepEqual operations)
+*
+* @private
+* @param {*} properties Properties
+* @param {Object} filter Filter
+* @returns {Boolean} does filter equal Properties
+* @example
+* propertiesContainsFilter({foo: 'bar', cluster: 0}, {cluster: 0})
+* //= true
+* propertiesContainsFilter({foo: 'bar', cluster: 0}, {cluster: 1})
+* //= false
+*/
+function propertiesContainsFilter(properties, filter) {
+    var keys = Object.keys(filter);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (properties[key] !== filter[key]) return false;
+    }
+    return true;
+}
+
+/**
+* Filter Properties
+*
+* @private
+* @param {*} properties Properties
+* @param {string[]} keys Used to filter Properties
+* @returns {*} filtered Properties
+* @example
+* filterProperties({foo: 'bar', cluster: 0}, ['cluster'])
+* //= {cluster: 0}
+*/
+function filterProperties(properties, keys) {
+    if (!keys) return {};
+    if (!keys.length) return {};
+
+    var newProperties = {};
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (properties.hasOwnProperty(key)) newProperties[key] = properties[key];
+    }
+    return newProperties;
+}
+
+module.exports = {
+    createBins: createBins,
+    applyFilter: applyFilter,
+    propertiesContainsFilter: propertiesContainsFilter,
+    filterProperties: filterProperties
+};

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -49,6 +49,17 @@ import {
     lineEach, // v4.7.0
     lineReduce // v4.7.0
 } from '@turf/meta';
+import * as clusters from '@turf/clusters'; // v4.6.0
+import {
+    clusterEach,
+    clusterReduce,
+    getCluster
+} from '@turf/clusters'; // v4.6.0
+import * as projection from '@turf/projection'; // v4.7.0
+import {
+    toMercator,
+    toWgs84
+} from '@turf/projection'; // v4.7.0
 import * as isolines from '@turf/isolines';
 import * as convex from '@turf/convex';
 import * as within from '@turf/within';
@@ -134,6 +145,11 @@ import * as cleanCoords from '@turf/clean-coords';
 import * as pointToLineDistance from '@turf/point-to-line-distance'; // v4.7.0
 import * as booleanParallel from '@turf/boolean-parallel'; // v4.8.0
 import * as nearestPointToLine from '@turf/nearest-point-to-line'; // v4.8.0
+import * as clustersDbscan from '@turf/clusters-dbscan'; // v4.6.0
+import * as clustersKmeans from '@turf/clusters-kmeans'; // v4.6.0
+import * as interpolate from '@turf/interpolate'; // v4.6.0
+import * as booleanPointOnLine from '@turf/boolean-point-on-line' // v4.6.0
+import * as booleanOverlap from '@turf/boolean-overlap' // v4.6.0
 export {
     isolines,
     convex,
@@ -256,7 +272,7 @@ export {
     clone,
     segmentEach,
     segmentReduce,
-    cleanCoords,
+    cleanCoords, // v4.6.0
     isNumber,
     pointToLineDistance, // v4.7.0
     helpers,
@@ -266,5 +282,17 @@ export {
     lineReduce, // v4.7.0
     getType, // v4.8.0
     booleanParallel, // v4.8.0
-    nearestPointToLine // v4.8.0
+    nearestPointToLine, // v4.8.0
+    clusters, // v4.6.0
+    clustersDbscan, // v4.6.0
+    clustersKmeans, // v4.6.0
+    clusterEach, // v4.6.0
+    clusterReduce, // v4.6.0
+    getCluster, // v4.6.0
+    interpolate, // v4.6.0
+    booleanPointOnLine, // v4.6.0
+    booleanOverlap, // v4.6.0
+    projection, // v4.7.0
+    toMercator, // v4.7.0
+    toWgs84 // v4.7.0
 };

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -11,6 +11,7 @@ var helpers = require('@turf/helpers');
 var invariant = require('@turf/invariant');
 var meta = require('@turf/meta');
 var clusters = require('@turf/clusters');
+var projection = require('@turf/projection'); // v4.7.0
 
 var turf = {
     isolines: require('@turf/isolines'),
@@ -103,9 +104,14 @@ var turf = {
     pointToLineDistance: require('@turf/point-to-line-distance'), // v4.7.0
     booleanParallel: require('@turf/boolean-parallel'), // v4.8.0
     nearestPointToLine: require('@turf/nearest-point-to-line'), // v4.8.0
+    projection: projection, // v4.7.0
+    toMercator: projection.toMercator, // v4.7.0
+    toWgs84: projection.toWgs84, // v4.7.0
+    clusters: clusters, // v4.6.0
     getCluster: clusters.getCluster, // v4.6.0
     clusterEach: clusters.clusterEach, // v4.6.0
     clusterReduce: clusters.clusterReduce, // v4.6.0
+    helpers: helpers,
     point: helpers.point,
     polygon: helpers.polygon,
     lineString: helpers.lineString,
@@ -126,6 +132,7 @@ var turf = {
     isNumber: helpers.isNumber, // 4.7.0
     round: helpers.round,
     convertArea: helpers.convertArea,
+    invariant: invariant,
     getCoord: invariant.getCoord,
     getCoords: invariant.getCoords,
     geojsonType: invariant.geojsonType,
@@ -135,6 +142,7 @@ var turf = {
     getType: invariant.getType, // v4.8.0
     getGeom: invariant.getGeom,
     getGeomType: invariant.getGeomType,
+    meta: meta,
     coordEach: meta.coordEach,
     coordReduce: meta.coordReduce,
     propEach: meta.propEach,

--- a/packages/turf/module.js
+++ b/packages/turf/module.js
@@ -49,6 +49,17 @@ import {
     lineEach, // v4.7.0
     lineReduce // v4.7.0
 } from '@turf/meta';
+import * as clusters from '@turf/clusters'; // v4.6.0
+import {
+    clusterEach,
+    clusterReduce,
+    getCluster
+} from '@turf/clusters'; // v4.6.0
+import * as projection from '@turf/projection'; // v4.7.0
+import {
+    toMercator,
+    toWgs84
+} from '@turf/projection'; // v4.7.0
 import * as isolines from '@turf/isolines';
 import * as convex from '@turf/convex';
 import * as within from '@turf/within';
@@ -134,6 +145,11 @@ import * as cleanCoords from '@turf/clean-coords';
 import * as pointToLineDistance from '@turf/point-to-line-distance'; // v4.7.0
 import * as booleanParallel from '@turf/boolean-parallel'; // v4.8.0
 import * as nearestPointToLine from '@turf/nearest-point-to-line'; // v4.8.0
+import * as clustersDbscan from '@turf/clusters-dbscan'; // v4.6.0
+import * as clustersKmeans from '@turf/clusters-kmeans'; // v4.6.0
+import * as interpolate from '@turf/interpolate'; // v4.6.0
+import * as booleanPointOnLine from '@turf/boolean-point-on-line' // v4.6.0
+import * as booleanOverlap from '@turf/boolean-overlap' // v4.6.0
 export {
     isolines,
     convex,
@@ -256,7 +272,7 @@ export {
     clone,
     segmentEach,
     segmentReduce,
-    cleanCoords,
+    cleanCoords, // v4.6.0
     isNumber,
     pointToLineDistance, // v4.7.0
     helpers,
@@ -266,5 +282,17 @@ export {
     lineReduce, // v4.7.0
     getType, // v4.8.0
     booleanParallel, // v4.8.0
-    nearestPointToLine // v4.8.0
+    nearestPointToLine, // v4.8.0
+    clusters, // v4.6.0
+    clustersDbscan, // v4.6.0
+    clustersKmeans, // v4.6.0
+    clusterEach, // v4.6.0
+    clusterReduce, // v4.6.0
+    getCluster, // v4.6.0
+    interpolate, // v4.6.0
+    booleanPointOnLine, // v4.6.0
+    booleanOverlap, // v4.6.0
+    projection, // v4.7.0
+    toMercator, // v4.7.0
+    toWgs84 // v4.7.0
 };

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -128,6 +128,7 @@
     "@turf/polygon-tangents": "^4.7.3",
     "@turf/polygon-to-linestring": "^4.7.3",
     "@turf/polygonize": "^4.7.3",
+    "@turf/projection": "^4.7.3",
     "@turf/random": "^4.7.3",
     "@turf/rewind": "^4.7.3",
     "@turf/rhumb-bearing": "^4.7.3",
@@ -152,6 +153,7 @@
   },
   "devDependencies": {
     "browserify": "~9.0.3",
+    "camelcase": "^4.1.0",
     "disc": "^1.3.2",
     "documentation": "^4.0.0-rc.1",
     "glob": "^7.1.2",

--- a/packages/turf/yarn.lock
+++ b/packages/turf/yarn.lock
@@ -703,6 +703,13 @@
   dependencies:
     polygonize "1.0.1"
 
+"@turf/projection@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-4.7.3.tgz#c3e45745d89371ee720e43add56f08850e90694a"
+  dependencies:
+    "@turf/clone" "^4.7.3"
+    "@turf/meta" "^4.7.3"
+
 "@turf/random@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/random/-/random-4.7.3.tgz#0a8a3b84a1f15b8916d4dce43566beb2e2bda522"


### PR DESCRIPTION
## Add tests for missing modules published to `@turf/turf`

Ref: https://github.com/Turfjs/turf/issues/945#issuecomment-330129662

These tests only get conducted once the module is added to the `packages/turf/package.json`, modules which are still in active development fall under these tests.

Test can be found here: https://github.com/Turfjs/turf/blob/00cc41ff1445d9ddf8149cbda87492a3f8a4f918/packages/turf/test.js#L185-L214

## To-Do

- [x] Added `@turf/projection`
- [x] Added `@turf/clusters`
- [x] Added other missing modules (clustersDbscan, clustersKmeans, interpolate,, booleanPointOnLine, booleanOverlap)
- [x] Removed exposed `utils` methods from main `@turf/clusters` module.export