### PR TITLE
Rework @turf/random & @turf/turf export modules

### DIFF
--- a/packages/turf-difference/index.d.ts
+++ b/packages/turf-difference/index.d.ts
@@ -1,12 +1,10 @@
-/// <reference types="geojson" />
-
-import {Polygon, MultiPolygon, Feature} from '@turf/meta'
-
-export type Input = Feature<Polygon|MultiPolygon> | Polygon | MultiPolygon;
-export type Output = Feature<Polygon|MultiPolygon> | null;
+import { Polygon, MultiPolygon, Feature } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#difference
  */
-export default function difference(polygon1: Input, polygon2: Input): Output;
+export default function difference(
+    polygon1: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon,
+    polygon2: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon
+): Feature<Polygon | MultiPolygon> | null;
 

--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -9,6 +9,7 @@ export type BBox = [number, number, number, number];
 export type Units = 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres';
 export type Geometry = 'Point' | 'LineString' | 'Polygon' | 'MultiPoint' | 'MultiLineString' | 'MultiPolygon';
 export type Grid = 'point' | 'square' | 'hex' | 'triangle';
+export type Types = Geometry | 'Feature' | 'FeatureCollection'
 
 // GeoJSON Geometry Types
 export type Position = GeoJSON.Position;
@@ -31,6 +32,7 @@ export interface ExtendedFeatureCollection<Feat extends Feature<any>> {
     type: 'FeatureCollection';
     features: Feat[];
 }
+export type AllGeoJSON = Feature<any> | FeatureCollection<any> | FeatureGeometryCollection | GeometryObject | GeometryCollection;
 
 /**
  * http://turfjs.org/docs/#feature

--- a/packages/turf-invariant/index.d.ts
+++ b/packages/turf-invariant/index.d.ts
@@ -1,11 +1,11 @@
-/// <reference types="geojson" />
-
-export type GeometryObject = GeoJSON.GeometryObject;
-export type GeometryCollection = GeoJSON.GeometryCollection;
-export type Feature<Geom extends GeometryObject> = GeoJSON.Feature<Geom>;
-export type FeatureCollection<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
-export type StringGeomTypes = 'Point' | 'LineString' | 'Polygon' | 'MultiPoint' | 'MultiLineString' | 'MultiPolygon' | 'GeometryCollection'
-export type StringTypes = StringGeomTypes | 'Feature' | 'FeatureCollection'
+import {
+    GeometryObject,
+    GeometryCollection,
+    Feature,
+    FeatureCollection,
+    Geometry,
+    Types
+} from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#getcoords
@@ -45,4 +45,5 @@ export function getGeom(geojson: GeometryCollection | GeometryObject | Feature<a
 /**
  * http://turfjs.org/docs/#gettype
  */
-export function getType(geojson: GeometryCollection | GeometryObject | Feature<any> | FeatureCollection<any>): StringTypes;
+export function getType(geojson: GeometryObject | Feature<any>): Geometry;
+export function getType(geojson: GeometryCollection | GeometryObject | Feature<any> | FeatureCollection<any>): Types;

