### PR TITLE
Add WGS84 to @turf/helpers

### DIFF
--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -139,3 +139,13 @@ export function isNumber(num: any): boolean
  * http://turfjs.org/docs/#isobject
  */
 export function isObject(input: any): boolean
+
+/**
+ * http://turfjs.org/docs/#wgs84
+ */
+export const wgs84: {
+    RADIUS: number
+    FLATTENING_DENOM: number
+    FLATTENING: number
+    POLAR_RADIUS: number
+}

--- a/packages/turf-helpers/index.js
+++ b/packages/turf-helpers/index.js
@@ -352,6 +352,7 @@ const areaFactors = {
     feet: 10.763910417,
     inches: 1550.003100006
 };
+
 /**
  * Round number to precision
  *
@@ -533,3 +534,20 @@ export function isNumber(num) {
 export function isObject(input) {
     return (!!input) && (input.constructor === Object);
 }
+
+const RADIUS = 6378137;
+const FLATTENING_DENOM = 298.257223563;
+const FLATTENING = 1 / FLATTENING_DENOM;
+const POLAR_RADIUS = RADIUS * (1 - FLATTENING);
+
+/**
+ * WGS84 Provides radius, FLATTENING, and POLAR_RADIUS constants from the reference ellipsoid.
+ *
+ * http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/egm96.html
+ */
+export const wgs84 = {
+    RADIUS,
+    FLATTENING_DENOM,
+    FLATTENING,
+    POLAR_RADIUS,
+};

--- a/packages/turf-helpers/types.ts
+++ b/packages/turf-helpers/types.ts
@@ -22,6 +22,7 @@ import {
     convertArea,
     isNumber,
     isObject,
+    wgs84,
     // Typescript types
     Point,
     LineString,
@@ -156,3 +157,9 @@ const polyGeom: Polygon = geometry('Polygon', poly.geometry.coordinates);
 const multiPtGeom: MultiPoint = geometry('MultiPoint', multiPt.geometry.coordinates);
 const multiLineGeom: MultiLineString = geometry('MultiLineString', multiLine.geometry.coordinates);
 const multiPolyGeom: MultiPolygon = geometry('MultiPolygon', multiPoly.geometry.coordinates);
+
+// WGS84
+wgs84.FLATTENING
+wgs84.FLATTENING_DENOM
+wgs84.POLAR_RADIUS
+wgs84.RADIUS

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -128,7 +128,8 @@ export {
     convertDistance,
     isNumber,
     round,
-    convertArea
+    convertArea,
+    wgs84
 } from '@turf/helpers';
 import * as helpers from '@turf/helpers';
 export { helpers };

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -129,7 +129,8 @@ export {
     isNumber,
     isObject,
     round,
-    convertArea
+    convertArea,
+    wgs84
 } from '@turf/helpers';
 import * as helpers from '@turf/helpers';
 export { helpers };


### PR DESCRIPTION
## Add WGS84 to `@turf/helpers`

Pulled from @tmcw's https://github.com/mapbox/wgs84

Built-in variables for WGS84 related things.

Ref: https://github.com/Turfjs/turf/issues/978

## How to use

```js
import { wgs84 } from '@turf/helpers';

wgs84.RADIUS // => 6378137
```

CC: @stebogit