### PR TITLE
Add GeoJSON Hint to @turf/circle

### DIFF
--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -36,14 +36,15 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
+    "@mapbox/geojsonhint": "*",
+    "@std/esm": "*",
     "@turf/truncate": "*",
     "benchmark": "*",
     "load-json-file": "*",
-    "tape": "*",
-    "write-json-file": "*",
     "rollup": "*",
-    "@std/esm": "*",
-    "uglify-js": "*"
+    "tape": "*",
+    "uglify-js": "*",
+    "write-json-file": "*"
   },
   "dependencies": {
     "@turf/destination": "5.0.0",

--- a/packages/turf-circle/test.js
+++ b/packages/turf-circle/test.js
@@ -5,6 +5,7 @@ import load from 'load-json-file';
 import write from 'write-json-file';
 import truncate from '@turf/truncate';
 import { featureCollection } from '@turf/helpers';
+import geojsonhint from '@mapbox/geojsonhint';
 import circle from '.';
 
 const directories = {
@@ -36,5 +37,11 @@ test('turf-circle', t => {
         if (process.env.REGEN) write.sync(directories.out + filename, results);
         t.deepEquals(results, load.sync(directories.out + filename), name);
     });
+    t.end();
+});
+
+test('turf-circle -- validate geojson', t => {
+    const C = circle([0, 0], 100);
+    geojsonhint.hint(C).forEach(hint => t.fail(hint.message));
     t.end();
 });


### PR DESCRIPTION
# Add GeoJSON Hint to @turf/circle

Ref: #997 

Added tests to validate GeoJSON output using [`geojsonhint`](https://github.com/mapbox/geojsonhint).

Errors raised by test (prior to fix):

```
# turf-circle -- validate geojson
not ok 2 Polygons and MultiPolygons should follow the right-hand rule
  ---
    operator: fail
    at: geojsonhint.hint.forEach.hint (/Users/mac/Github/turf/packages/turf-circle/test.js:45:43)
    stack: |-
      Error: Polygons and MultiPolygons should follow the right-hand rule
```