--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -1,3 +1,5 @@
+import { isNumber } from '@turf/helpers';
+
 /**
  * Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
  *
@@ -16,9 +18,7 @@ export function getCoord(obj) {
     var coordinates = getCoords(obj);
 
     // getCoord() must contain at least two numbers (Point)
-    if (coordinates.length > 1 &&
-        typeof coordinates[0] === 'number' &&
-        typeof coordinates[1] === 'number') {
+    if (coordinates.length > 1 && isNumber(coordinates[0]) && isNumber(coordinates[1])) {
         return coordinates;
     } else {
         throw new Error('Coordinate is not a valid Point');
@@ -69,9 +69,7 @@ export function getCoords(obj) {
  * @returns {boolean} true if Array contains a number
  */
 export function containsNumber(coordinates) {
-    if (coordinates.length > 1 &&
-        typeof coordinates[0] === 'number' &&
-        typeof coordinates[1] === 'number') {
+    if (coordinates.length > 1 && isNumber(coordinates[0]) && isNumber(coordinates[1])) {
         return true;
     }
 

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -37,14 +37,15 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@turf/helpers": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*",
     "@std/esm": "*",
     "uglify-js": "*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@turf/helpers": "^5.0.0"
+  },
   "@std/esm": {
     "esm": "js",
     "cjs": true

--- a/packages/turf-invariant/test.js
+++ b/packages/turf-invariant/test.js
@@ -7,9 +7,9 @@ test('invariant -- containsNumber', t => {
     t.equals(invariant.containsNumber([[1, 1], [1, 1]]), true);
     t.equals(invariant.containsNumber([[[1, 1], [1, 1]], [1, 1]]), true);
 
-    //# Ensure recusive call handles Max callstack exceeded
+    //# Ensure recursive call handles Max callstack exceeded
     t.throws(() => {
-        invariant.containsNumber(['1', 1]);
+        invariant.containsNumber(['foo', 1]);
     }, /coordinates must only contain numbers/, 'Must only contain numbers');
     t.end();
 });

--- a/packages/turf-invariant/types.ts
+++ b/packages/turf-invariant/types.ts
@@ -4,7 +4,10 @@ import {
     lineString,
     polygon,
     geometryCollection,
-    featureCollection} from '@turf/helpers'
+    featureCollection,
+    Geometry,
+    Types
+} from '@turf/helpers'
 import {
     getCoord,
     getCoords,
@@ -13,9 +16,8 @@ import {
     collectionOf,
     containsNumber,
     getGeom,
-    getType,
-    StringGeomTypes,
-    StringTypes} from './'
+    getType
+} from './'
 
 /**
  * Fixtures
@@ -40,7 +42,7 @@ invariant.getGeom(pt.geometry)
 /**
  * invariant.getType
  */
-const type: StringTypes = invariant.getType(pt)
+const type: Geometry = invariant.getType(pt)
 getType(gc)
 invariant.getType(gc)
 invariant.getType(line)

--- a/packages/turf-isobands/test.js
+++ b/packages/turf-isobands/test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import load from 'load-json-file';
 import write from 'write-json-file';
-import random from '@turf/random';
+import { randomPolygon }  from '@turf/random';
 import envelope from '@turf/envelope';
 import { lineString } from '@turf/helpers';
 import { getCoords } from '@turf/invariant';
@@ -68,7 +68,7 @@ test('isobands', t => {
 test('isobands -- throws', t => {
     const points = pointGrid([-70.823364, -33.553984, -70.473175, -33.302986], 5);
 
-    t.throws(() => isobands(random('polygon'), [1, 2, 3]), 'invalid points');
+    t.throws(() => isobands(randomPolygon(), [1, 2, 3]), 'invalid points');
     t.throws(() => isobands(points, ''), 'invalid breaks');
     t.throws(() => isobands(points, [1, 2, 3], {zProperty: 'temp', isobandProperties: 'hello' }), 'invalid options');
 

--- a/packages/turf-isolines/test.js
+++ b/packages/turf-isolines/test.js
@@ -3,12 +3,12 @@ import test from 'tape';
 import path from 'path';
 import load from 'load-json-file';
 import write from 'write-json-file';
-import random from '@turf/random';
 import envelope from '@turf/envelope';
 import pointGrid from '@turf/point-grid';
+import { randomPolygon } from '@turf/random';
 import { getCoords } from '@turf/invariant';
 import matrixToGrid from 'matrix-to-grid';
-import { lineString } from '@turf/helpers';
+import { lineString, polygon } from '@turf/helpers';
 import isolines from '.';
 
 const directories = {
@@ -58,7 +58,7 @@ test('isolines', t => {
 test('isolines -- throws', t => {
     const points = pointGrid([-70.823364, -33.553984, -70.473175, -33.302986], 5);
 
-    t.throws(() => isolines(random('polygon'), [1, 2, 3]), 'invalid points');
+    t.throws(() => isolines(randomPolygon()), 'invalid points');
     t.throws(() => isolines(points), /breaks is required/);
     t.throws(() => isolines(points, 'string'), /breaks must be an Array/);
     t.throws(() => isolines(points, [1, 2, 3], 5), /zProperty must be a string/);

--- a/packages/turf-isolines/types.ts
+++ b/packages/turf-isolines/types.ts
@@ -1,7 +1,7 @@
-import random from '@turf/random'
+import { randomPoint } from '@turf/random'
 import isolines from './'
 
-const points = random('point', 100, {
+const points = randomPoint(100, {
     bbox: [0, 30, 20, 50]
 })
 for (let i = 0; i < points.features.length; i++) {

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -1,25 +1,18 @@
-/// <reference types="geojson" />
-
-export type Point = GeoJSON.Point;
-export type LineString = GeoJSON.LineString;
-export type Polygon = GeoJSON.Polygon;
-export type MultiPoint = GeoJSON.MultiPoint;
-export type MultiLineString = GeoJSON.MultiLineString;
-export type MultiPolygon = GeoJSON.MultiPolygon;
-export type FeatureCollection<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
-export type Feature<Geom extends GeometryObject> = GeoJSON.Feature<Geom>;
-export type GeometryObject = GeoJSON.GeometryObject;
-export type GeometryCollection = GeoJSON.GeometryCollection;
-export type Geoms = Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon;
-export type Lines = LineString | Polygon | MultiLineString | MultiPolygon;
-export type AllGeoJSON = Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection;
-export interface FeatureGeometryCollection extends GeoJSON.Feature<any> {
-    geometry: GeometryCollection;
-}
-export interface ExtendedFeatureCollection<Feat extends Feature<any>> {
-    type: 'FeatureCollection';
-    features: Feat[];
-}
+import {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    FeatureCollection,
+    Feature,
+    GeometryObject,
+    GeometryCollection,
+    AllGeoJSON,
+    FeatureGeometryCollection,
+    ExtendedFeatureCollection
+} from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#coordreduce
@@ -140,8 +133,8 @@ export function segmentEach(
 /**
  * http://turfjs.org/docs/#linereduce
  */
-export function lineReduce<Reducer extends any>(
-    geojson: Feature<Lines> | Lines,
+export function lineReduce<Reducer extends any, Geom extends LineString | MultiLineString | Polygon | MultiPolygon>(
+    geojson: Feature<Geom> | Geom,
     callback: (previousValue?: Reducer, currentLine?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number) => Reducer,
     initialValue?: Reducer
 ): Reducer;
@@ -149,7 +142,7 @@ export function lineReduce<Reducer extends any>(
 /**
  * http://turfjs.org/docs/#lineeach
  */
-export function lineEach(
-    geojson: Feature<Lines> | Lines,
+export function lineEach<Geom extends LineString | MultiLineString | Polygon | MultiPolygon>(
+    geojson: Feature<Geom> | Geom,
     callback: (currentLine?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number) => void
 ): void;

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -53,7 +53,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@turf/helpers": "*",
     "@turf/random": "*",
     "benchmark": "*",
     "rollup": "*",
@@ -61,7 +60,9 @@
     "@std/esm": "*",
     "uglify-js": "*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@turf/helpers": "^5.0.0"
+  },
   "@std/esm": {
     "esm": "js",
     "cjs": true

--- a/packages/turf-projection/index.d.ts
+++ b/packages/turf-projection/index.d.ts
@@ -5,12 +5,10 @@ import {
     GeometryCollection
 } from '@turf/helpers';
 
-type Types = Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection
-
 /**
  * http://turfjs.org/docs/#toMercator
  */
-export function toMercator<T extends Types>(
+export function toMercator<T extends Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection>(
     geojson: T,
     options?: {
         mutate?: boolean
@@ -20,7 +18,7 @@ export function toMercator<T extends Types>(
 /**
  * http://turfjs.org/docs/#toWgs84
  */
-export function toWgs84<T extends Types>(
+export function toWgs84<T extends Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection>(
     geojson: T,
     options?: {
         mutate?: boolean

--- a/packages/turf-random/index.d.ts
+++ b/packages/turf-random/index.d.ts
@@ -1,21 +1,41 @@
-/// <reference types="geojson" />
-
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type BBox = Array<number>;
-
-export interface Options {
-    bbox?: BBox
-    num_vertices?: number
-    max_radial_length?: number
-}
+import { BBox, FeatureCollection, Feature, Point, LineString, Polygon, Position } from '@turf/helpers';
 
 /**
- * http://turfjs.org/docs/#random
+ * http://turfjs.org/docs/#randomposition
  */
-declare function random(type?: 'point' | 'points', count?: number, options?: Options): Points;
-declare function random(type?: 'polygon' | 'polygons', count?: number, options?: Options): Polygons;
+export function randomPosition(bbox?: BBox | {bbox?: BBox}): Position
 
-export default random;
+/**
+ * http://turfjs.org/docs/#randompoint
+ */
+export function randomPoint(
+    count?: number,
+    options?: {
+        bbox?: BBox
+    }
+): FeatureCollection<Point>
 
+/**
+ * http://turfjs.org/docs/#randomlinestring
+ */
+export function randomLineString(
+    count?: number,
+    options?: {
+        bbox?: BBox,
+        num_vertices?: number,
+        max_length?: number,
+        max_rotation?: number
+    }
+): FeatureCollection<LineString>
+
+/**
+ * http://turfjs.org/docs/#randompolygon
+ */
+export function randomPolygon(
+    count?: number,
+    options?: {
+        bbox?: BBox,
+        num_vertices?: number,
+        max_radial_length?: number
+    }
+): FeatureCollection<LineString>

--- a/packages/turf-random/index.js
+++ b/packages/turf-random/index.js
@@ -1,52 +1,173 @@
-var geojsonRandom = require('geojson-random');
+import {
+    point,
+    lineString,
+    polygon,
+    featureCollection,
+    isObject,
+    isNumber
+} from '@turf/helpers';
 
 /**
- * Generates random {@link GeoJSON} data, including {@link Point|Points} and {@link Polygon|Polygons}, for testing
- * and experimentation.
+ * Random Position
  *
- * @name random
- * @param {string} [type='point'] type of features desired: 'points' or 'polygons'
- * @param {number} [count=1] how many geometries should be generated.
- * @param {Object} options options relevant to the feature desired. Can include:
- * @param {Array<number>} options.bbox a bounding box inside of which geometries
- * are placed. In the case of {@link Point} features, they are guaranteed to be within this bounds,
- * while {@link Polygon} features have their centroid within the bounds.
- * @param {number} [options.num_vertices=10] options.vertices the number of vertices added
- * to polygon features.
- * @param {Number} [options.max_radial_length=10] the total number of decimal
- * degrees longitude or latitude that a polygon can extent outwards to
- * from its center.
- * @returns {FeatureCollection} generated random features
+ * @param {Array<number>} [bbox=[-180, -90, 180, 90]] a bounding box inside of which positions are placed.
+ * @returns {Array<number>} Position [longitude, latitude]
  * @example
- * var points = turf.random('points', 100, {
- *   bbox: [-70, 40, -60, 60]
- * });
- *
- * var polygons = turf.random('polygons', 4, {
- *   bbox: [-70, 40, -60, 60]
- * });
- *
- * //addToMap
- * var addToMap = [points, polygons]
+ * const position = turf.randomPosition([-180, -90, 180, 90])
+ * //=position
  */
-function random(type, count, options) {
-    options = options || {};
-    count = count || 1;
-    switch (type) {
-    case 'point':
-    case 'points':
-    case undefined:
-        return geojsonRandom.point(count, options.bbox);
-    case 'polygon':
-    case 'polygons':
-        return geojsonRandom.polygon(
-            count,
-            options.num_vertices,
-            options.max_radial_length,
-            options.bbox);
-    default:
-        throw new Error('Unknown type given: valid options are points and polygons');
-    }
+export function randomPosition(bbox) {
+    if (isObject(bbox)) bbox = bbox.bbox;
+    if (bbox && !Array.isArray(bbox)) throw new Error('bbox is invalid');
+    if (bbox) return coordInBBox(bbox);
+    else return [lon(), lat()];
 }
 
-export default random;
+/**
+ * Random Point
+ *
+ * @param {number} [count=1] how many geometries will be generated
+ * @param {Object} [options={}] Optional parameters
+ * @param {Array<number>} [options.bbox=[-180, -90, 180, 90]] a bounding box inside of which geometries are placed.
+ * @returns {FeatureCollection<Point>} GeoJSON FeatureCollection of points
+ * @example
+ * const points = turf.randomPoint(25, {bbox: [-180, -90, 180, 90]})
+ * //=points
+ */
+export function randomPoint(count, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var bbox = options.bbox;
+    if (count === undefined || count === null) count = 1;
+
+    var features = [];
+    for (var i = 0; i < count; i++) {
+        features.push(point(randomPosition(bbox)));
+    }
+    return featureCollection(features);
+}
+
+/**
+ * Random Polygon
+ *
+ * @param {number} [count=1] how many geometries will be generated
+ * @param {Object} [options={}] Optional parameters
+ * @param {Array<number>} [options.bbox=[-180, -90, 180, 90]] a bounding box inside of which geometries are placed.
+ * @param {number} [options.num_vertices=10] is how many coordinates each LineString will contain.
+ * @param {number} [options.max_radial_length=10] is the maximum number of decimal degrees latitude or longitude that a vertex can reach out of the center of the Polygon.
+ * @returns {FeatureCollection<Point>} GeoJSON FeatureCollection of points
+ * @example
+ * const polygons = turf.randomPolygon(25, {bbox: [-180, -90, 180, 90]})
+ * //=polygons
+ */
+export function randomPolygon(count, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var bbox = options.bbox;
+    var num_vertices = options.num_vertices;
+    var max_radial_length = options.max_radial_length;
+    if (count === undefined || count === null) count = 1;
+
+    // Validation
+    if (!isNumber(num_vertices)) num_vertices = 10;
+    if (!isNumber(max_radial_length)) max_radial_length = 10;
+
+    var features = [];
+    for (var i = 0; i < count; i++) {
+        var vertices = [],
+            circle_offsets = Array.apply(null,
+                new Array(num_vertices + 1)).map(Math.random);
+
+        circle_offsets.forEach(sumOffsets);
+        circle_offsets.forEach(scaleOffsets);
+        vertices[vertices.length - 1] = vertices[0]; // close the ring
+
+        // center the polygon around something
+        vertices = vertices.map(vertexToCoordinate(randomPosition(bbox)));
+        features.push(polygon([vertices]));
+    }
+
+    function sumOffsets(cur, index, arr) {
+        arr[index] = (index > 0) ? cur + arr[index - 1] : cur;
+    }
+
+    function scaleOffsets(cur) {
+        cur = cur * 2 * Math.PI / circle_offsets[circle_offsets.length - 1];
+        var radial_scaler = Math.random();
+        vertices.push([
+            radial_scaler * max_radial_length * Math.sin(cur),
+            radial_scaler * max_radial_length * Math.cos(cur)
+        ]);
+    }
+
+    return featureCollection(features);
+}
+
+/**
+ * Random LineString
+ *
+ * @param {number} [count=1] how many geometries will be generated
+ * @param {Object} [options={}] Optional parameters
+ * @param {Array<number>} [options.bbox=[-180, -90, 180, 90]] a bounding box inside of which geometries are placed.
+ * @param {number} [options.num_vertices=10] is how many coordinates each LineString will contain.
+ * @param {number} [options.max_length=0.0001] is the maximum number of decimal degrees that a vertex can be from its predecessor
+ * @param {number} [options.max_rotation=Math.PI / 8] is the maximum number of radians that a line segment can turn from the previous segment.
+ * @returns {FeatureCollection<Point>} GeoJSON FeatureCollection of points
+ * @example
+ * const lineStrings = turf.randomLineString(25, {bbox: [-180, -90, 180, 90]})
+ * //=lineStrings
+ */
+export function randomLineString(count, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var bbox = options.bbox;
+    var num_vertices = options.num_vertices;
+    var max_length = options.max_length;
+    var max_rotation = options.max_rotation;
+    if (count === undefined || count === null) count = 1;
+
+    // Default parameters
+    if (!isNumber(num_vertices) || num_vertices < 2) num_vertices = 10;
+    if (!isNumber(max_length)) max_length = 0.0001;
+    if (!isNumber(max_rotation)) max_rotation = Math.PI / 8;
+
+    var features = [];
+    for (var i = 0; i < count; i++) {
+        var startingPoint = randomPosition(bbox);
+        var vertices = [startingPoint];
+        for (var j = 0; j < num_vertices - 1; j++) {
+            var priorAngle = (j === 0) ?
+                Math.random() * 2 * Math.PI :
+                Math.tan(
+                    (vertices[j][1] - vertices[j - 1][1]) /
+              (vertices[j][0] - vertices[j - 1][0])
+                );
+            var angle = priorAngle + (Math.random() - 0.5) * max_rotation * 2;
+            var distance = Math.random() * max_length;
+            vertices.push([
+                vertices[j][0] + distance * Math.cos(angle),
+                vertices[j][1] + distance * Math.sin(angle)
+            ]);
+        }
+        features.push(lineString(vertices));
+    }
+
+    return featureCollection(features);
+}
+
+function vertexToCoordinate(hub) {
+    return function (cur) { return [cur[0] + hub[0], cur[1] + hub[1]]; };
+}
+
+function rnd() { return Math.random() - 0.5; }
+function lon() { return rnd() * 360; }
+function lat() { return rnd() * 180; }
+
+function coordInBBox(bbox) {
+    return [
+        (Math.random() * (bbox[2] - bbox[0])) + bbox[0],
+        (Math.random() * (bbox[3] - bbox[1])) + bbox[1]];
+}

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -40,7 +40,7 @@
     "uglify-js": "*"
   },
   "dependencies": {
-    "geojson-random": "^0.2.2"
+    "@turf/helpers": "^5.0.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-random/test.js
+++ b/packages/turf-random/test.js
@@ -1,8 +1,13 @@
 import test from 'tape';
-import random from '.';
+import {
+    randomPoint,
+    randomLineString,
+    randomPolygon,
+    randomPosition
+} from '.';
 
 test('random(points)', t => {
-    var points = random('points');
+    var points = randomPoint();
     t.equal(points.type, 'FeatureCollection', 'is a featurecollection');
     t.equal(points.features.length, 1, 'right number of features');
     t.equal(points.features[0].geometry.type, 'Point', 'feature type correct');
@@ -10,7 +15,7 @@ test('random(points)', t => {
 });
 
 test('random(polygons)', t => {
-    var points = random('polygons');
+    var points = randomPolygon();
     t.equal(points.type, 'FeatureCollection', 'is a featurecollection');
     t.equal(points.features.length, 1, 'right number of features');
     t.equal(points.features[0].geometry.type, 'Polygon', 'feature type correct');
@@ -18,7 +23,7 @@ test('random(polygons)', t => {
 });
 
 test('random(polygons, 10)', t => {
-    var points = random('polygons', 10);
+    var points = randomPolygon(10);
     t.equal(points.type, 'FeatureCollection', 'is a featurecollection');
     t.equal(points.features.length, 10, 'right number of features');
     t.equal(points.features[0].geometry.type, 'Polygon', 'feature type correct');
@@ -26,7 +31,7 @@ test('random(polygons, 10)', t => {
 });
 
 test('random(polygons, 1, {num_vertices})', t => {
-    var points = random('polygons', 10, {num_vertices: 23});
+    var points = randomPolygon(10, {num_vertices: 23});
     t.equal(points.type, 'FeatureCollection', 'is a featurecollection');
     t.equal(points.features.length, 10, 'right number of features');
     t.equal(points.features[0].geometry.coordinates[0].length, 24, 'num vertices');
@@ -34,7 +39,7 @@ test('random(polygons, 1, {num_vertices})', t => {
 });
 
 test('random(points, 10, {bbox})', t => {
-    var points = random('points', 10, { bbox: [0, 0, 0, 0] });
+    var points = randomPoint(10, { bbox: [0, 0, 0, 0] });
     t.equal(points.type, 'FeatureCollection', 'is a featurecollection');
     t.equal(points.features.length, 10, 'right number of features');
     t.equal(points.features[0].geometry.type, 'Point', 'feature type correct');

--- a/packages/turf-random/types.ts
+++ b/packages/turf-random/types.ts
@@ -1,9 +1,26 @@
-import random from './'
+import {
+    randomPoint,
+    randomLineString,
+    randomPolygon,
+    randomPosition
+} from './'
 
-random('points', 3, {bbox: [1, 2, 3, 4]})
-random('point')
-random()
-random(undefined)
-random(undefined, 3, {})
-random('polygon')
-random('polygon')
+// Random Point
+randomPoint()
+randomPoint(3)
+randomPoint(3, {bbox: [1, 2, 3, 4]})
+
+// Random Polygon
+randomPolygon()
+randomPolygon(3)
+randomPolygon(3, {bbox: [1, 2, 3, 4]})
+
+// Random LineString
+randomLineString()
+randomLineString(3)
+randomLineString(3, {bbox: [1, 2, 3, 4]})
+
+// Random Position
+randomPosition()
+randomPosition([1, 2, 3, 4])
+randomPosition({bbox: [1, 2, 3, 4]})

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -35,7 +35,6 @@ export {default as inside} from '@turf/inside';
 export {default as intersect} from '@turf/intersect';
 export {default as nearest} from '@turf/nearest';
 export {default as planepoint} from '@turf/planepoint';
-export {default as random} from '@turf/random';
 export {default as tin} from '@turf/tin';
 export {default as union} from '@turf/union';
 export {default as bearing} from '@turf/bearing';
@@ -95,73 +94,9 @@ export {default as clustersKmeans} from '@turf/clusters-kmeans';
 export {default as pointToLineDistance} from '@turf/point-to-line-distance';
 export {default as booleanParallel} from '@turf/boolean-parallel';
 export {default as nearestPointToLine} from '@turf/nearest-point-to-line';
-export {
-    toMercator,
-    toWgs84
-} from '@turf/projection';
-import * as projection from '@turf/projection';
-export { projection };
-export {
-    getCluster,
-    clusterEach,
-    clusterReduce
-} from '@turf/clusters';
-import * as clusters from '@turf/clusters';
-export { clusters };
-export {
-    point,
-    polygon,
-    lineString,
-    multiPoint,
-    multiPolygon,
-    multiLineString,
-    feature,
-    geometry,
-    featureCollection,
-    geometryCollection,
-    radiansToDistance,
-    distanceToRadians,
-    distanceToDegrees,
-    bearingToAngle,
-    degrees2radians,
-    radians2degrees,
-    convertDistance,
-    isNumber,
-    isObject,
-    round,
-    convertArea,
-    earthRadius
-} from '@turf/helpers';
-import * as helpers from '@turf/helpers';
-export { helpers };
-export {
-    getCoord,
-    getCoords,
-    geojsonType,
-    featureOf,
-    collectionOf,
-    containsNumber,
-    getType,
-    getGeom
-} from '@turf/invariant';
-import * as invariant from '@turf/invariant';
-export { invariant };
-export {
-    coordEach,
-    coordReduce,
-    propEach,
-    propReduce,
-    featureEach,
-    featureReduce,
-    coordAll,
-    geomEach,
-    geomReduce,
-    flattenEach,
-    flattenReduce,
-    segmentReduce,
-    segmentEach,
-    lineEach,
-    lineReduce
-} from '@turf/meta';
-import * as meta from '@turf/meta';
-export { meta };
+export * from '@turf/projection';
+export * from '@turf/random';
+export * from '@turf/clusters';
+export * from '@turf/helpers';
+export * from '@turf/invariant';
+export * from '@turf/meta';

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -35,7 +35,6 @@ export {default as inside} from '@turf/inside';
 export {default as intersect} from '@turf/intersect';
 export {default as nearest} from '@turf/nearest';
 export {default as planepoint} from '@turf/planepoint';
-export {default as random} from '@turf/random';
 export {default as tin} from '@turf/tin';
 export {default as union} from '@turf/union';
 export {default as bearing} from '@turf/bearing';
@@ -95,73 +94,9 @@ export {default as clustersKmeans} from '@turf/clusters-kmeans';
 export {default as pointToLineDistance} from '@turf/point-to-line-distance';
 export {default as booleanParallel} from '@turf/boolean-parallel';
 export {default as nearestPointToLine} from '@turf/nearest-point-to-line';
-export {
-    toMercator,
-    toWgs84
-} from '@turf/projection';
-import * as projection from '@turf/projection';
-export { projection };
-export {
-    getCluster,
-    clusterEach,
-    clusterReduce
-} from '@turf/clusters';
-import * as clusters from '@turf/clusters';
-export { clusters };
-export {
-    point,
-    polygon,
-    lineString,
-    multiPoint,
-    multiPolygon,
-    multiLineString,
-    feature,
-    geometry,
-    featureCollection,
-    geometryCollection,
-    radiansToDistance,
-    distanceToRadians,
-    distanceToDegrees,
-    bearingToAngle,
-    degrees2radians,
-    radians2degrees,
-    convertDistance,
-    isNumber,
-    isObject,
-    round,
-    convertArea,
-    earthRadius
-} from '@turf/helpers';
-import * as helpers from '@turf/helpers';
-export { helpers };
-export {
-    getCoord,
-    getCoords,
-    geojsonType,
-    featureOf,
-    collectionOf,
-    containsNumber,
-    getType,
-    getGeom
-} from '@turf/invariant';
-import * as invariant from '@turf/invariant';
-export { invariant };
-export {
-    coordEach,
-    coordReduce,
-    propEach,
-    propReduce,
-    featureEach,
-    featureReduce,
-    coordAll,
-    geomEach,
-    geomReduce,
-    flattenEach,
-    flattenReduce,
-    segmentReduce,
-    segmentEach,
-    lineEach,
-    lineReduce
-} from '@turf/meta';
-import * as meta from '@turf/meta';
-export { meta };
+export * from '@turf/projection';
+export * from '@turf/random';
+export * from '@turf/clusters';
+export * from '@turf/helpers';
+export * from '@turf/invariant';
+export * from '@turf/meta';

--- a/packages/turf/types.ts
+++ b/packages/turf/types.ts
@@ -1,13 +1,10 @@
 import * as turf from './'
 
 // Helpers
-turf.helpers.point([10, 20])
 turf.point([10, 20])
 
 // Meta
-turf.meta.featureEach
 turf.featureEach
 
 // Invariant
-turf.invariant.featureOf
 turf.featureOf


### PR DESCRIPTION
## Rework `@turf/random` & `@turf/turf` export `*` modules

Ref: #994 

### `@turf/random`

now exposes multiple methods:

```js
import { randomPoint } from '@turf/random';

const bbox = [-70, 40, -60, 60]
const points = randomPoint(100, {bbox})
```

### `@turf/turf`

Reworked exporting modules with multiple methods.

**Before**

```js
export {
    coordEach,
    coordReduce,
    propEach,
    propReduce,
    featureEach,
    featureReduce,
    coordAll,
    geomEach,
    geomReduce,
    flattenEach,
    flattenReduce,
    segmentReduce,
    segmentEach,
    lineEach,
    lineReduce
} from '@turf/meta';
```

**Now**

```js
export * from '@turf/meta';
```


Allowing this to work you can't have duplicate exported members (`@turf/helpers` has been added to `@turf/meta` & `@turf/invariant` to share methods & Typescript definitions).

Exporting all methods using `*` eliminates any possibilities of forgetting an exported method.