### PR TITLE
Extend Typescript definition for featureEach & featureReduce

### DIFF
--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -27,6 +27,10 @@ export type Feature<T extends GeometryObject> = GeoJSON.Feature<T>;
 export interface FeatureGeometryCollection extends Feature<any> {
     geometry: GeometryCollection;
 }
+export interface ExtendedFeatureCollection<Feat extends Feature<any>> {
+    type: 'FeatureCollection';
+    features: Feat[];
+}
 
 /**
  * http://turfjs.org/docs/#feature

--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -40,7 +40,7 @@ export function feature<T extends GeometryObject>(geometry: T, properties?: Prop
 /**
  * http://turfjs.org/docs/#featurecollection
  */
-export function featureCollection<T extends GeometryObject>(features: Feature<T>[], bbox?: BBox, id?: Id): FeatureCollection<T>;
+export function featureCollection<Geom extends GeometryObject>(features: Feature<Geom>[], bbox?: BBox, id?: Id): FeatureCollection<Geom>;
 export function featureCollection(features: Feature<any>[], bbox?: BBox, id?: Id): FeatureCollection<any>;
 
 /**

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -16,6 +16,10 @@ export type AllGeoJSON = Feature<any> | FeatureCollection<any> | GeometryObject 
 export interface FeatureGeometryCollection extends GeoJSON.Feature<any> {
     geometry: GeometryCollection;
 }
+export interface ExtendedFeatureCollection<Feat extends Feature<any>> {
+    type: 'FeatureCollection';
+    features: Feat[];
+}
 
 /**
  * http://turfjs.org/docs/#coordreduce
@@ -59,6 +63,11 @@ export function featureReduce<Reducer extends any, Geom extends GeometryObject>(
     callback: (previousValue: Reducer, currentFeature: Feature<Geom>, featureIndex: number) => Reducer,
     initialValue?: Reducer
 ): Reducer;
+export function featureReduce<Reducer extends any, Feat extends Feature<any>>(
+    geojson: Feat | ExtendedFeatureCollection<Feat>,
+    callback: (previousValue: Reducer, currentFeature: Feat, featureIndex: number) => Reducer,
+    initialValue?: Reducer
+): Reducer;
 
 /**
  * http://turfjs.org/docs/#featureeach
@@ -66,6 +75,10 @@ export function featureReduce<Reducer extends any, Geom extends GeometryObject>(
 export function featureEach<Geom extends GeometryObject>(
     geojson: Feature<Geom> | FeatureCollection<Geom> | FeatureGeometryCollection,
     callback: (currentFeature: Feature<Geom>, featureIndex: number) => void
+): void;
+export function featureEach<Feat extends Feature<any>>(
+    geojson: Feat | ExtendedFeatureCollection<Feat>,
+    callback: (currentFeature: Feat, featureIndex: number) => void
 ): void;
 
 /**

--- a/packages/turf-meta/types.ts
+++ b/packages/turf-meta/types.ts
@@ -1,4 +1,10 @@
 import * as helpers from '@turf/helpers'
+import {
+    featureCollection,
+    point,
+    Feature,
+    Point
+} from '@turf/helpers'
 import * as meta from './'
 import {
     coordReduce,
@@ -15,7 +21,8 @@ import {
     segmentReduce,
     segmentEach,
     lineReduce,
-    lineEach } from './'
+    lineEach
+} from './'
 
 // Fixtures
 const pt = helpers.point([0, 0])
@@ -189,3 +196,26 @@ meta.lineReduce(poly, (previousValue, currentLine, currentIndex) => currentLine)
 meta.lineReduce(poly, (previousValue, currentLine, currentIndex) => 1 + 1, 1)
 meta.lineReduce(multiPoly, (previousValue, currentLine, currentIndex, currentSubIndex) => currentLine)
 meta.lineReduce(multiPoly, (previousValue, currentLine, currentIndex, currentSubIndex) => 1 + 1, 1)
+
+/**
+ * Translate Feature Properties
+ */
+interface CustomPoint extends Feature<Point> {
+    properties: {
+        foo: string
+        bar: number
+        [key: string]: any
+    }
+}
+
+interface CustomPoints {
+    type: 'FeatureCollection';
+    features: CustomPoint[]
+}
+
+const customPoint = point([10, 20], {foo: 'abc', bar: 123})
+const customPoints: CustomPoints = featureCollection([customPoint])
+
+featureEach(customPoints, pt => {
+    pt.properties.bar
+})

--- a/packages/turf-meta/types.ts
+++ b/packages/turf-meta/types.ts
@@ -214,7 +214,7 @@ interface CustomPoints {
 }
 
 const customPoint = point([10, 20], {foo: 'abc', bar: 123})
-const customPoints: CustomPoints = featureCollection([customPoint])
+const customPoints: CustomPoints = featureCollection([customPoint, point([0, 0])])
 
 featureEach(customPoints, pt => {
     pt.properties.bar


### PR DESCRIPTION
## Extend Typescript definition for `featureEach` & `featureReduce`

If given a custom FeatureCollection to `featureEach` the callback `feature` is able to access the custom props defined in the previous interface.

**TS Example**

```ts
interface CustomPoint extends Feature<Point> {
    properties: {
        foo: string
        bar: number
        [key: string]: any
    }
}

interface CustomPoints {
    type: 'FeatureCollection';
    features: CustomPoint[]
}

const customPoint = point([10, 20], {foo: 'abc', bar: 123})
const customPoints: CustomPoints = featureCollection([customPoint, point([0, 0])])

featureEach(customPoints, pt => {
    pt.properties.bar
})
```
Code hinting translates the properties to the callback Feature.

![image](https://user-images.githubusercontent.com/550895/31090812-f9f1533c-a776-11e7-810f-dd14ed1bc3c7.png)


