### PR TITLE
Support export default (Typescript)

### DIFF
--- a/packages/turf-along/index.js
+++ b/packages/turf-along/index.js
@@ -50,4 +50,3 @@ function along(line, distance, options) {
 }
 
 export default along;
-module.exports.default = along;

--- a/packages/turf-area/index.js
+++ b/packages/turf-area/index.js
@@ -122,4 +122,3 @@ function rad(_) {
 }
 
 export default area;
-module.exports.default = area;

--- a/packages/turf-bbox-clip/index.js
+++ b/packages/turf-bbox-clip/index.js
@@ -19,7 +19,7 @@ import { lineString, multiLineString, polygon, multiPolygon } from '@turf/helper
  * //addToMap
  * var addToMap = [bbox, poly, clipped]
  */
-export default function bboxClip(feature, bbox) {
+function bboxClip(feature, bbox) {
     var geom = getGeom(feature);
     var coords = getCoords(feature);
     var properties = feature.properties;
@@ -64,3 +64,6 @@ function clipPolygon(rings, bbox) {
 function getGeom(feature) {
     return (feature.geometry) ? feature.geometry.type : feature.type;
 }
+
+export default bboxClip;
+module.exports.default = bboxClip;

--- a/packages/turf-bbox-clip/index.js
+++ b/packages/turf-bbox-clip/index.js
@@ -66,4 +66,3 @@ function getGeom(feature) {
 }
 
 export default bboxClip;
-module.exports.default = bboxClip;

--- a/packages/turf-bbox-polygon/index.js
+++ b/packages/turf-bbox-polygon/index.js
@@ -30,4 +30,3 @@ function bboxPolygon(bbox) {
 }
 
 export default bboxPolygon;
-module.exports.default = bboxPolygon;

--- a/packages/turf-bbox-polygon/index.js
+++ b/packages/turf-bbox-polygon/index.js
@@ -14,7 +14,7 @@ import { polygon } from '@turf/helpers';
  * //addToMap
  * var addToMap = [poly]
  */
-export default function bboxPolygon(bbox) {
+function bboxPolygon(bbox) {
     var lowLeft = [bbox[0], bbox[1]];
     var topLeft = [bbox[0], bbox[3]];
     var topRight = [bbox[2], bbox[3]];
@@ -28,3 +28,6 @@ export default function bboxPolygon(bbox) {
         lowLeft
     ]]);
 }
+
+export default bboxPolygon;
+module.exports.default = bboxPolygon;

--- a/packages/turf-bbox/index.js
+++ b/packages/turf-bbox/index.js
@@ -14,16 +14,15 @@ import { coordEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [line, bboxPolygon]
  */
-function turfBBox(geojson) {
-    var bbox = [Infinity, Infinity, -Infinity, -Infinity];
+function bbox(geojson) {
+    var BBox = [Infinity, Infinity, -Infinity, -Infinity];
     coordEach(geojson, function (coord) {
-        if (bbox[0] > coord[0]) bbox[0] = coord[0];
-        if (bbox[1] > coord[1]) bbox[1] = coord[1];
-        if (bbox[2] < coord[0]) bbox[2] = coord[0];
-        if (bbox[3] < coord[1]) bbox[3] = coord[1];
+        if (BBox[0] > coord[0]) BBox[0] = coord[0];
+        if (BBox[1] > coord[1]) BBox[1] = coord[1];
+        if (BBox[2] < coord[0]) BBox[2] = coord[0];
+        if (BBox[3] < coord[1]) BBox[3] = coord[1];
     });
-    return bbox;
+    return BBox;
 }
 
-export default turfBBox;
-module.exports.default = turfBBox;
+export default bbox;

--- a/packages/turf-bbox/index.js
+++ b/packages/turf-bbox/index.js
@@ -14,7 +14,7 @@ import { coordEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [line, bboxPolygon]
  */
-export default function turfBBox(geojson) {
+function turfBBox(geojson) {
     var bbox = [Infinity, Infinity, -Infinity, -Infinity];
     coordEach(geojson, function (coord) {
         if (bbox[0] > coord[0]) bbox[0] = coord[0];
@@ -24,3 +24,6 @@ export default function turfBBox(geojson) {
     });
     return bbox;
 }
+
+export default turfBBox;
+module.exports.default = turfBBox;

--- a/packages/turf-bearing/index.js
+++ b/packages/turf-bearing/index.js
@@ -62,4 +62,3 @@ function calculateFinalBearing(start, end) {
 }
 
 export default bearing;
-module.exports.default = bearing;

--- a/packages/turf-bearing/index.js
+++ b/packages/turf-bearing/index.js
@@ -24,7 +24,7 @@ import { getCoord } from '@turf/invariant';
  * point2.properties['marker-color'] = '#0f0'
  * point1.properties.bearing = bearing
  */
-export default function bearing(start, end, options) {
+function bearing(start, end, options) {
     // Backwards compatible with v4.0
     var final = (typeof options === 'object') ? options.final : options;
     if (final === true) return calculateFinalBearing(start, end);
@@ -61,3 +61,5 @@ function calculateFinalBearing(start, end) {
     return bear;
 }
 
+export default bearing;
+module.exports.default = bearing;

--- a/packages/turf-bezier/index.js
+++ b/packages/turf-bezier/index.js
@@ -30,7 +30,7 @@ import Spline from './spline.js';
  * var addToMap = [line, curved]
  * curved.properties = { stroke: '#0F0' };
  */
-export default function bezier(line, options) {
+function bezier(line, options) {
     // Optional params
     options = options || {};
     var resolution = options.resolution || 10000;
@@ -59,3 +59,6 @@ export default function bezier(line, options) {
 
     return lineString(coords, line.properties);
 }
+
+export default bezier;
+module.exports.default = bezier;

--- a/packages/turf-bezier/index.js
+++ b/packages/turf-bezier/index.js
@@ -61,4 +61,3 @@ function bezier(line, options) {
 }
 
 export default bezier;
-module.exports.default = bezier;

--- a/packages/turf-boolean-clockwise/index.js
+++ b/packages/turf-boolean-clockwise/index.js
@@ -35,4 +35,3 @@ function booleanClockwise(line) {
 }
 
 export default booleanClockwise;
-module.exports.default = booleanClockwise;

--- a/packages/turf-boolean-clockwise/index.js
+++ b/packages/turf-boolean-clockwise/index.js
@@ -15,7 +15,7 @@ import { getCoords } from '@turf/invariant';
  * turf.booleanClockwise(counterClockwiseRing)
  * //=false
  */
-export default function booleanClockwise(line) {
+function booleanClockwise(line) {
     // validation
     if (!line) throw new Error('line is required');
     var type = (line.geometry) ? line.geometry.type : line.type;
@@ -33,3 +33,6 @@ export default function booleanClockwise(line) {
     }
     return sum > 0;
 }
+
+export default booleanClockwise;
+module.exports.default = booleanClockwise;

--- a/packages/turf-boolean-contains/index.js
+++ b/packages/turf-boolean-contains/index.js
@@ -20,7 +20,7 @@ import { getGeom, getCoords, getType } from '@turf/invariant';
  * turf.booleanContains(line, point);
  * //=true
  */
-export default function booleanContains(feature1, feature2) {
+function booleanContains(feature1, feature2) {
     var type1 = getType(feature1);
     var type2 = getType(feature2);
     var geom1 = getGeom(feature1);
@@ -206,3 +206,6 @@ function compareCoords(pair1, pair2) {
 function getMidpoint(pair1, pair2) {
     return [(pair1[0] + pair2[0]) / 2, (pair1[1] + pair2[1]) / 2];
 }
+
+export default booleanContains;
+module.exports.default = booleanContains;

--- a/packages/turf-boolean-contains/index.js
+++ b/packages/turf-boolean-contains/index.js
@@ -208,4 +208,3 @@ function getMidpoint(pair1, pair2) {
 }
 
 export default booleanContains;
-module.exports.default = booleanContains;

--- a/packages/turf-boolean-crosses/index.js
+++ b/packages/turf-boolean-crosses/index.js
@@ -167,4 +167,3 @@ function isPointOnLineSegment(lineSegmentStart, lineSegmentEnd, pt, incEnd) {
 }
 
 export default booleanCrosses;
-module.exports.default = booleanCrosses;

--- a/packages/turf-boolean-crosses/index.js
+++ b/packages/turf-boolean-crosses/index.js
@@ -22,7 +22,7 @@ import { getGeom, getType } from '@turf/invariant';
  * var cross = turf.booleanCrosses(line1, line2);
  * //=true
  */
-export default function booleanCrosses(feature1, feature2) {
+function booleanCrosses(feature1, feature2) {
     var type1 = getType(feature1);
     var type2 = getType(feature2);
     var geom1 = getGeom(feature1);
@@ -165,3 +165,6 @@ function isPointOnLineSegment(lineSegmentStart, lineSegmentEnd, pt, incEnd) {
         return dyl > 0 ? lineSegmentStart[1] < pt[1] && pt[1] < lineSegmentEnd[1] : lineSegmentEnd[1] < pt[1] && pt[1] < lineSegmentStart[1];
     }
 }
+
+export default booleanCrosses;
+module.exports.default = booleanCrosses;

--- a/packages/turf-boolean-disjoint/index.js
+++ b/packages/turf-boolean-disjoint/index.js
@@ -157,4 +157,3 @@ function compareCoords(pair1, pair2) {
 }
 
 export default booleanDisjoint;
-module.exports.default = booleanDisjoint;

--- a/packages/turf-boolean-disjoint/index.js
+++ b/packages/turf-boolean-disjoint/index.js
@@ -17,7 +17,7 @@ import polyToLinestring from '@turf/polygon-to-linestring';
  * turf.booleanDisjoint(line, point);
  * //=true
  */
-export default function booleanDisjoint(feature1, feature2) {
+function booleanDisjoint(feature1, feature2) {
     var boolean;
     flattenEach(feature1, function (flatten1) {
         flattenEach(feature2, function (flatten2) {
@@ -155,3 +155,6 @@ function isPointOnLineSegment(LineSegmentStart, LineSegmentEnd, Point) {
 function compareCoords(pair1, pair2) {
     return pair1[0] === pair2[0] && pair1[1] === pair2[1];
 }
+
+export default booleanDisjoint;
+module.exports.default = booleanDisjoint;

--- a/packages/turf-boolean-equal/index.js
+++ b/packages/turf-boolean-equal/index.js
@@ -20,7 +20,7 @@ import { getType } from '@turf/invariant';
  * turf.booleanEqual(pt2, pt3);
  * //= false
  */
-export default function booleanEqual(feature1, feature2) {
+function booleanEqual(feature1, feature2) {
     // validation
     if (!feature1) throw new Error('feature1 is required');
     if (!feature2) throw new Error('feature2 is required');
@@ -31,3 +31,6 @@ export default function booleanEqual(feature1, feature2) {
     var equality = new GeojsonEquality({precision: 6});
     return equality.compare(cleanCoords(feature1), cleanCoords(feature2));
 }
+
+export default booleanEqual;
+module.exports.default = booleanEqual;

--- a/packages/turf-boolean-equal/index.js
+++ b/packages/turf-boolean-equal/index.js
@@ -33,4 +33,3 @@ function booleanEqual(feature1, feature2) {
 }
 
 export default booleanEqual;
-module.exports.default = booleanEqual;

--- a/packages/turf-boolean-overlap/index.js
+++ b/packages/turf-boolean-overlap/index.js
@@ -72,4 +72,3 @@ function booleanOverlap(feature1, feature2) {
 }
 
 export default booleanOverlap;
-module.exports.default = booleanOverlap;

--- a/packages/turf-boolean-overlap/index.js
+++ b/packages/turf-boolean-overlap/index.js
@@ -23,7 +23,7 @@ var GeojsonEquality = require('geojson-equality');
  * turf.booleanOverlap(poly2, poly3)
  * //=false
  */
-export default function booleanOverlap(feature1, feature2) {
+function booleanOverlap(feature1, feature2) {
     // validation
     if (!feature1) throw new Error('feature1 is required');
     if (!feature2) throw new Error('feature2 is required');
@@ -70,3 +70,6 @@ export default function booleanOverlap(feature1, feature2) {
 
     return overlap > 0;
 }
+
+export default booleanOverlap;
+module.exports.default = booleanOverlap;

--- a/packages/turf-boolean-parallel/index.js
+++ b/packages/turf-boolean-parallel/index.js
@@ -17,7 +17,7 @@ import { bearingToAngle } from '@turf/helpers';
  * turf.booleanParallel(line1, line2);
  * //=true
  */
-export default function booleanParallel(line1, line2) {
+function booleanParallel(line1, line2) {
     // validation
     if (!line1) throw new Error('line1 is required');
     if (!line2) throw new Error('line2 is required');
@@ -67,3 +67,6 @@ function getType(geojson, name) {
     if (geojson.type) return geojson.type; // if GeoJSON geometry
     throw new Error('Invalid GeoJSON object for ' + name);
 }
+
+export default booleanParallel;
+module.exports.default = booleanParallel;

--- a/packages/turf-boolean-parallel/index.js
+++ b/packages/turf-boolean-parallel/index.js
@@ -69,4 +69,3 @@ function getType(geojson, name) {
 }
 
 export default booleanParallel;
-module.exports.default = booleanParallel;

--- a/packages/turf-boolean-point-on-line/index.js
+++ b/packages/turf-boolean-point-on-line/index.js
@@ -75,4 +75,3 @@ function isPointOnLineSegment(lineSegmentStart, lineSegmentEnd, point, excludeBo
 }
 
 export default booleanPointOnLine;
-module.exports.default = booleanPointOnLine;

--- a/packages/turf-boolean-point-on-line/index.js
+++ b/packages/turf-boolean-point-on-line/index.js
@@ -15,7 +15,7 @@ import { getCoords } from '@turf/invariant';
  * var isPointOnLine = turf.booleanPointOnLine(pt, line);
  * //=true
  */
-export default function booleanPointOnLine(point, linestring, options) {
+function booleanPointOnLine(point, linestring, options) {
     // Backwards compatible with v4.0
     var ignoreEndVertices = (typeof options === 'object') ? options.ignoreEndVertices : options;
 
@@ -73,3 +73,6 @@ function isPointOnLineSegment(lineSegmentStart, lineSegmentEnd, point, excludeBo
         return dyl > 0 ? lineSegmentStart[1] < point[1] && point[1] < lineSegmentEnd[1] : lineSegmentEnd[1] < point[1] && point[1] < lineSegmentStart[1];
     }
 }
+
+export default booleanPointOnLine;
+module.exports.default = booleanPointOnLine;

--- a/packages/turf-boolean-within/index.js
+++ b/packages/turf-boolean-within/index.js
@@ -216,4 +216,3 @@ function getMidpoint(pair1, pair2) {
 }
 
 export default booleanWithin;
-module.exports.default = booleanWithin;

--- a/packages/turf-boolean-within/index.js
+++ b/packages/turf-boolean-within/index.js
@@ -20,7 +20,7 @@ import { getGeom, getType } from '@turf/invariant';
  * turf.booleanWithin(point, line);
  * //=true
  */
-export default function booleanWithin(feature1, feature2) {
+function booleanWithin(feature1, feature2) {
     var type1 = getType(feature1);
     var type2 = getType(feature2);
     var geom1 = getGeom(feature1);
@@ -214,3 +214,6 @@ function compareCoords(pair1, pair2) {
 function getMidpoint(pair1, pair2) {
     return [(pair1[0] + pair2[0]) / 2, (pair1[1] + pair2[1]) / 2];
 }
+
+export default booleanWithin;
+module.exports.default = booleanWithin;

--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -29,7 +29,7 @@ import { toWgs84, toMercator } from '@turf/projection';
  * //addToMap
  * var addToMap = [point, buffered]
  */
-export default function (geojson, radius, options) {
+function buffer(geojson, radius, options) {
     // Optional params
     options = options || {};
     var units = options.units;
@@ -52,13 +52,13 @@ export default function (geojson, radius, options) {
     switch (geojson.type) {
     case 'GeometryCollection':
         geomEach(geojson, function (geometry) {
-            var buffered = buffer(geometry, radius, units, steps);
+            var buffered = bufferFeature(geometry, radius, units, steps);
             if (buffered) results.push(buffered);
         });
         return featureCollection(results);
     case 'FeatureCollection':
         featureEach(geojson, function (feature) {
-            var multiBuffered = buffer(feature, radius, units, steps);
+            var multiBuffered = bufferFeature(feature, radius, units, steps);
             if (multiBuffered) {
                 featureEach(multiBuffered, function (buffered) {
                     if (buffered) results.push(buffered);
@@ -67,7 +67,7 @@ export default function (geojson, radius, options) {
         });
         return featureCollection(results);
     }
-    return buffer(geojson, radius, units, steps);
+    return bufferFeature(geojson, radius, units, steps);
 }
 
 /**
@@ -80,7 +80,7 @@ export default function (geojson, radius, options) {
  * @param {number} [steps=64] number of steps
  * @returns {Feature<Polygon|MultiPolygon>} buffered feature
  */
-function buffer(geojson, radius, units, steps) {
+function bufferFeature(geojson, radius, units, steps) {
     var properties = geojson.properties || {};
     var geometry = (geojson.type === 'Feature') ? geojson.geometry : geojson;
 
@@ -88,7 +88,7 @@ function buffer(geojson, radius, units, steps) {
     if (geometry.type === 'GeometryCollection') {
         var results = [];
         geomEach(geojson, function (geometry) {
-            var buffered = buffer(geometry, radius, units, steps);
+            var buffered = bufferFeature(geometry, radius, units, steps);
             if (buffered) results.push(buffered);
         });
         return featureCollection(results);
@@ -190,3 +190,6 @@ function defineProjection(geojson) {
         .rotate(rotate)
         .scale(6373000);
 }
+
+export default buffer;
+module.exports.default = buffer;

--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -192,4 +192,3 @@ function defineProjection(geojson) {
 }
 
 export default buffer;
-module.exports.default = buffer;

--- a/packages/turf-center-of-mass/index.js
+++ b/packages/turf-center-of-mass/index.js
@@ -98,3 +98,4 @@ function centerOfMass(geojson, properties) {
 }
 
 export default centerOfMass;
+module.exports.default = centerOfMass;

--- a/packages/turf-center-of-mass/index.js
+++ b/packages/turf-center-of-mass/index.js
@@ -98,4 +98,3 @@ function centerOfMass(geojson, properties) {
 }
 
 export default centerOfMass;
-module.exports.default = centerOfMass;

--- a/packages/turf-center/index.js
+++ b/packages/turf-center/index.js
@@ -30,4 +30,3 @@ function center(geojson, properties) {
 }
 
 export default center;
-module.exports.default = center;

--- a/packages/turf-center/index.js
+++ b/packages/turf-center/index.js
@@ -22,9 +22,12 @@ import { point } from '@turf/helpers';
  * center.properties['marker-size'] = 'large';
  * center.properties['marker-color'] = '#000';
  */
-export default function (geojson, properties) {
+function center(geojson, properties) {
     var ext = bbox(geojson);
     var x = (ext[0] + ext[2]) / 2;
     var y = (ext[1] + ext[3]) / 2;
     return point([x, y], properties);
 }
+
+export default center;
+module.exports.default = center;

--- a/packages/turf-centroid/index.js
+++ b/packages/turf-centroid/index.js
@@ -17,7 +17,7 @@ import { point } from '@turf/helpers';
  * //addToMap
  * var addToMap = [polygon, centroid]
  */
-export default function (geojson, properties) {
+function centroid(geojson, properties) {
     var xSum = 0;
     var ySum = 0;
     var len = 0;
@@ -28,3 +28,6 @@ export default function (geojson, properties) {
     }, true);
     return point([xSum / len, ySum / len], properties);
 }
+
+export default centroid;
+module.exports.default = centroid;

--- a/packages/turf-centroid/index.js
+++ b/packages/turf-centroid/index.js
@@ -30,4 +30,3 @@ function centroid(geojson, properties) {
 }
 
 export default centroid;
-module.exports.default = centroid;

--- a/packages/turf-circle/index.js
+++ b/packages/turf-circle/index.js
@@ -24,7 +24,7 @@ import { polygon } from '@turf/helpers';
  * //addToMap
  * var addToMap = [turf.point(center), circle]
  */
-export default function (center, radius, options) {
+function circle(center, radius, options) {
     // Optional params
     options = options || {};
     var steps = options.steps || 64;
@@ -49,3 +49,6 @@ export default function (center, radius, options) {
 
     return polygon([coordinates], properties);
 }
+
+export default circle;
+module.exports.default = circle;

--- a/packages/turf-circle/index.js
+++ b/packages/turf-circle/index.js
@@ -51,4 +51,3 @@ function circle(center, radius, options) {
 }
 
 export default circle;
-module.exports.default = circle;

--- a/packages/turf-clean-coords/index.js
+++ b/packages/turf-clean-coords/index.js
@@ -145,4 +145,3 @@ function isPointOnLineSegment(start, end, point) {
 }
 
 export default cleanCoords;
-module.exports.default = cleanCoords;

--- a/packages/turf-clean-coords/index.js
+++ b/packages/turf-clean-coords/index.js
@@ -18,7 +18,7 @@ import { getCoords, getType } from '@turf/invariant';
  * turf.cleanCoords(multiPoint).geometry.coordinates;
  * //= [[0, 0], [2, 2]]
  */
-export default function (geojson, mutate) {
+function cleanCoords(geojson, mutate) {
     if (!geojson) throw new Error('geojson is required');
     var type = getType(geojson);
 
@@ -27,19 +27,19 @@ export default function (geojson, mutate) {
 
     switch (type) {
     case 'LineString':
-        newCoords = cleanCoords(geojson);
+        newCoords = cleanLine(geojson);
         break;
     case 'MultiLineString':
     case 'Polygon':
         getCoords(geojson).forEach(function (line) {
-            newCoords.push(cleanCoords(line));
+            newCoords.push(cleanLine(line));
         });
         break;
     case 'MultiPolygon':
         getCoords(geojson).forEach(function (polygons) {
             var polyPoints = [];
             polygons.forEach(function (ring) {
-                polyPoints.push(cleanCoords(ring));
+                polyPoints.push(cleanLine(ring));
             });
             newCoords.push(polyPoints);
         });
@@ -83,7 +83,7 @@ export default function (geojson, mutate) {
  * @param {Array<number>|LineString} line Line
  * @returns {Array<number>} Cleaned coordinates
  */
-function cleanCoords(line) {
+function cleanLine(line) {
     var points = getCoords(line);
     // handle "clean" segment
     if (points.length === 2 && !equals(points[0], points[1])) return points;
@@ -143,3 +143,6 @@ function isPointOnLineSegment(start, end, point) {
     else if (Math.abs(dxl) >= Math.abs(dyl)) return dxl > 0 ? startX <= x && x <= endX : endX <= x && x <= startX;
     else return dyl > 0 ? startY <= y && y <= endY : endY <= y && y <= startY;
 }
+
+export default cleanCoords;
+module.exports.default = cleanCoords;

--- a/packages/turf-clone/index.js
+++ b/packages/turf-clone/index.js
@@ -144,4 +144,3 @@ function deepSlice(coords) {
 }
 
 export default clone;
-module.exports.default = clone;

--- a/packages/turf-clone/index.js
+++ b/packages/turf-clone/index.js
@@ -10,7 +10,7 @@
  *
  * var lineCloned = turf.clone(line);
  */
-export default function clone(geojson) {
+function clone(geojson) {
     if (!geojson) throw new Error('geojson is required');
 
     switch (geojson.type) {
@@ -142,3 +142,6 @@ function deepSlice(coords) {
         return deepSlice(coord);
     });
 }
+
+export default clone;
+module.exports.default = clone;

--- a/packages/turf-clusters-dbscan/index.js
+++ b/packages/turf-clusters-dbscan/index.js
@@ -28,7 +28,7 @@ import { collectionOf } from '@turf/invariant';
  * //addToMap
  * var addToMap = [clustered];
  */
-export default function (points, maxDistance, units, minPoints) {
+function clustersDbscan(points, maxDistance, units, minPoints) {
     // Input validation
     collectionOf(points, 'Point', 'Input must contain Points');
     if (maxDistance === null || maxDistance === undefined) throw new Error('maxDistance is required');
@@ -69,3 +69,6 @@ export default function (points, maxDistance, units, minPoints) {
 
     return points;
 }
+
+export default clustersDbscan;
+module.exports.default = clustersDbscan;

--- a/packages/turf-clusters-dbscan/index.js
+++ b/packages/turf-clusters-dbscan/index.js
@@ -71,4 +71,3 @@ function clustersDbscan(points, maxDistance, units, minPoints) {
 }
 
 export default clustersDbscan;
-module.exports.default = clustersDbscan;

--- a/packages/turf-clusters-kmeans/index.js
+++ b/packages/turf-clusters-kmeans/index.js
@@ -25,7 +25,7 @@ import { collectionOf } from '@turf/invariant';
  * //addToMap
  * var addToMap = [clustered];
  */
-export default function (points, numberOfClusters, mutate) {
+function clustersKmeans(points, numberOfClusters, mutate) {
     // Input validation
     collectionOf(points, 'Point', 'Input must contain Points');
 
@@ -64,3 +64,6 @@ export default function (points, numberOfClusters, mutate) {
 
     return points;
 }
+
+export default clustersKmeans;
+module.exports.default = clustersKmeans;

--- a/packages/turf-clusters-kmeans/index.js
+++ b/packages/turf-clusters-kmeans/index.js
@@ -66,4 +66,3 @@ function clustersKmeans(points, numberOfClusters, mutate) {
 }
 
 export default clustersKmeans;
-module.exports.default = clustersKmeans;

--- a/packages/turf-collect/index.js
+++ b/packages/turf-collect/index.js
@@ -67,4 +67,3 @@ function collect(polygons, points, inProperty, outProperty) {
 }
 
 export default collect;
-module.exports.default = collect;

--- a/packages/turf-collect/index.js
+++ b/packages/turf-collect/index.js
@@ -32,7 +32,7 @@ var rbush = require('rbush');
  * //addToMap
  * var addToMap = [pointFC, collected]
  */
-export default function (polygons, points, inProperty, outProperty) {
+function collect(polygons, points, inProperty, outProperty) {
     var rtree = rbush(6);
 
     var treeItems = points.features.map(function (item) {
@@ -65,3 +65,6 @@ export default function (polygons, points, inProperty, outProperty) {
 
     return polygons;
 }
+
+export default collect;
+module.exports.default = collect;

--- a/packages/turf-combine/index.js
+++ b/packages/turf-combine/index.js
@@ -19,7 +19,7 @@ import { featureEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [combined]
  */
-export default function (fc) {
+function combine(fc) {
     var groups = {
         MultiPoint: {coordinates: [], properties: []},
         MultiLineString: {coordinates: [], properties: []},
@@ -60,3 +60,6 @@ export default function (fc) {
             return feature(geometry, properties);
         }));
 }
+
+export default combine;
+module.exports.default = combine;

--- a/packages/turf-combine/index.js
+++ b/packages/turf-combine/index.js
@@ -62,4 +62,3 @@ function combine(fc) {
 }
 
 export default combine;
-module.exports.default = combine;

--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -29,7 +29,7 @@ import { featureEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [points, hull]
  */
-export default function (points, maxEdge, units) {
+function concave(points, maxEdge, units) {
     // validation
     if (!points) throw new Error('points is required');
     if (maxEdge === undefined || maxEdge === null) throw new Error('maxEdge is required');
@@ -83,3 +83,6 @@ function removeDuplicates(points) {
     });
     return featureCollection(cleaned);
 }
+
+export default concave;
+module.exports.default = concave;

--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -85,4 +85,3 @@ function removeDuplicates(points) {
 }
 
 export default concave;
-module.exports.default = concave;

--- a/packages/turf-convex/index.js
+++ b/packages/turf-convex/index.js
@@ -50,4 +50,3 @@ function convex(feature) {
 }
 
 export default convex;
-module.exports.default = convex;

--- a/packages/turf-convex/index.js
+++ b/packages/turf-convex/index.js
@@ -27,7 +27,7 @@ import { polygon } from '@turf/helpers';
  * //addToMap
  * var addToMap = [points, hull]
  */
-export default function (feature) {
+function convex(feature) {
     var points = [];
 
     // Remove Z in coordinates because it breaks the convexHull algorithm
@@ -48,3 +48,6 @@ export default function (feature) {
     }
     return undefined;
 }
+
+export default convex;
+module.exports.default = convex;

--- a/packages/turf-destination/index.js
+++ b/packages/turf-destination/index.js
@@ -25,7 +25,7 @@ import { point, distanceToRadians } from '@turf/helpers';
  * destination.properties['marker-color'] = '#f00';
  * point.properties['marker-color'] = '#0f0';
  */
-export default function (origin, distance, bearing, units) {
+function destination(origin, distance, bearing, units) {
     var degrees2radians = Math.PI / 180;
     var radians2degrees = 180 / Math.PI;
     var coordinates1 = getCoord(origin);
@@ -42,3 +42,6 @@ export default function (origin, distance, bearing, units) {
 
     return point([radians2degrees * longitude2, radians2degrees * latitude2]);
 }
+
+export default destination;
+module.exports.default = destination;

--- a/packages/turf-destination/index.js
+++ b/packages/turf-destination/index.js
@@ -44,4 +44,3 @@ function destination(origin, distance, bearing, units) {
 }
 
 export default destination;
-module.exports.default = destination;

--- a/packages/turf-difference/index.js
+++ b/packages/turf-difference/index.js
@@ -83,4 +83,3 @@ function removeEmptyPolygon(geom) {
 }
 
 export default difference;
-module.exports.default = difference;

--- a/packages/turf-difference/index.js
+++ b/packages/turf-difference/index.js
@@ -38,7 +38,7 @@ import { flattenEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [polygon1, polygon2, difference];
  */
-export default function (polygon1, polygon2) {
+function difference(polygon1, polygon2) {
     var geom1 = getGeom(polygon1);
     var geom2 = getGeom(polygon2);
     var properties = polygon1.properties || {};
@@ -81,3 +81,6 @@ function removeEmptyPolygon(geom) {
         if (coordinates.length) return {type: 'MultiPolygon', coordinates: coordinates};
     }
 }
+
+export default difference;
+module.exports.default = difference;

--- a/packages/turf-dissolve/index.js
+++ b/packages/turf-dissolve/index.js
@@ -24,7 +24,7 @@ var getClosest = require('get-closest');
  * //addToMap
  * var addToMap = [features, dissolved]
  */
-export default function (featureCollection, propertyName) {
+function dissolve(featureCollection, propertyName) {
 
     var originalIndexOfItemsRemoved = [];
     var treeItems = [];
@@ -132,3 +132,6 @@ function toLinestring(polygon) {
     polygon.geometry.coordinates = flat_arr;
     return polygon;
 }
+
+export default dissolve;
+module.exports.default = dissolve;

--- a/packages/turf-dissolve/index.js
+++ b/packages/turf-dissolve/index.js
@@ -134,4 +134,3 @@ function toLinestring(polygon) {
 }
 
 export default dissolve;
-module.exports.default = dissolve;

--- a/packages/turf-distance/index.js
+++ b/packages/turf-distance/index.js
@@ -26,7 +26,7 @@ import { radiansToDistance } from '@turf/helpers';
  * from.properties.distance = distance;
  * to.properties.distance = distance;
  */
-export default function (from, to, units) {
+function distance(from, to, units) {
     var degrees2radians = Math.PI / 180;
     var coordinates1 = getCoord(from);
     var coordinates2 = getCoord(to);
@@ -40,3 +40,6 @@ export default function (from, to, units) {
 
     return radiansToDistance(2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)), units);
 }
+
+export default distance;
+module.exports.default = distance;

--- a/packages/turf-distance/index.js
+++ b/packages/turf-distance/index.js
@@ -42,4 +42,3 @@ function distance(from, to, units) {
 }
 
 export default distance;
-module.exports.default = distance;

--- a/packages/turf-envelope/index.js
+++ b/packages/turf-envelope/index.js
@@ -24,4 +24,3 @@ function envelope(geojson) {
 }
 
 export default envelope;
-module.exports.default = envelope;

--- a/packages/turf-envelope/index.js
+++ b/packages/turf-envelope/index.js
@@ -19,6 +19,9 @@ import bboxPolygon from '@turf/bbox-polygon';
  * //addToMap
  * var addToMap = [features, enveloped];
  */
-export default function (geojson) {
+function envelope(geojson) {
     return bboxPolygon(bbox(geojson));
 }
+
+export default envelope;
+module.exports.default = envelope;

--- a/packages/turf-explode/index.js
+++ b/packages/turf-explode/index.js
@@ -16,7 +16,7 @@ import { point, featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [polygon, explode]
  */
-export default function (geojson) {
+function explode(geojson) {
     var points = [];
     if (geojson.type === 'FeatureCollection') {
         featureEach(geojson, function (feature) {
@@ -31,3 +31,6 @@ export default function (geojson) {
     }
     return featureCollection(points);
 }
+
+export default explode;
+module.exports.default = explode;

--- a/packages/turf-explode/index.js
+++ b/packages/turf-explode/index.js
@@ -33,4 +33,3 @@ function explode(geojson) {
 }
 
 export default explode;
-module.exports.default = explode;

--- a/packages/turf-flatten/index.js
+++ b/packages/turf-flatten/index.js
@@ -30,4 +30,3 @@ function flatten(geojson) {
 }
 
 export default flatten;
-module.exports.default = flatten;

--- a/packages/turf-flatten/index.js
+++ b/packages/turf-flatten/index.js
@@ -19,7 +19,7 @@ import { featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [flatten]
  */
-export default function (geojson) {
+function flatten(geojson) {
     if (!geojson) throw new Error('geojson is required');
 
     var results = [];
@@ -28,3 +28,6 @@ export default function (geojson) {
     });
     return featureCollection(results);
 }
+
+export default flatten;
+module.exports.default = flatten;

--- a/packages/turf-flip/index.js
+++ b/packages/turf-flip/index.js
@@ -15,7 +15,7 @@ import { coordEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [serbia, saudiArabia];
  */
-export default function (geojson, mutate) {
+function flip(geojson, mutate) {
     if (!geojson) throw new Error('geojson is required');
     // ensure that we don't modify features in-place and changes to the
     // output do not change the previous feature, including changes to nested
@@ -30,3 +30,6 @@ export default function (geojson, mutate) {
     });
     return geojson;
 }
+
+export default flip;
+module.exports.default = flip;

--- a/packages/turf-flip/index.js
+++ b/packages/turf-flip/index.js
@@ -32,4 +32,3 @@ function flip(geojson, mutate) {
 }
 
 export default flip;
-module.exports.default = flip;

--- a/packages/turf-great-circle/index.js
+++ b/packages/turf-great-circle/index.js
@@ -38,4 +38,3 @@ function greatCircle(start, end, properties, npoints, offset) {
 }
 
 export default greatCircle;
-module.exports.default = greatCircle;

--- a/packages/turf-great-circle/index.js
+++ b/packages/turf-great-circle/index.js
@@ -21,7 +21,7 @@ import { GreatCircle } from './arc';
  * //addToMap
  * var addToMap = [start, end, greatCircle]
  */
-export default function (start, end, properties, npoints, offset) {
+function greatCircle(start, end, properties, npoints, offset) {
     start = getCoord(start);
     end = getCoord(end);
     properties = properties || {};
@@ -36,3 +36,6 @@ export default function (start, end, properties, npoints, offset) {
 
     return line.json();
 }
+
+export default greatCircle;
+module.exports.default = greatCircle;

--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -137,4 +137,3 @@ function hexTriangles(center, rx, ry) {
 }
 
 export default hexGrid;
-module.exports.default = hexGrid;

--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -32,7 +32,7 @@ for (var i = 0; i < 6; i++) {
  * //addToMap
  * var addToMap = [hexgrid];
  */
-export default function hexGrid(bbox, cellDiameter, units, triangles) {
+function hexGrid(bbox, cellDiameter, units, triangles) {
     var west = bbox[0];
     var south = bbox[1];
     var east = bbox[2];
@@ -135,3 +135,6 @@ function hexTriangles(center, rx, ry) {
     }
     return triangles;
 }
+
+export default hexGrid;
+module.exports.default = hexGrid;

--- a/packages/turf-idw/index.js
+++ b/packages/turf-idw/index.js
@@ -55,4 +55,3 @@ function idw(controlPoints, valueField, weight, cellWidth, units) {
 }
 
 export default idw;
-module.exports.default = idw;

--- a/packages/turf-idw/index.js
+++ b/packages/turf-idw/index.js
@@ -18,7 +18,7 @@ import squareGrid from '@turf/square-grid';
  * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
  * @returns {FeatureCollection<Polygon>} grid A grid of polygons with a property field named as `valueField`
  */
-export default function (controlPoints, valueField, weight, cellWidth, units) {
+function idw(controlPoints, valueField, weight, cellWidth, units) {
     // validation
     if (!valueField) throw new Error('valueField is required');
     if (weight === undefined || weight === null) throw new Error('weight is required');
@@ -53,3 +53,6 @@ export default function (controlPoints, valueField, weight, cellWidth, units) {
     }
     return samplingGrid;
 }
+
+export default idw;
+module.exports.default = idw;

--- a/packages/turf-inside/index.js
+++ b/packages/turf-inside/index.js
@@ -102,4 +102,3 @@ function inBBox(pt, bbox) {
 }
 
 export default inside;
-module.exports.default = inside;

--- a/packages/turf-inside/index.js
+++ b/packages/turf-inside/index.js
@@ -26,7 +26,7 @@ import { getCoord, getCoords } from '@turf/invariant';
  * turf.inside(pt, poly);
  * //= true
  */
-export default function (point, polygon, ignoreBoundary) {
+function inside(point, polygon, ignoreBoundary) {
     // validation
     if (!point) throw new Error('point is required');
     if (!polygon) throw new Error('polygon is required');
@@ -100,3 +100,6 @@ function inBBox(pt, bbox) {
            bbox[2] >= pt[0] &&
            bbox[3] >= pt[1];
 }
+
+export default inside;
+module.exports.default = inside;

--- a/packages/turf-interpolate/index.js
+++ b/packages/turf-interpolate/index.js
@@ -95,4 +95,3 @@ function interpolate(points, cellSize, gridType, property, units, weight) {
 }
 
 export default interpolate;
-module.exports.default = interpolate;

--- a/packages/turf-interpolate/index.js
+++ b/packages/turf-interpolate/index.js
@@ -34,7 +34,7 @@ import { collectionOf } from '@turf/invariant';
  * //addToMap
  * var addToMap = [grid];
  */
-export default function (points, cellSize, gridType, property, units, weight) {
+function interpolate(points, cellSize, gridType, property, units, weight) {
     // validation
     if (!points) throw new Error('points is required');
     collectionOf(points, 'Point', 'input must contain Points');
@@ -93,3 +93,6 @@ export default function (points, cellSize, gridType, property, units, weight) {
     });
     return featureCollection(results);
 }
+
+export default interpolate;
+module.exports.default = interpolate;

--- a/packages/turf-intersect/index.js
+++ b/packages/turf-intersect/index.js
@@ -35,7 +35,7 @@ import { feature } from '@turf/helpers';
  * //addToMap
  * var addToMap = [poly1, poly2, intersection];
  */
-export default function (poly1, poly2) {
+function intersect(poly1, poly2) {
     var geom1 = (poly1.type === 'Feature') ? poly1.geometry : poly1;
     var geom2 = (poly2.type === 'Feature') ? poly2.geometry : poly2;
 
@@ -51,3 +51,6 @@ export default function (poly1, poly2) {
     var geom = writer.write(intersection);
     return feature(geom);
 }
+
+export default intersect;
+module.exports.default = intersect;

--- a/packages/turf-intersect/index.js
+++ b/packages/turf-intersect/index.js
@@ -53,4 +53,3 @@ function intersect(poly1, poly2) {
 }
 
 export default intersect;
-module.exports.default = intersect;

--- a/packages/turf-isobands/index.js
+++ b/packages/turf-isobands/index.js
@@ -271,4 +271,3 @@ function allGrouped(list) {
 }
 
 export default isobands;
-module.exports.default = isobands;

--- a/packages/turf-isobands/index.js
+++ b/packages/turf-isobands/index.js
@@ -35,7 +35,7 @@ import isoBands from './marchingsquares-isobands';
  * //addToMap
  * var addToMap = [isobands];
  */
-export default function (pointGrid, breaks, options) {
+function isobands(pointGrid, breaks, options) {
     // Optional Parameters
     options = options || {};
     var zProperty = options.zProperty || 'elevation';
@@ -269,3 +269,6 @@ function allGrouped(list) {
     }
     return true;
 }
+
+export default isobands;
+module.exports.default = isobands;

--- a/packages/turf-isolines/index.js
+++ b/packages/turf-isolines/index.js
@@ -33,7 +33,7 @@ import gridToMatrix from './grid-to-matrix';
  * //addToMap
  * var addToMap = [isolines];
  */
-export default function (pointGrid, breaks, zProperty, propertiesToAllIsolines, propertiesPerIsoline) {
+function isolines(pointGrid, breaks, zProperty, propertiesToAllIsolines, propertiesPerIsoline) {
     // Default Params
     zProperty = zProperty || 'elevation';
     propertiesToAllIsolines = propertiesToAllIsolines || {};
@@ -138,3 +138,6 @@ function rescaleIsolines(isolines, matrix, points) {
 function isObject(input) {
     return (!!input) && (input.constructor === Object);
 }
+
+export default isolines;
+module.exports.default = isolines;

--- a/packages/turf-isolines/index.js
+++ b/packages/turf-isolines/index.js
@@ -140,4 +140,3 @@ function isObject(input) {
 }
 
 export default isolines;
-module.exports.default = isolines;

--- a/packages/turf-kinks/index.js
+++ b/packages/turf-kinks/index.js
@@ -20,7 +20,7 @@ import { point } from '@turf/helpers';
  * //addToMap
  * var addToMap = [poly, kinks]
  */
-export default function (featureIn) {
+function kinks(featureIn) {
     var coordinates;
     var feature;
     var results = {
@@ -124,3 +124,6 @@ function lineIntersects(line1StartX, line1StartY, line1EndX, line1EndY, line2Sta
         return false;
     }
 }
+
+export default kinks;
+module.exports.default = kinks;

--- a/packages/turf-kinks/index.js
+++ b/packages/turf-kinks/index.js
@@ -126,4 +126,3 @@ function lineIntersects(line1StartX, line1StartY, line1EndX, line1EndY, line2Sta
 }
 
 export default kinks;
-module.exports.default = kinks;

--- a/packages/turf-line-arc/index.js
+++ b/packages/turf-line-arc/index.js
@@ -86,4 +86,3 @@ function convertAngleTo360(alfa) {
 }
 
 export default lineArc;
-module.exports.default = lineArc;

--- a/packages/turf-line-arc/index.js
+++ b/packages/turf-line-arc/index.js
@@ -26,7 +26,7 @@ import { lineString } from '@turf/helpers';
  * //addToMap
  * var addToMap = [center, arc]
  */
-export default function lineArc(center, radius, bearing1, bearing2, options) {
+function lineArc(center, radius, bearing1, bearing2, options) {
     // Optional params
     options = options || {};
     var steps = options.steps;
@@ -84,3 +84,6 @@ function convertAngleTo360(alfa) {
     }
     return beta;
 }
+
+export default lineArc;
+module.exports.default = lineArc;

--- a/packages/turf-line-chunk/index.js
+++ b/packages/turf-line-chunk/index.js
@@ -21,7 +21,7 @@ import { flattenEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [chunk];
  */
-export default function (geojson, segmentLength, units, reverse) {
+function lineChunk(geojson, segmentLength, units, reverse) {
     if (!geojson) throw new Error('geojson is required');
     if (segmentLength <= 0) throw new Error('segmentLength must be greater than 0');
     var results = [];
@@ -60,3 +60,6 @@ function sliceLineSegments(line, segmentLength, units, callback) {
         callback(outline, i);
     }
 }
+
+export default lineChunk;
+module.exports.default = lineChunk;

--- a/packages/turf-line-chunk/index.js
+++ b/packages/turf-line-chunk/index.js
@@ -62,4 +62,3 @@ function sliceLineSegments(line, segmentLength, units, callback) {
 }
 
 export default lineChunk;
-module.exports.default = lineChunk;

--- a/packages/turf-line-distance/index.js
+++ b/packages/turf-line-distance/index.js
@@ -16,7 +16,7 @@ import { segmentReduce } from '@turf/meta';
  * var addToMap = [line];
  * line.properties.distance = length;
  */
-export default function lineDistance(geojson, units) {
+function lineDistance(geojson, units) {
     // Input Validation
     if (!geojson) throw new Error('geojson is required');
 
@@ -26,3 +26,6 @@ export default function lineDistance(geojson, units) {
         return previousValue + distance(coords[0], coords[1], units);
     }, 0);
 }
+
+export default lineDistance;
+module.exports.default = lineDistance;

--- a/packages/turf-line-distance/index.js
+++ b/packages/turf-line-distance/index.js
@@ -28,4 +28,3 @@ function lineDistance(geojson, units) {
 }
 
 export default lineDistance;
-module.exports.default = lineDistance;

--- a/packages/turf-line-intersect/index.js
+++ b/packages/turf-line-intersect/index.js
@@ -105,4 +105,3 @@ function intersects(line1, line2) {
 }
 
 export default lineIntersect;
-module.exports.default = lineIntersect;

--- a/packages/turf-line-intersect/index.js
+++ b/packages/turf-line-intersect/index.js
@@ -19,7 +19,7 @@ import { point, featureCollection, feature } from '@turf/helpers';
  * //addToMap
  * var addToMap = [line1, line2, intersects]
  */
-export default function (line1, line2) {
+function lineIntersect(line1, line2) {
     var unique = {};
     var results = [];
 
@@ -103,3 +103,6 @@ function intersects(line1, line2) {
     }
     return null;
 }
+
+export default lineIntersect;
+module.exports.default = lineIntersect;

--- a/packages/turf-line-offset/index.js
+++ b/packages/turf-line-offset/index.js
@@ -20,7 +20,7 @@ import { lineString, multiLineString, distanceToDegrees } from '@turf/helpers';
  * var addToMap = [offsetLine, line]
  * offsetLine.properties.stroke = "#00F"
  */
-export default function (geojson, distance, units) {
+function lineOffset(geojson, distance, units) {
     if (!geojson) throw new Error('geojson is required');
     if (distance === undefined || distance === null || isNaN(distance)) throw new Error('distance is required');
     var type = (geojson.type === 'Feature') ? geojson.geometry.type : geojson.type;
@@ -28,11 +28,11 @@ export default function (geojson, distance, units) {
 
     switch (type) {
     case 'LineString':
-        return lineOffset(geojson, distance, units);
+        return lineOffsetFeature(geojson, distance, units);
     case 'MultiLineString':
         var coords = [];
         flattenEach(geojson, function (feature) {
-            coords.push(lineOffset(feature, distance, units).geometry.coordinates);
+            coords.push(lineOffsetFeature(feature, distance, units).geometry.coordinates);
         });
         return multiLineString(coords, properties);
     default:
@@ -49,7 +49,7 @@ export default function (geojson, distance, units) {
  * @param {string} [units=kilometers] units
  * @returns {Feature<LineString>} Line offset from the input line
  */
-function lineOffset(line, distance, units) {
+function lineOffsetFeature(line, distance, units) {
     var segments = [];
     var offsetDegrees = distanceToDegrees(distance, units);
     var coords = getCoords(line);
@@ -103,3 +103,6 @@ function processSegment(point1, point2, offset) {
     var out2y = point2[1] + offset * (point1[0] - point2[0]) / L;
     return [[out1x, out1y], [out2x, out2y]];
 }
+
+export default lineOffset;
+module.exports.default = lineOffset;

--- a/packages/turf-line-offset/index.js
+++ b/packages/turf-line-offset/index.js
@@ -105,4 +105,3 @@ function processSegment(point1, point2, offset) {
 }
 
 export default lineOffset;
-module.exports.default = lineOffset;

--- a/packages/turf-line-overlap/index.js
+++ b/packages/turf-line-overlap/index.js
@@ -109,4 +109,3 @@ function concatSegment(line, segment) {
 }
 
 export default lineOverlap;
-module.exports.default = lineOverlap;

--- a/packages/turf-line-overlap/index.js
+++ b/packages/turf-line-overlap/index.js
@@ -24,7 +24,7 @@ import { featureEach, segmentEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [line1, line2, overlapping]
  */
-export default function (line1, line2, tolerance) {
+function lineOverlap(line1, line2, tolerance) {
     var features = [];
     tolerance = tolerance || 0;
 
@@ -107,3 +107,6 @@ function concatSegment(line, segment) {
     else if (equal(coords[1], end)) geom.push(coords[0]);
     return line;
 }
+
+export default lineOverlap;
+module.exports.default = lineOverlap;

--- a/packages/turf-line-segment/index.js
+++ b/packages/turf-line-segment/index.js
@@ -92,4 +92,3 @@ function bbox(coords1, coords2) {
 }
 
 export default lineSegment;
-module.exports.default = lineSegment;

--- a/packages/turf-line-segment/index.js
+++ b/packages/turf-line-segment/index.js
@@ -15,12 +15,12 @@ import { flattenEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [polygon, segments]
  */
-export default function (geojson) {
+function lineSegment(geojson) {
     if (!geojson) throw new Error('geojson is required');
 
     var results = [];
     flattenEach(geojson, function (feature) {
-        lineSegment(feature, results);
+        lineSegmentFeature(feature, results);
     });
     return featureCollection(results);
 }
@@ -33,7 +33,7 @@ export default function (geojson) {
  * @param {Array} results push to results
  * @returns {void}
  */
-function lineSegment(geojson, results) {
+function lineSegmentFeature(geojson, results) {
     var coords = [];
     var geometry = geojson.geometry;
     switch (geometry.type) {
@@ -90,3 +90,6 @@ function bbox(coords1, coords2) {
     var north = (y1 > y2) ? y1 : y2;
     return [west, south, east, north];
 }
+
+export default lineSegment;
+module.exports.default = lineSegment;

--- a/packages/turf-line-slice-along/index.js
+++ b/packages/turf-line-slice-along/index.js
@@ -73,4 +73,3 @@ function lineSliceAlong(line, startDist, stopDist, units) {
 }
 
 export default lineSliceAlong;
-module.exports.default = lineSliceAlong;

--- a/packages/turf-line-slice-along/index.js
+++ b/packages/turf-line-slice-along/index.js
@@ -25,7 +25,7 @@ import { lineString } from '@turf/helpers';
  * //addToMap
  * var addToMap = [line, start, stop, sliced]
  */
-export default function (line, startDist, stopDist, units) {
+function lineSliceAlong(line, startDist, stopDist, units) {
     var coords;
     var slice = [];
     if (line.type === 'Feature') coords = line.geometry.coordinates;
@@ -71,3 +71,6 @@ export default function (line, startDist, stopDist, units) {
     }
     return lineString(coords[coords.length - 1]);
 }
+
+export default lineSliceAlong;
+module.exports.default = lineSliceAlong;

--- a/packages/turf-line-slice/index.js
+++ b/packages/turf-line-slice/index.js
@@ -57,4 +57,3 @@ function lineSlice(startPt, stopPt, line) {
 }
 
 export default lineSlice;
-module.exports.default = lineSlice;

--- a/packages/turf-line-slice/index.js
+++ b/packages/turf-line-slice/index.js
@@ -30,7 +30,7 @@ import pointOnLine from '@turf/point-on-line';
  * //addToMap
  * var addToMap = [start, stop, line]
  */
-export default function lineSlice(startPt, stopPt, line) {
+function lineSlice(startPt, stopPt, line) {
     var coords;
     if (line.type === 'Feature') {
         coords = line.geometry.coordinates;
@@ -55,3 +55,6 @@ export default function lineSlice(startPt, stopPt, line) {
     clipCoords.push(ends[1].geometry.coordinates);
     return linestring(clipCoords, line.properties);
 }
+
+export default lineSlice;
+module.exports.default = lineSlice;

--- a/packages/turf-line-split/index.js
+++ b/packages/turf-line-split/index.js
@@ -194,4 +194,3 @@ function pointsEquals(pt1, pt2) {
 }
 
 export default lineSplit;
-module.exports.default = lineSplit;

--- a/packages/turf-line-split/index.js
+++ b/packages/turf-line-split/index.js
@@ -24,7 +24,7 @@ import lineIntersect from '@turf/line-intersect';
  * //addToMap
  * var addToMap = [line, splitter]
  */
-export default function (line, splitter) {
+function lineSplit(line, splitter) {
     if (!line) throw new Error('line is required');
     if (!splitter) throw new Error('splitter is required');
 
@@ -192,3 +192,6 @@ function findClosestFeature(point, lines) {
 function pointsEquals(pt1, pt2) {
     return pt1[0] === pt2[0] && pt1[1] === pt2[1];
 }
+
+export default lineSplit;
+module.exports.default = lineSplit;

--- a/packages/turf-linestring-to-polygon/index.js
+++ b/packages/turf-linestring-to-polygon/index.js
@@ -19,7 +19,7 @@ import { polygon, multiPolygon, lineString } from '@turf/helpers';
  * //addToMap
  * var addToMap = [polygon];
  */
-export default function (lines, properties, autoComplete, orderCoords) {
+function linestringToPolygon(lines, properties, autoComplete, orderCoords) {
     // validation
     if (!lines) throw new Error('lines is required');
 
@@ -124,3 +124,6 @@ function calculateArea(bbox) {
     var north = bbox[3];
     return Math.abs(west - east) * Math.abs(south - north);
 }
+
+export default linestringToPolygon;
+module.exports.default = linestringToPolygon;

--- a/packages/turf-linestring-to-polygon/index.js
+++ b/packages/turf-linestring-to-polygon/index.js
@@ -126,4 +126,3 @@ function calculateArea(bbox) {
 }
 
 export default linestringToPolygon;
-module.exports.default = linestringToPolygon;

--- a/packages/turf-mask/index.js
+++ b/packages/turf-mask/index.js
@@ -20,7 +20,7 @@ import { flattenEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [masked]
  */
-export default function (polygon, mask) {
+function mask(polygon, mask) {
     // Define mask
     var maskPolygon = createMask(mask);
 
@@ -181,3 +181,6 @@ function createIndex(features) {
     tree.load(load);
     return tree;
 }
+
+export default mask;
+module.exports.default = mask;

--- a/packages/turf-mask/index.js
+++ b/packages/turf-mask/index.js
@@ -183,4 +183,3 @@ function createIndex(features) {
 }
 
 export default mask;
-module.exports.default = mask;

--- a/packages/turf-midpoint/index.js
+++ b/packages/turf-midpoint/index.js
@@ -20,10 +20,13 @@ import distance from '@turf/distance';
  * var addToMap = [point1, point2, midpoint];
  * midpoint.properties['marker-color'] = '#f00';
  */
-export default function (point1, point2) {
+function midpoint(point1, point2) {
     var dist = distance(point1, point2, 'miles');
     var heading = bearing(point1, point2);
     var midpoint = destination(point1, dist / 2, heading, 'miles');
 
     return midpoint;
 }
+
+export default midpoint;
+module.exports.default = midpoint;

--- a/packages/turf-midpoint/index.js
+++ b/packages/turf-midpoint/index.js
@@ -29,4 +29,3 @@ function midpoint(point1, point2) {
 }
 
 export default midpoint;
-module.exports.default = midpoint;

--- a/packages/turf-nearest-point-to-line/index.js
+++ b/packages/turf-nearest-point-to-line/index.js
@@ -76,4 +76,3 @@ function handleCollection(points) {
 }
 
 export default nearestPointToLine;
-module.exports.default = nearestPointToLine;

--- a/packages/turf-nearest-point-to-line/index.js
+++ b/packages/turf-nearest-point-to-line/index.js
@@ -22,7 +22,7 @@ import { featureEach, geomEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [nearest, line];
  */
-export default function (points, line, options) {
+function nearestPointToLine(points, line, options) {
     // Backwards compatible with v4.0
     var units = (typeof options === 'object') ? options.units : options;
 
@@ -74,3 +74,6 @@ function handleCollection(points) {
         throw new Error('points must be a Point Collection');
     }
 }
+
+export default nearestPointToLine;
+module.exports.default = nearestPointToLine;

--- a/packages/turf-nearest/index.js
+++ b/packages/turf-nearest/index.js
@@ -24,7 +24,7 @@ import distance from '@turf/distance';
  * var addToMap = [targetPoint, points, nearest];
  * nearest.properties['marker-color'] = '#F00';
  */
-export default function (targetPoint, points) {
+function nearest(targetPoint, points) {
     var nearestPoint, minDist = Infinity;
     for (var i = 0; i < points.features.length; i++) {
         var distanceToPoint = distance(targetPoint, points.features[i], 'miles');
@@ -35,3 +35,6 @@ export default function (targetPoint, points) {
     }
     return nearestPoint;
 }
+
+export default nearest;
+module.exports.default = nearest;

--- a/packages/turf-nearest/index.js
+++ b/packages/turf-nearest/index.js
@@ -37,4 +37,3 @@ function nearest(targetPoint, points) {
 }
 
 export default nearest;
-module.exports.default = nearest;

--- a/packages/turf-planepoint/index.js
+++ b/packages/turf-planepoint/index.js
@@ -32,7 +32,7 @@ import { getCoord, getGeom } from '@turf/invariant';
  * //addToMap
  * var addToMap = [triangle, point];
  */
-export default function (point, triangle) {
+function planepoint(point, triangle) {
     // Normalize input
     var coord = getCoord(point);
     var geom = getGeom(triangle);
@@ -63,3 +63,6 @@ export default function (point, triangle) {
 
     return z;
 }
+
+export default planepoint;
+module.exports.default = planepoint;

--- a/packages/turf-planepoint/index.js
+++ b/packages/turf-planepoint/index.js
@@ -65,4 +65,3 @@ function planepoint(point, triangle) {
 }
 
 export default planepoint;
-module.exports.default = planepoint;

--- a/packages/turf-point-grid/index.js
+++ b/packages/turf-point-grid/index.js
@@ -80,4 +80,3 @@ function pointGrid(bbox, cellSide, options) {
 }
 
 export default pointGrid;
-module.exports.default = pointGrid;

--- a/packages/turf-point-grid/index.js
+++ b/packages/turf-point-grid/index.js
@@ -24,7 +24,7 @@ import { getType } from '@turf/invariant';
  * //addToMap
  * var addToMap = [grid];
  */
-export default function pointGrid(bbox, cellSide, options) {
+function pointGrid(bbox, cellSide, options) {
     options = options || {};
     var  results = [];
     var  bboxMask = bbox;
@@ -78,3 +78,6 @@ export default function pointGrid(bbox, cellSide, options) {
 
     return featureCollection(results);
 }
+
+export default pointGrid;
+module.exports.default = pointGrid;

--- a/packages/turf-point-on-line/index.js
+++ b/packages/turf-point-on-line/index.js
@@ -31,7 +31,7 @@ import { getCoords } from '@turf/invariant';
  * var addToMap = [line, pt, snapped];
  * snapped.properties['marker-color'] = '#00f';
  */
-export default function (lines, pt, units) {
+function pointOnLine(lines, pt, units) {
     // validation
     var type = (lines.geometry) ? lines.geometry.type : lines.type;
     if (type !== 'LineString' && type !== 'MultiLineString') {
@@ -90,3 +90,6 @@ export default function (lines, pt, units) {
 
     return closestPt;
 }
+
+export default pointOnLine;
+module.exports.default = pointOnLine;

--- a/packages/turf-point-on-line/index.js
+++ b/packages/turf-point-on-line/index.js
@@ -92,4 +92,3 @@ function pointOnLine(lines, pt, units) {
 }
 
 export default pointOnLine;
-module.exports.default = pointOnLine;

--- a/packages/turf-point-on-surface/index.js
+++ b/packages/turf-point-on-surface/index.js
@@ -139,3 +139,4 @@ function pointOnSegment(x, y, x1, y1, x2, y2) {
 }
 
 export default pointOnSurface;
+module.exports.default = pointOnSurface;

--- a/packages/turf-point-on-surface/index.js
+++ b/packages/turf-point-on-surface/index.js
@@ -139,4 +139,3 @@ function pointOnSegment(x, y, x1, y1, x2, y2) {
 }
 
 export default pointOnSurface;
-module.exports.default = pointOnSurface;

--- a/packages/turf-point-to-line-distance/index.js
+++ b/packages/turf-point-to-line-distance/index.js
@@ -34,7 +34,7 @@ import {
  * var distance = turf.pointToLineDistance(pt, line, 'miles');
  * //=69.11854715938406
  */
-export default function (pt, line, options) {
+function pointToLineDistance(pt, line, options) {
     // Optional params
     options = options || {};
     // var units = options.units;
@@ -253,3 +253,6 @@ function toWGS84(xy) {
         ((Math.PI * 0.5) - 2.0 * Math.atan(Math.exp(-xy[1] / A))) * R2D
     ];
 }
+
+export default pointToLineDistance;
+module.exports.default = pointToLineDistance;

--- a/packages/turf-point-to-line-distance/index.js
+++ b/packages/turf-point-to-line-distance/index.js
@@ -255,4 +255,3 @@ function toWGS84(xy) {
 }
 
 export default pointToLineDistance;
-module.exports.default = pointToLineDistance;

--- a/packages/turf-polygon-tangents/index.js
+++ b/packages/turf-polygon-tangents/index.js
@@ -85,4 +85,3 @@ function isLeft(point1, point2, point3) {
 }
 
 export default polygonTangents;
-module.exports.default = polygonTangents;

--- a/packages/turf-polygon-tangents/index.js
+++ b/packages/turf-polygon-tangents/index.js
@@ -17,7 +17,7 @@ import { point, featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [tangents, point, polygon];
  */
-export default function (pt, polygon) {
+function polygonTangents(pt, polygon) {
     var eprev;
     var enext;
     var rtan;
@@ -83,3 +83,6 @@ function isBelow(point1, point2, point3) {
 function isLeft(point1, point2, point3) {
     return (point2[0] - point1[0]) * (point3[1] - point1[1]) - (point3[0] - point1[0]) * (point2[1] - point1[1]);
 }
+
+export default polygonTangents;
+module.exports.default = polygonTangents;

--- a/packages/turf-polygon-to-linestring/index.js
+++ b/packages/turf-polygon-to-linestring/index.js
@@ -16,7 +16,7 @@ import { lineString, multiLineString, featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [line];
  */
-export default function (polygon, properties) {
+function polygonToLinestring(polygon, properties) {
     var geom = getType(polygon);
     var coords = getCoords(polygon);
     properties = properties || polygon.properties || {};
@@ -41,3 +41,6 @@ function coordsToLine(coords, properties) {
     if (coords.length > 1) return multiLineString(coords, properties);
     return lineString(coords[0], properties);
 }
+
+export default polygonToLinestring;
+module.exports.default = polygonToLinestring;

--- a/packages/turf-polygon-to-linestring/index.js
+++ b/packages/turf-polygon-to-linestring/index.js
@@ -43,4 +43,3 @@ function coordsToLine(coords, properties) {
 }
 
 export default polygonToLinestring;
-module.exports.default = polygonToLinestring;

--- a/packages/turf-polygonize/index.js
+++ b/packages/turf-polygonize/index.js
@@ -25,4 +25,3 @@ function polygonize(geojson) {
 }
 
 export default polygonize;
-module.exports.default = polygonize;

--- a/packages/turf-polygonize/index.js
+++ b/packages/turf-polygonize/index.js
@@ -1,4 +1,4 @@
-var polygonize = require('polygonize');
+var polygonizeSource = require('polygonize');
 
 /**
  * Polygonizes {@link LineString|(Multi)LineString(s)} into {@link Polygons}.
@@ -21,7 +21,7 @@ var polygonize = require('polygonize');
  * @throws {Error} if GeoJSON is invalid.
  */
 function polygonize(geojson) {
-    return polygonize(geojson);
+    return polygonizeSource(geojson);
 }
 
 export default polygonize;

--- a/packages/turf-polygonize/index.js
+++ b/packages/turf-polygonize/index.js
@@ -20,6 +20,9 @@ var polygonize = require('polygonize');
  * @returns {FeatureCollection<Polygon>} Polygons created
  * @throws {Error} if GeoJSON is invalid.
  */
-export default function (geojson) {
+function polygonize(geojson) {
     return polygonize(geojson);
 }
+
+export default polygonize;
+module.exports.default = polygonize;

--- a/packages/turf-projection/index.js
+++ b/packages/turf-projection/index.js
@@ -134,4 +134,3 @@ function convertToWgs84(xy) {
 function sign(x) {
     return (x < 0) ? -1 : (x > 0) ? 1 : 0;
 }
-

--- a/packages/turf-random/index.js
+++ b/packages/turf-random/index.js
@@ -50,4 +50,3 @@ function random(type, count, options) {
 }
 
 export default random;
-module.exports.default = random;

--- a/packages/turf-random/index.js
+++ b/packages/turf-random/index.js
@@ -1,4 +1,4 @@
-var random = require('geojson-random');
+var geojsonRandom = require('geojson-random');
 
 /**
  * Generates random {@link GeoJSON} data, including {@link Point|Points} and {@link Polygon|Polygons}, for testing
@@ -29,17 +29,17 @@ var random = require('geojson-random');
  * //addToMap
  * var addToMap = [points, polygons]
  */
-export default function (type, count, options) {
+function random(type, count, options) {
     options = options || {};
     count = count || 1;
     switch (type) {
     case 'point':
     case 'points':
     case undefined:
-        return random.point(count, options.bbox);
+        return geojsonRandom.point(count, options.bbox);
     case 'polygon':
     case 'polygons':
-        return random.polygon(
+        return geojsonRandom.polygon(
             count,
             options.num_vertices,
             options.max_radial_length,
@@ -48,3 +48,6 @@ export default function (type, count, options) {
         throw new Error('Unknown type given: valid options are points and polygons');
     }
 }
+
+export default random;
+module.exports.default = random;

--- a/packages/turf-rewind/index.js
+++ b/packages/turf-rewind/index.js
@@ -19,7 +19,7 @@ import { featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [rewind];
  */
-export default function (geojson, reverse, mutate) {
+function rewind(geojson, reverse, mutate) {
     // default params
     reverse = (reverse !== undefined) ? reverse : false;
     mutate = (mutate !== undefined) ? mutate : false;
@@ -37,19 +37,19 @@ export default function (geojson, reverse, mutate) {
     switch (geojson.type) {
     case 'GeometryCollection':
         geomEach(geojson, function (geometry) {
-            rewind(geometry, reverse);
+            rewindFeature(geometry, reverse);
         });
         return geojson;
     case 'FeatureCollection':
         featureEach(geojson, function (feature) {
-            featureEach(rewind(feature, reverse), function (result) {
+            featureEach(rewindFeature(feature, reverse), function (result) {
                 results.push(result);
             });
         });
         return featureCollection(results);
     }
     // Support Feature or Geometry Objects
-    return rewind(geojson, reverse);
+    return rewindFeature(geojson, reverse);
 }
 
 /**
@@ -60,14 +60,14 @@ export default function (geojson, reverse, mutate) {
  * @param {Boolean} [reverse=false] enable reverse winding
  * @returns {Geometry|Feature<any>} rewind Geometry or Feature
  */
-function rewind(geojson, reverse) {
+function rewindFeature(geojson, reverse) {
     var type = (geojson.type === 'Feature') ? geojson.geometry.type : geojson.type;
 
     // Support all GeoJSON Geometry Objects
     switch (type) {
     case 'GeometryCollection':
         geomEach(geojson, function (geometry) {
-            rewind(geometry, reverse);
+            rewindFeature(geometry, reverse);
         });
         return geojson;
     case 'LineString':
@@ -124,3 +124,6 @@ function rewindPolygon(coords, reverse) {
         }
     }
 }
+
+export default rewind;
+module.exports.default = rewind;

--- a/packages/turf-rewind/index.js
+++ b/packages/turf-rewind/index.js
@@ -126,4 +126,3 @@ function rewindPolygon(coords, reverse) {
 }
 
 export default rewind;
-module.exports.default = rewind;

--- a/packages/turf-rhumb-bearing/index.js
+++ b/packages/turf-rhumb-bearing/index.js
@@ -72,4 +72,3 @@ function calculateRhumbBearing(from, to) {
 }
 
 export default rhumbBearing;
-module.exports.default = rhumbBearing;

--- a/packages/turf-rhumb-bearing/index.js
+++ b/packages/turf-rhumb-bearing/index.js
@@ -23,7 +23,7 @@ import {radians2degrees, degrees2radians} from '@turf/helpers';
  * point1.properties.bearing = bearing;
  * point2.properties.bearing = bearing;
  */
-export default function rhumbBearing(start, end, options) {
+function rhumbBearing(start, end, options) {
     // validation
     if (!start) throw new Error('start point is required');
     if (!end) throw new Error('end point is required');
@@ -70,3 +70,6 @@ function calculateRhumbBearing(from, to) {
 
     return (radians2degrees(theta) + 360) % 360;
 }
+
+export default rhumbBearing;
+module.exports.default = rhumbBearing;

--- a/packages/turf-rhumb-destination/index.js
+++ b/packages/turf-rhumb-destination/index.js
@@ -85,4 +85,3 @@ function calculateRhumbDestination(origin, distance, bearing, radius) {
 }
 
 export default rhumbDestination;
-module.exports.default = rhumbDestination;

--- a/packages/turf-rhumb-destination/index.js
+++ b/packages/turf-rhumb-destination/index.js
@@ -24,7 +24,7 @@ import { getCoord } from '@turf/invariant';
  * var addToMap = [pt, destination]
  * destination.properties['marker-color'] = '#00F';
  */
-export default function rhumbDestination(origin, distance, bearing, options) {
+function rhumbDestination(origin, distance, bearing, options) {
     // validation
     if (!origin) throw new Error('origin is required');
     if (distance === undefined || distance === null) throw new Error('distance is required');
@@ -34,7 +34,7 @@ export default function rhumbDestination(origin, distance, bearing, options) {
 
     var distanceInMeters = convertDistance(distance, units, 'meters');
     var coords = getCoord(origin);
-    var destination = rhumbDestinationPoint(coords, distanceInMeters, bearing);
+    var destination = calculateRhumbDestination(coords, distanceInMeters, bearing);
 
     // compensate the crossing of the 180th meridian (https://macwright.org/2016/09/26/the-180th-meridian.html)
     // solution from https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678
@@ -54,7 +54,7 @@ export default function rhumbDestination(origin, distance, bearing, options) {
  * @param   {number} [radius=6371e3] - (Mean) radius of earth (defaults to radius in metres).
  * @returns {Array<number>} Destination point.
  */
-function rhumbDestinationPoint(origin, distance, bearing, radius) {
+function calculateRhumbDestination(origin, distance, bearing, radius) {
     // φ => phi
     // λ => lambda
     // ψ => psi
@@ -83,3 +83,6 @@ function rhumbDestinationPoint(origin, distance, bearing, radius) {
 
     return [((lambda2 * 180 / Math.PI) + 540) % 360 - 180, phi2 * 180 / Math.PI]; // normalise to −180..+180°
 }
+
+export default rhumbDestination;
+module.exports.default = rhumbDestination;

--- a/packages/turf-rhumb-distance/index.js
+++ b/packages/turf-rhumb-distance/index.js
@@ -87,4 +87,3 @@ function calculateRhumbDistance(origin, destination, radius) {
 }
 
 export default rhumbDistance;
-module.exports.default = rhumbDistance;

--- a/packages/turf-rhumb-distance/index.js
+++ b/packages/turf-rhumb-distance/index.js
@@ -23,7 +23,7 @@ import { getCoord } from '@turf/invariant';
  * from.properties.distance = distance;
  * to.properties.distance = distance;
  */
-export default function (from, to, options) {
+function rhumbDistance(from, to, options) {
     // validation
     if (!from) throw new Error('from point is required');
     if (!to) throw new Error('to point is required');
@@ -35,7 +35,7 @@ export default function (from, to, options) {
     // compensate the crossing of the 180th meridian (https://macwright.org/2016/09/26/the-180th-meridian.html)
     // solution from https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678
     destination[0] += (destination[0] - origin[0] > 180) ? -360 : (origin[0] - destination[0] > 180) ? 360 : 0;
-    var distanceInMeters = rhumbDistance(origin, destination);
+    var distanceInMeters = calculateRhumbDistance(origin, destination);
     var distance = convertDistance(distanceInMeters, 'meters', units);
     return distance;
 }
@@ -55,7 +55,7 @@ export default function (from, to, options) {
  *     var p2 = new LatLon(50.964, 1.853);
  *     var d = p1.distanceTo(p2); // 40.31 km
  */
-function rhumbDistance(origin, destination, radius) {
+function calculateRhumbDistance(origin, destination, radius) {
     // φ => phi
     // λ => lambda
     // ψ => psi
@@ -85,3 +85,6 @@ function rhumbDistance(origin, destination, radius) {
 
     return dist;
 }
+
+export default rhumbDistance;
+module.exports.default = rhumbDistance;

--- a/packages/turf-sample/index.js
+++ b/packages/turf-sample/index.js
@@ -22,7 +22,7 @@ import { featureCollection } from '@turf/helpers';
  *   currentFeature.properties['marker-color'] = '#000';
  * });
  */
-export default function (featurecollection, num) {
+function sample(featurecollection, num) {
     if (!featurecollection) throw new Error('featurecollection is required');
     if (num === null || num === undefined) throw new Error('num is required');
     if (typeof num !== 'number') throw new Error('num must be a number');
@@ -41,3 +41,6 @@ function getRandomSubarray(arr, size) {
     }
     return shuffled.slice(min);
 }
+
+export default sample;
+module.exports.default = sample;

--- a/packages/turf-sample/index.js
+++ b/packages/turf-sample/index.js
@@ -43,4 +43,3 @@ function getRandomSubarray(arr, size) {
 }
 
 export default sample;
-module.exports.default = sample;

--- a/packages/turf-sector/index.js
+++ b/packages/turf-sector/index.js
@@ -70,4 +70,3 @@ function convertAngleTo360(alfa) {
 }
 
 export default sector;
-module.exports.default = sector;

--- a/packages/turf-sector/index.js
+++ b/packages/turf-sector/index.js
@@ -28,7 +28,7 @@ import { getCoords } from '@turf/invariant';
  * //addToMap
  * var addToMap = [center, sector];
  */
-export default function (center, radius, bearing1, bearing2, options) {
+function sector(center, radius, bearing1, bearing2, options) {
     // Optional params
     options = options || {};
 
@@ -68,3 +68,6 @@ function convertAngleTo360(alfa) {
     }
     return beta;
 }
+
+export default sector;
+module.exports.default = sector;

--- a/packages/turf-simplify/index.js
+++ b/packages/turf-simplify/index.js
@@ -165,4 +165,3 @@ function checkValidity(ring) {
 }
 
 export default simplify;
-module.exports.default = simplify;

--- a/packages/turf-simplify/index.js
+++ b/packages/turf-simplify/index.js
@@ -43,7 +43,7 @@ import { geomEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [geojson, simplified]
  */
-export default function (geojson, tolerance, highQuality, mutate) {
+function simplify(geojson, tolerance, highQuality, mutate) {
     if (!geojson) throw new Error('geojson is required');
     if (tolerance && tolerance < 0) throw new Error('invalid tolerance');
 
@@ -51,7 +51,7 @@ export default function (geojson, tolerance, highQuality, mutate) {
     if (mutate !== true) geojson = clone(geojson);
 
     geomEach(geojson, function (geom) {
-        simplify(geom, tolerance, highQuality);
+        simplifyGeom(geom, tolerance, highQuality);
     });
     return geojson;
 }
@@ -65,7 +65,7 @@ export default function (geojson, tolerance, highQuality, mutate) {
  * @param {boolean} [highQuality=false] whether or not to spend more time to create a higher-quality simplification with a different algorithm
  * @returns {Geometry} output
  */
-function simplify(geometry, tolerance, highQuality) {
+function simplifyGeom(geometry, tolerance, highQuality) {
     var type = geometry.type;
 
     // "unsimplyfiable" geometry types
@@ -163,3 +163,6 @@ function checkValidity(ring) {
     //if the last point is the same as the first, it's not a triangle
     return !(ring.length === 3 && ((ring[2][0] === ring[0][0]) && (ring[2][1] === ring[0][1])));
 }
+
+export default simplify;
+module.exports.default = simplify;

--- a/packages/turf-square-grid/index.js
+++ b/packages/turf-square-grid/index.js
@@ -21,7 +21,7 @@ import { point, polygon, featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [squareGrid]
  */
-export default function squareGrid(bbox, cellSize, units, completelyWithin) {
+function squareGrid(bbox, cellSize, units, completelyWithin) {
     var results = [];
 
     // validation
@@ -72,3 +72,6 @@ export default function squareGrid(bbox, cellSize, units, completelyWithin) {
     }
     return featureCollection(results);
 }
+
+export default squareGrid;
+module.exports.default = squareGrid;

--- a/packages/turf-square-grid/index.js
+++ b/packages/turf-square-grid/index.js
@@ -74,4 +74,3 @@ function squareGrid(bbox, cellSize, units, completelyWithin) {
 }
 
 export default squareGrid;
-module.exports.default = squareGrid;

--- a/packages/turf-square/index.js
+++ b/packages/turf-square/index.js
@@ -46,4 +46,3 @@ function square(bbox) {
 }
 
 export default square;
-module.exports.default = square;

--- a/packages/turf-square/index.js
+++ b/packages/turf-square/index.js
@@ -18,7 +18,7 @@ import distance from '@turf/distance';
  * //addToMap
  * var addToMap = [features]
  */
-export default function (bbox) {
+function square(bbox) {
     var west = bbox[0];
     var south = bbox[1];
     var east = bbox[2];
@@ -44,3 +44,6 @@ export default function (bbox) {
         ];
     }
 }
+
+export default square;
+module.exports.default = square;

--- a/packages/turf-tag/index.js
+++ b/packages/turf-tag/index.js
@@ -37,7 +37,7 @@ import { featureEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [tagged, polygons]
  */
-export default function (points, polygons, field, outField) {
+function tag(points, polygons, field, outField) {
     // prevent mutations
     points = clone(points);
     polygons = clone(polygons);
@@ -51,3 +51,6 @@ export default function (points, polygons, field, outField) {
     });
     return points;
 }
+
+export default tag;
+module.exports.default = tag;

--- a/packages/turf-tag/index.js
+++ b/packages/turf-tag/index.js
@@ -53,4 +53,3 @@ function tag(points, polygons, field, outField) {
 }
 
 export default tag;
-module.exports.default = tag;

--- a/packages/turf-tesselate/index.js
+++ b/packages/turf-tesselate/index.js
@@ -74,4 +74,3 @@ function flattenCoords(data) {
 }
 
 export default tesselate;
-module.exports.default = tesselate;

--- a/packages/turf-tesselate/index.js
+++ b/packages/turf-tesselate/index.js
@@ -15,7 +15,7 @@ import { polygon } from '@turf/helpers';
  * //addToMap
  * var addToMap = [poly, triangles]
  */
-export default function (poly) {
+function tesselate(poly) {
     if (!poly.geometry || (poly.geometry.type !== 'Polygon' && poly.geometry.type !== 'MultiPolygon')) {
         throw new Error('input must be a Polygon or MultiPolygon');
     }
@@ -72,3 +72,6 @@ function flattenCoords(data) {
 
     return result;
 }
+
+export default tesselate;
+module.exports.default = tesselate;

--- a/packages/turf-tin/index.js
+++ b/packages/turf-tin/index.js
@@ -35,7 +35,7 @@ import { polygon, featureCollection } from '@turf/helpers';
  *   properties.fill = '#' + properties.a + properties.b + properties.c;
  * }
  */
-export default function (points, z) {
+function tin(points, z) {
     if (points.type !== 'FeatureCollection') throw new Error('points must be a FeatureCollection');
     //break down points
     var isPointZ = false;
@@ -255,3 +255,6 @@ function triangulate(vertices) {
 
     return closed;
 }
+
+export default tin;
+module.exports.default = tin;

--- a/packages/turf-tin/index.js
+++ b/packages/turf-tin/index.js
@@ -257,4 +257,3 @@ function triangulate(vertices) {
 }
 
 export default tin;
-module.exports.default = tin;

--- a/packages/turf-transform-rotate/index.js
+++ b/packages/turf-transform-rotate/index.js
@@ -50,4 +50,3 @@ function transformRotate(geojson, angle, pivot, mutate) {
 }
 
 export default transformRotate;
-module.exports.default = transformRotate;

--- a/packages/turf-transform-rotate/index.js
+++ b/packages/turf-transform-rotate/index.js
@@ -23,7 +23,7 @@ import { getCoords } from '@turf/invariant';
  * var addToMap = [poly, rotatedPoly];
  * rotatedPoly.properties = {stroke: '#F00', 'stroke-width': 4};
  */
-export default function (geojson, angle, pivot, mutate) {
+function transformRotate(geojson, angle, pivot, mutate) {
     // Input validation
     if (!geojson) throw new Error('geojson is required');
     if (angle === undefined || angle === null || isNaN(angle)) throw new Error('angle is required');
@@ -48,3 +48,6 @@ export default function (geojson, angle, pivot, mutate) {
     });
     return geojson;
 }
+
+export default transformRotate;
+module.exports.default = transformRotate;

--- a/packages/turf-transform-scale/index.js
+++ b/packages/turf-transform-scale/index.js
@@ -133,4 +133,3 @@ function defineOrigin(geojson, origin) {
 }
 
 export default transformScale;
-module.exports.default = transformScale;

--- a/packages/turf-transform-scale/index.js
+++ b/packages/turf-transform-scale/index.js
@@ -27,7 +27,7 @@ import { getCoord, getCoords, getType} from '@turf/invariant';
  * var addToMap = [poly, scaledPoly];
  * scaledPoly.properties = {stroke: '#F00', 'stroke-width': 4};
  */
-export default function (geojson, factor, origin, mutate) {
+function transformScale(geojson, factor, origin, mutate) {
     // Input validation
     if (!geojson) throw new Error('geojson required');
     if (typeof factor !== 'number' || factor === 0) throw new Error('invalid factor');
@@ -131,3 +131,6 @@ function defineOrigin(geojson, origin) {
         throw new Error('invalid origin');
     }
 }
+
+export default transformScale;
+module.exports.default = transformScale;

--- a/packages/turf-transform-translate/index.js
+++ b/packages/turf-transform-translate/index.js
@@ -22,7 +22,7 @@ import rhumbDestination from '@turf/rhumb-destination';
  * var addToMap = [poly, translatedPoly];
  * translatedPoly.properties = {stroke: '#F00', 'stroke-width': 4};
  */
-export default function (geojson, distance, direction, units, zTranslation, mutate) {
+function transformTranslate(geojson, distance, direction, units, zTranslation, mutate) {
     // Input validation
     if (!geojson) throw new Error('geojson is required');
     if (distance === undefined || distance === null || isNaN(distance)) throw new Error('distance is required');
@@ -52,3 +52,6 @@ export default function (geojson, distance, direction, units, zTranslation, muta
     });
     return geojson;
 }
+
+export default transformTranslate;
+module.exports.default = transformTranslate;

--- a/packages/turf-transform-translate/index.js
+++ b/packages/turf-transform-translate/index.js
@@ -54,4 +54,3 @@ function transformTranslate(geojson, distance, direction, units, zTranslation, m
 }
 
 export default transformTranslate;
-module.exports.default = transformTranslate;

--- a/packages/turf-triangle-grid/index.js
+++ b/packages/turf-triangle-grid/index.js
@@ -19,7 +19,7 @@ import { polygon, featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [triangleGrid];
  */
-export default function (bbox, cellSize, units) {
+function triangleGrid(bbox, cellSize, units) {
     var fc = featureCollection([]);
     var xFraction = cellSize / (distance([bbox[0], bbox[1]], [bbox[2], bbox[1]], units));
     var cellWidth = xFraction * (bbox[2] - bbox[0]);
@@ -90,3 +90,6 @@ export default function (bbox, cellSize, units) {
     return fc;
 }
 
+
+export default triangleGrid;
+module.exports.default = triangleGrid;

--- a/packages/turf-triangle-grid/index.js
+++ b/packages/turf-triangle-grid/index.js
@@ -92,4 +92,3 @@ function triangleGrid(bbox, cellSize, units) {
 
 
 export default triangleGrid;
-module.exports.default = triangleGrid;

--- a/packages/turf-truncate/index.js
+++ b/packages/turf-truncate/index.js
@@ -64,4 +64,3 @@ function truncateCoords(coords, factor, coordinates) {
 }
 
 export default truncate;
-module.exports.default = truncate;

--- a/packages/turf-truncate/index.js
+++ b/packages/turf-truncate/index.js
@@ -21,7 +21,7 @@ import { coordEach } from '@turf/meta';
  * //addToMap
  * var addToMap = [truncated];
  */
-export default function truncate(geojson, precision, coordinates, mutate) {
+function truncate(geojson, precision, coordinates, mutate) {
     // default params
     precision = (precision === undefined || precision === null || isNaN(precision)) ? 6 : precision;
     coordinates = (coordinates === undefined || coordinates === null || isNaN(coordinates)) ? 3 : coordinates;
@@ -62,3 +62,6 @@ function truncateCoords(coords, factor, coordinates) {
     }
     return coords;
 }
+
+export default truncate;
+module.exports.default = truncate;

--- a/packages/turf-union/index.js
+++ b/packages/turf-union/index.js
@@ -27,7 +27,7 @@ var jsts = require('jsts');
  * //addToMap
  * var addToMap = [poly1, poly2, union];
  */
-export default function () {
+function union() {
     var reader = new jsts.io.GeoJSONReader();
     var result = reader.read(JSON.stringify(arguments[0].geometry));
 
@@ -44,3 +44,6 @@ export default function () {
         properties: arguments[0].properties
     };
 }
+
+export default union;
+module.exports.default = union;

--- a/packages/turf-union/index.js
+++ b/packages/turf-union/index.js
@@ -46,4 +46,3 @@ function union() {
 }
 
 export default union;
-module.exports.default = union;

--- a/packages/turf-unkink-polygon/index.js
+++ b/packages/turf-unkink-polygon/index.js
@@ -17,7 +17,7 @@ import { polygon, featureCollection } from '@turf/helpers';
  * //addToMap
  * var addToMap = [poly, result]
  */
-export default function (geojson) {
+function unkinkPolygon(geojson) {
     var features = [];
     flattenEach(geojson, function (feature) {
         if (feature.geometry.type !== 'Polygon') return;
@@ -27,3 +27,6 @@ export default function (geojson) {
     });
     return featureCollection(features);
 }
+
+export default unkinkPolygon;
+module.exports.default = unkinkPolygon;

--- a/packages/turf-unkink-polygon/index.js
+++ b/packages/turf-unkink-polygon/index.js
@@ -29,4 +29,3 @@ function unkinkPolygon(geojson) {
 }
 
 export default unkinkPolygon;
-module.exports.default = unkinkPolygon;

--- a/packages/turf-within/index.js
+++ b/packages/turf-within/index.js
@@ -51,4 +51,3 @@ function within(points, polygons) {
 }
 
 export default within;
-module.exports.default = within;

--- a/packages/turf-within/index.js
+++ b/packages/turf-within/index.js
@@ -37,7 +37,7 @@ import { featureCollection } from '@turf/helpers';
  *   currentFeature.properties['marker-color'] = '#000';
  * });
  */
-export default function (points, polygons) {
+function within(points, polygons) {
     var pointsWithin = featureCollection([]);
     for (var i = 0; i < polygons.features.length; i++) {
         for (var j = 0; j < points.features.length; j++) {
@@ -49,3 +49,6 @@ export default function (points, polygons) {
     }
     return pointsWithin;
 }
+
+export default within;
+module.exports.default = within;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,21 @@
+function typesciptDefaultExport() {
+    return {
+        name: 'typescript-default-export',
+        transformBundle(code) {
+            code = code.trim();
+            const name = code.match(/module.exports = (\w+)/)
+            if (name) code += `\nmodule.exports.default = ${name[1]};\n`;
+            return code;
+        }
+    }
+}
+
 export default {
     input: 'index.js',
     output: {
         extend: true,
         file: 'main.js',
         format: 'cjs'
-    }
+    },
+    plugins: [typesciptDefaultExport()]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-function typesciptDefaultExport() {
+function typescriptExportsDefault() {
     return {
         name: 'typescript-default-export',
         transformBundle(code) {
@@ -17,5 +17,5 @@ export default {
         file: 'main.js',
         format: 'cjs'
     },
-    plugins: [typesciptDefaultExport()]
+    plugins: [typescriptExportsDefault()]
 };

--- a/scripts/update-export-default-typescript.js
+++ b/scripts/update-export-default-typescript.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+const fs = require('fs-extra');
+const path = require('path');
+const glob = require('glob');
+const load = require('load-json-file');
+const camelcase = require('camelcase');
+
+// Update index.js export default module (Typescript compatible)
+glob.sync(path.join(__dirname, '..', 'packages', 'turf-*', 'index.js')).forEach(filepath => {
+    let index = fs.readFileSync(filepath, 'utf8');
+    const dir = path.parse(filepath).dir;
+    const pckg = load.sync(path.join(dir, 'package.json'));
+    const name = camelcase(pckg.name).replace('@turf/', '');
+
+    // Modules without named export function
+    if (index.includes('export default function (')) {
+        // duplicate function names
+        if (index.includes('function ' + name)) {
+            throw new Error('duplicate function name', name);
+        }
+        index = index.replace('export default function (', `function ${name}(`);
+        index += `\nexport default ${name};`;
+        index += `\nmodule.exports.default = ${name};\n`;
+        fs.writeFileSync(filepath, index);
+    }
+    // Modules with named export function
+    if (index.includes(`export default function ${name}(`)) {
+        index = index.replace(`export default function ${name}(`, `function ${name}(`);
+        index += `\nexport default ${name};`;
+        index += `\nmodule.exports.default = ${name};\n`;
+        fs.writeFileSync(filepath, index);
+    }
+    if (index.includes('export default') && !index.includes('module.exports.default')) {
+        throw new Error('missing module.exports.default =', name);
+    }
+});

--- a/scripts/update-export-default-typescript.js
+++ b/scripts/update-export-default-typescript.js
@@ -31,7 +31,12 @@ glob.sync(path.join(__dirname, '..', 'packages', 'turf-*', 'index.js')).forEach(
         index += `\nmodule.exports.default = ${name};\n`;
         fs.writeFileSync(filepath, index);
     }
-    if (index.includes('export default') && !index.includes('module.exports.default')) {
-        throw new Error('missing module.exports.default =', name);
+    if (index.includes('module.exports.default')) {
+        console.log(name);
+        // throw new Error('invalid module.exports.default =', name);
     }
+    // Remove module.exports.default (will be handled with Rollup)
+    index = index.replace(`module.exports.default = ${name};`, '');
+    index = index.trim() + '\n';
+    fs.writeFileSync(filepath, index);
 });

--- a/scripts/update-to-es-modules.js
+++ b/scripts/update-to-es-modules.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const fs = require('fs-extra');
 const load = require('load-json-file');
 const write = require('write-json-file');
 const path = require('path');
@@ -31,7 +30,7 @@ function updateDependencies(pckg) {
 function updateDevDependencies(pckg) {
     const devDependencies = {};
     const dev = new Map(entries(pckg.devDependencies));
-    dev.delete('rollup-plugin-uglify', '*')
+    dev.delete('rollup-plugin-uglify', '*');
     dev.set('rollup', '*')
         .set('uglify-js', '*')
         .set('tape', '*')


### PR DESCRIPTION
# Support export default (Typescript)

Apparently Typescript doesn't support the Rollup CommonJS bundles... 😡 

## Typescript Issue

When a `.ts` file gets compiled, it attempts to import the module using `.default` and since Rollup doesn't export default then the module cannot be found.

```ts
var buffer = require("@turf/buffer");
buffer.default(pt, 5);
```

## Rollup solution ⭐️ 

All modules will have a `pretest` to compile the Rollup bundle. An extra preprocess has been added to the Rollup config to add the extra `module.exports.default` at the end of the bundle.

```bash
$ rollup -c ../../rollup.config.js
```

**main.js** (before)

```js
// <code>
module.exports = buffer;
```

**main.js** (after)

```js
// <code>
module.exports = buffer;
module.exports.default = buffer;
```