### PR TITLE
Fix segmentReduce & segmentEach `@turf/meta`

### DIFF
--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -510,9 +510,9 @@ Callback for segmentEach
 **Parameters**
 
 -   `currentSegment` **[Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;[LineString](http://geojson.org/geojson-spec.html#linestring)>** The current segment being processed.
--   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The index of the current element being processed in the array, starts at index 0.
--   `featureSubIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The subindex of the current element being processed in the
-    array. Starts at index 0 and increases for each iterating line segment.
+-   `segmentIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The segmentIndex currently being processed, starts at index 0.
+-   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The featureIndex currently being processed, starts at index 0.
+-   `featureSubIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The featureSubIndex currently being processed, starts at index 0.
 -   `geojson`  
 -   `callback`  
 
@@ -536,6 +536,7 @@ var polygon = turf.polygon([[[-50, 5], [-40, -10], [-50, -10], [-40, 5], [-50, 5
 // Iterate over GeoJSON by 2-vertex segments
 turf.segmentEach(polygon, function (currentSegment, featureIndex, featureSubIndex) {
   //= currentSegment
+  //= segmentIndex
   //= featureIndex
   //= featureSubIndex
 });
@@ -571,10 +572,9 @@ If an initialValue is not provided:
 -   `previousValue` **\[Any]** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
 -   `currentSegment` **\[[Feature](http://geojson.org/geojson-spec.html#feature-objects)&lt;[LineString](http://geojson.org/geojson-spec.html#linestring)>]** The current segment being processed.
--   `currentIndex` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** The index of the current element being processed in the
-    array. Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
--   `currentSubIndex` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** The subindex of the current element being processed in the
-    array. Starts at index 0 and increases for each iterating line segment.
+-   `segmentIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The segmentIndex currently being processed, starts at index 0.
+-   `featureIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The featureIndex currently being processed, starts at index 0.
+-   `featureSubIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The featureSubIndex currently being processed, starts at index 0.
 -   `geojson`  
 -   `callback`  
 -   `initialValue`  
@@ -596,11 +596,12 @@ Reduce 2-vertex line segment in any GeoJSON object, similar to Array.reduce()
 var polygon = turf.polygon([[[-50, 5], [-40, -10], [-50, -10], [-40, 5], [-50, 5]]]);
 
 // Iterate over GeoJSON by 2-vertex segments
-turf.segmentReduce(polygon, function (previousSegment, currentSegment, currentIndex, currentSubIndex) {
+turf.segmentReduce(polygon, function (previousSegment, currentSegment, segmentIndex, featureIndex, featureSubIndex) {
   //= previousSegment
   //= currentSegment
-  //= currentIndex
-  //= currentSubIndex
+  //= segmentInex
+  //= featureIndex
+  //= featureSubIndex
   return currentSegment
 });
 


### PR DESCRIPTION
## Fix `segmentReduce` & `segmentEach` `@turf/meta`

Was using `segmentReduce` and it didn't return anything in the callback, looks like https://github.com/Turfjs/turf/pull/959 had do something with it.

Going to attempt a patch release for `@turf/meta` 🤞

```js
const geojson = featureCollection([
    point([0, 1]), // ignored
    lineString([[0, 0], [2, 2], [4, 4]]),
    polygon([[[5, 5], [0, 0], [2, 2], [4, 4], [5, 5]]]),
    point([0, 1]), // ignored
    multiLineString([
        [[0, 0], [2, 2], [4, 4]],
        [[0, 0], [2, 2], [4, 4]]
    ])
]);
segmentEach(geojson, (segment, segmentIndex, featureIndex, featureSubIndex) => {
  //=segmentIndexes => [0, 1, 0, 1, 2, 3, 0, 1, 0, 1]
  //=featureIndexes => [1, 1, 2, 2, 2, 2, 4, 4, 4, 4]
  //=featureSubIndexes => [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]
});
```
It's previous state wasn't usable, so I highly doubt this would "break" anyone's code since I personally wasn't able to use the index numbers properly before this fix.