### PR TITLE
Update all Typescript definitions

### DIFF
--- a/packages/turf-bbox-clip/index.d.ts
+++ b/packages/turf-bbox-clip/index.d.ts
@@ -1,18 +1,9 @@
-/// <reference types="geojson" />
-
-import {
-    BBox,
-    LineString,
-    MultiLineString,
-    Polygon,
-    MultiPolygon,
-    Feature
-} from '@turf/helpers'
+import { BBox, LineString, MultiLineString, Polygon, MultiPolygon, Feature } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#bboxclip
  */
-declare function bboxClip(feature: Feature<LineString | MultiLineString> | LineString | MultiLineString, bbox: BBox): Feature<LineString | MultiLineString>;
-declare function bboxClip(feature: Feature<Polygon | MultiPolygon> | Polygon | MultiPolygon, bbox: BBox): Feature<Polygon | MultiPolygon>;
-
-export default bboxClip;
+export default function <T extends Polygon|MultiPolygon|LineString|MultiLineString>(
+    feature: Feature<T> | T,
+    bbox: BBox
+): Feature<T>;

--- a/packages/turf-bbox-polygon/index.d.ts
+++ b/packages/turf-bbox-polygon/index.d.ts
@@ -1,9 +1,6 @@
-/// <reference types="geojson" />
-
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
-export type BBox = [number, number, number, number];
+import { BBox, Feature, Polygon } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#bboxpolygon
  */
-export default function bboxPolygon(bbox: BBox): Polygon;
+export default function (bbox: BBox): Feature<Polygon>;

--- a/packages/turf-bezier/index.d.ts
+++ b/packages/turf-bezier/index.d.ts
@@ -1,13 +1,12 @@
-/// <reference types="geojson" />
-
-export type LineString = GeoJSON.Feature<GeoJSON.LineString>;
-
-interface Options {
-    resolution?: number;
-    sharpness?: number;
-}
+import { LineString, Feature } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#bezier
  */
-export default function bezier(line: LineString, options?: Options): LineString;
+export default function bezier(
+    line: Feature<LineString> | LineString,
+    options?: {
+        resolution?: number;
+        sharpness?: number;
+    }
+): Feature<LineString>;

--- a/packages/turf-bezier/index.js
+++ b/packages/turf-bezier/index.js
@@ -1,4 +1,5 @@
 import { lineString } from '@turf/helpers';
+import { getGeom } from '@turf/invariant';
 import Spline from './spline.js';
 
 /**
@@ -9,7 +10,7 @@ import Spline from './spline.js';
  * The bezier spline implementation is by [Leszek Rybicki](http://leszek.rybicki.cc/).
  *
  * @name bezier
- * @param {Feature<LineString>} line input LineString
+ * @param {Geometry|Feature<LineString>} line input LineString
  * @param {object} [options] Optional parameters
  * @param {number} [options.resolution=10000] time in milliseconds between points
  * @param {number} [options.sharpness=0.85] a measure of how curvy the path should be between splines
@@ -43,7 +44,7 @@ function bezier(line, options) {
 
     var coords = [];
     var spline = new Spline({
-        points: line.geometry.coordinates.map(function (pt) {
+        points: getGeom(line).coordinates.map(function (pt) {
             return {x: pt[0], y: pt[1]};
         }),
         duration: resolution,

--- a/packages/turf-bezier/package.json
+++ b/packages/turf-bezier/package.json
@@ -43,7 +43,8 @@
     "@std/esm": "*"
   },
   "dependencies": {
-    "@turf/helpers": "^5.0.0"
+    "@turf/helpers": "^5.0.0",
+    "@turf/invariant": "^5.0.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-buffer/index.d.ts
+++ b/packages/turf-buffer/index.d.ts
@@ -1,18 +1,18 @@
-/// <reference types="geojson" />
 
-import { Units, FeatureGeometryCollection } from '@turf/helpers';
-
-export type Point = GeoJSON.Point;
-export type LineString = GeoJSON.LineString;
-export type Polygon = GeoJSON.Polygon;
-export type MultiPoint = GeoJSON.MultiPoint;
-export type MultiLineString = GeoJSON.MultiLineString;
-export type MultiPolygon = GeoJSON.MultiPolygon;
-export type GeometryObject = GeoJSON.GeometryObject;
-export type GeometryCollection = GeoJSON.GeometryCollection;
-export type Feature<Geom extends GeometryObject> = GeoJSON.Feature<Geom>;
-export type FeatureCollection<Geom extends GeometryObject> = GeoJSON.FeatureCollection<Geom>;
-export type Geoms = Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon;
+import {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryObject,
+    GeometryCollection,
+    Feature,
+    FeatureCollection,
+    Units,
+    FeatureGeometryCollection
+} from '@turf/helpers';
 
 interface Options {
     units?: Units;
@@ -22,11 +22,11 @@ interface Options {
 /**
  * http://turfjs.org/docs/#buffer
  */
-declare function buffer<Geom extends Point | LineString | Polygon>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<Polygon> | undefined;
-declare function buffer<Geom extends MultiPoint | MultiLineString | MultiPolygon>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<MultiPolygon> | undefined;
+declare function buffer<Geom extends Point | LineString | Polygon>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<Polygon>;
+declare function buffer<Geom extends MultiPoint | MultiLineString | MultiPolygon>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<MultiPolygon>;
 declare function buffer<Geom extends Point | LineString | Polygon>(feature: FeatureCollection<Geom>, radius?: number, options?: Options): FeatureCollection<Polygon>;
 declare function buffer<Geom extends MultiPoint | MultiLineString | MultiPolygon>(feature: FeatureCollection<Geom>, radius?: number, options?: Options): FeatureCollection<MultiPolygon>;
 declare function buffer(feature: FeatureCollection<any> | FeatureGeometryCollection | GeometryCollection, radius?: number, options?: Options): FeatureCollection<Polygon | MultiPolygon>;
-declare function buffer(feature: Feature<any> | GeometryObject, radius?: number, options?: Options): Feature<Polygon | MultiPolygon> | undefined;
+declare function buffer(feature: Feature<any> | GeometryObject, radius?: number, options?: Options): Feature<Polygon | MultiPolygon>;
 
 export default buffer;

--- a/packages/turf-center-of-mass/index.d.ts
+++ b/packages/turf-center-of-mass/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="geojson" />
-
-export type Feature = GeoJSON.Feature<any>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Point = GeoJSON.Feature<GeoJSON.Point>;
+import { AllGeoJSON, Feature, Point, Properties } from '@turf/helpers';
 
 /**
- * http://turfjs.org/docs/#center
+ * http://turfjs.org/docs/#centerofmass
  */
-export default function (features: Feature | Features, properties?: any): Point;
+export default function (
+    features: AllGeoJSON,
+    properties?: Properties
+): Feature<Point>;

--- a/packages/turf-center/index.d.ts
+++ b/packages/turf-center/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="geojson" />
-
-export type Feature = GeoJSON.Feature<any>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Point = GeoJSON.Feature<GeoJSON.Point>;
+import { AllGeoJSON, Feature, Point, Properties } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#center
  */
-export default function (features: Feature | Features, properties?: any): Point;
+export default function (
+    features: AllGeoJSON,
+    properties?: Properties
+): Feature<Point>;

--- a/packages/turf-centroid/index.d.ts
+++ b/packages/turf-centroid/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="geojson" />
-
-export type Feature = GeoJSON.Feature<any>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Point = GeoJSON.Feature<GeoJSON.Point>;
+import { AllGeoJSON, Feature, Point, Properties } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#centroid
  */
-export default function (features: Feature | Features, properties?: any): Point;
+export default function (
+    features: AllGeoJSON,
+    properties?: Properties
+): Feature<Point>;

--- a/packages/turf-clusters-dbscan/index.d.ts
+++ b/packages/turf-clusters-dbscan/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="geojson" />
-
 import { Units, FeatureCollection, Point, Feature } from '@turf/helpers';
 
 export type Dbscan = 'core' | 'edge' | 'noise'

--- a/packages/turf-collect/index.d.ts
+++ b/packages/turf-collect/index.d.ts
@@ -1,9 +1,11 @@
-/// <reference types="geojson" />
-
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
+import { FeatureCollection, Polygon, Feature, Point } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#collect
  */
-export default function (polygons: Polygons, points: Points, inProperty: string, outProperty: string): Polygons;
+export default function (
+    polygons: FeatureCollection<Polygon>,
+    points: FeatureCollection<Point>,
+    inProperty: string,
+    outProperty: string
+): FeatureCollection<Polygon>;

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@turf/helpers": "*",
     "benchmark": "*",
     "tape": "*",
     "rollup": "*",
@@ -46,6 +45,7 @@
   },
   "dependencies": {
     "@turf/bbox": "^5.0.0",
+    "@turf/helpers": "^5.0.0",
     "@turf/inside": "^4.7.3",
     "rbush": "^2.0.1"
   },

--- a/packages/turf-combine/index.d.ts
+++ b/packages/turf-combine/index.d.ts
@@ -1,19 +1,20 @@
-/// <reference types="geojson" />
-
-type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
-type LineStrings = GeoJSON.FeatureCollection<GeoJSON.LineString>;
-type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
-type MultiPoints = GeoJSON.FeatureCollection<GeoJSON.MultiPoint>;
-type MultiLineStrings = GeoJSON.FeatureCollection<GeoJSON.MultiLineString>;
-type MultiPolygons = GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>;
-type Features = GeoJSON.FeatureCollection<any>;
+import {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    Feature,
+    FeatureCollection
+} from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#combine
  */
-declare function combine(features: Points): MultiPoints;
-declare function combine(features: LineStrings): MultiLineStrings;
-declare function combine(features: Polygons): MultiPolygons;
-declare function combine(features: Features): Features;
+declare function combine(features: FeatureCollection<Point>): MultiPoint;
+declare function combine(features: FeatureCollection<LineString>): MultiLineString;
+declare function combine(features: FeatureCollection<Polygon>): MultiPolygon;
+declare function combine(features: FeatureCollection<any>): Feature<any>;
 
 export default combine;

--- a/packages/turf-convex/index.d.ts
+++ b/packages/turf-convex/index.d.ts
@@ -1,10 +1,8 @@
-/// <reference types="geojson" />
-
-export type Feature = GeoJSON.Feature<any>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
+import { Feature, AllGeoJSON, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#convex
  */
-export default function convex(features: Feature | Features): Polygon;
+export default function (
+    geojson: AllGeoJSON
+): Feature<Polygon>;

--- a/packages/turf-convex/index.js
+++ b/packages/turf-convex/index.js
@@ -1,5 +1,5 @@
 var convexHull = require('convex-hull');
-import { coordEach as each } from '@turf/meta';
+import { coordEach } from '@turf/meta';
 import { polygon } from '@turf/helpers';
 
 /**
@@ -10,7 +10,7 @@ import { polygon } from '@turf/helpers';
  * implements a [monotone chain hull](http://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain).
  *
  * @name convex
- * @param {Feature|FeatureCollection} feature input Feature or FeatureCollection
+ * @param {GeoJSON} geojson input Feature or FeatureCollection
  * @returns {Feature<Polygon>} a convex hull
  * @example
  * var points = turf.featureCollection([
@@ -27,11 +27,11 @@ import { polygon } from '@turf/helpers';
  * //addToMap
  * var addToMap = [points, hull]
  */
-function convex(feature) {
+function convex(geojson) {
     var points = [];
 
     // Remove Z in coordinates because it breaks the convexHull algorithm
-    each(feature, function (coord) {
+    coordEach(geojson, function (coord) {
         points.push([coord[0], coord[1]]);
     });
 

--- a/packages/turf-envelope/index.d.ts
+++ b/packages/turf-envelope/index.d.ts
@@ -1,10 +1,8 @@
-/// <reference types="geojson" />
-
-export type Feature = GeoJSON.Feature<any>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
+import { Feature, AllGeoJSON, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#envelope
  */
-export default function envelope(features: Feature | Features): Polygon;
+export default function envelope(
+    features: AllGeoJSON
+): Feature<Polygon>;

--- a/packages/turf-envelope/index.js
+++ b/packages/turf-envelope/index.js
@@ -5,7 +5,7 @@ import bboxPolygon from '@turf/bbox-polygon';
  * Takes any number of features and returns a rectangular {@link Polygon} that encompasses all vertices.
  *
  * @name envelope
- * @param {FeatureCollection|Feature<any>} geojson input features
+ * @param {GeoJSON} geojson input features
  * @returns {Feature<Polygon>} a rectangular Polygon feature that encompasses all vertices
  * @example
  * var features = turf.featureCollection([

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "@turf/bbox": "^5.0.0",
-    "@turf/bbox-polygon": "^4.7.3"
+    "@turf/bbox-polygon": "^4.7.3",
+    "@turf/helpers": "^5.0.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-explode/index.d.ts
+++ b/packages/turf-explode/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="geojson" />
+import { AllGeoJSON, FeatureCollection, Point } from '@turf/helpers'
 
-export type Feature = GeoJSON.Feature<any>;
-export type Features = GeoJSON.FeatureCollection<any>;
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
 
 /**
  * http://turfjs.org/docs/#explode
  */
-export default function explode(features: Feature | Features): Points;
+export default function explode(
+    features: AllGeoJSON
+): FeatureCollection<Point>;

--- a/packages/turf-explode/index.js
+++ b/packages/turf-explode/index.js
@@ -5,7 +5,7 @@ import { point, featureCollection } from '@turf/helpers';
  * Takes a feature or set of features and returns all positions as {@link Point|points}.
  *
  * @name explode
- * @param {FeatureCollection|Feature<any>} geojson input features
+ * @param {GeoJSON} geojson input features
  * @returns {FeatureCollection<point>} points representing the exploded input features
  * @throws {Error} if it encounters an unknown geometry type
  * @example

--- a/packages/turf-flatten/index.d.ts
+++ b/packages/turf-flatten/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="geojson" />
-
 import {
     Point,
     MultiPoint,

--- a/packages/turf-flatten/index.js
+++ b/packages/turf-flatten/index.js
@@ -5,7 +5,7 @@ import { featureCollection } from '@turf/helpers';
  * Flattens any {@link GeoJSON} to a {@link FeatureCollection} inspired by [geojson-flatten](https://github.com/tmcw/geojson-flatten).
  *
  * @name flatten
- * @param {FeatureCollection|Geometry|Feature<any>} geojson any valid GeoJSON Object
+ * @param {GeoJSON} geojson any valid GeoJSON Object
  * @returns {FeatureCollection<any>} all Multi-Geometries are flattened into single Features
  * @example
  * var multiGeometry = turf.multiPolygon([

--- a/packages/turf-intersect/index.d.ts
+++ b/packages/turf-intersect/index.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="geojson" />
-
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
-export type Feature = GeoJSON.Feature<any>;
+import { Feature, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#intersect
  */
-export default function intersect(poly1: Polygon, poly2: Polygon): Feature;
+export default function <T extends Polygon>(
+    poly1: Feature<T> | T,
+    poly2: Feature<T> | T
+): Feature<any> | null;

--- a/packages/turf-mask/index.d.ts
+++ b/packages/turf-mask/index.d.ts
@@ -1,11 +1,9 @@
-/// <reference types="geojson" />
-
-export type Geom = GeoJSON.Polygon | GeoJSON.MultiPolygon;
-export type Poly = GeoJSON.FeatureCollection<Geom> | GeoJSON.Feature<Geom> | Geom;
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
-export type Mask = GeoJSON.Feature<GeoJSON.Polygon> | GeoJSON.Polygon;
+import { Feature, Polygon, MultiPolygon, FeatureCollection } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#mask
  */
-export default function mask(poly: Poly, mask?: Mask): Polygon;
+export default function <T extends Polygon | MultiPolygon>(
+    poly: Feature<T> | FeatureCollection<T> | T,
+    mask?: Feature<Polygon> | Polygon
+): Feature<Polygon>;

--- a/packages/turf-midpoint/index.d.ts
+++ b/packages/turf-midpoint/index.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="geojson" />
-
-export type Point = GeoJSON.Feature<GeoJSON.Point> | GeoJSON.Point | number[];
-export type Feature = GeoJSON.Feature<GeoJSON.Point>;
+import { Feature, Point, Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#midpoint
  */
-export default function midpoint(point1: Point, point2: Point): Feature;
+export default function (
+    point1: Coord,
+    point2: Coord
+): Feature<Point>;

--- a/packages/turf-nearest-point-to-line/index.d.ts
+++ b/packages/turf-nearest-point-to-line/index.d.ts
@@ -1,22 +1,28 @@
-/// <reference types="geojson" />
+import {
+  Units,
+  LineString,
+  Feature,
+  FeatureCollection,
+  FeatureGeometryCollection,
+  GeometryCollection,
+  Coord,
+  Point
+} from '@turf/helpers'
 
-import { Units, FeatureGeometryCollection } from '@turf/helpers'
-
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point> | FeatureGeometryCollection;
-export type LineString = GeoJSON.Feature<GeoJSON.LineString> | GeoJSON.LineString;
-export interface Point extends GeoJSON.Feature<GeoJSON.Point> {
+export interface NearestPointToLine extends Feature<Point> {
   properties: {
     dist: number
     [key: string]: any
   }
 }
-interface Options {
-  /**
-   * unit of the output distance property, can be degrees, radians, miles, or kilometer
-   */
-  units?: Units
-}
+
 /**
  * http://turfjs.org/docs/#nearestpointtoline
  */
-export default function nearestPointToLine(points: Points, line: LineString, options?: Options): Point;
+export default function nearestPointToLine(
+    points: FeatureCollection<Point> | FeatureGeometryCollection | GeometryCollection,
+    line: Feature<LineString> | LineString,
+    options?: {
+      units?: Units
+    }
+): NearestPointToLine;

--- a/packages/turf-nearest-point-to-line/types.ts
+++ b/packages/turf-nearest-point-to-line/types.ts
@@ -1,4 +1,9 @@
-import { geometryCollection, featureCollection, point, lineString } from '@turf/helpers'
+import {
+    geometryCollection,
+    featureCollection,
+    point,
+    lineString
+} from '@turf/helpers'
 import nearestPointToLine from './'
 
 const points = featureCollection([point([0, 0]), point([0.5, 0.5])]);

--- a/packages/turf-nearest/index.d.ts
+++ b/packages/turf-nearest/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="geojson" />
-
-export type Point = GeoJSON.Feature<GeoJSON.Point> | GeoJSON.Point | number[];
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
-export type Feature = GeoJSON.Feature<GeoJSON.Point>;
+import { Feature, FeatureCollection, Coord, Point } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#nearest
  */
-export default function nearest(targetPoint: Point, points: Points): Feature;
+export default function nearest(
+    targetPoint: Coord,
+    points: FeatureCollection<Point>
+): Feature<Point>;

--- a/packages/turf-nearest/package.json
+++ b/packages/turf-nearest/package.json
@@ -39,7 +39,8 @@
     "@std/esm": "*"
   },
   "dependencies": {
-    "@turf/distance": "^5.0.0"
+    "@turf/distance": "^5.0.0",
+    "@turf/helpers": "^5.0.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-planepoint/index.d.ts
+++ b/packages/turf-planepoint/index.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="geojson" />
-
-export type Point = GeoJSON.Feature<GeoJSON.Point> | GeoJSON.Point | number[];
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon> | GeoJSON.Polygon;
+import { Feature, Coord, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#planepoint
  */
-export default function planepoint(point: Point, triangle: Polygon): number;
+export default function planepoint(
+    point: Coord,
+    triangle: Feature<Polygon> | Polygon
+): number;

--- a/packages/turf-polygon-tangents/index.d.ts
+++ b/packages/turf-polygon-tangents/index.d.ts
@@ -1,11 +1,9 @@
-/// <reference types="geojson" />
-
-export type Point = GeoJSON.Feature<GeoJSON.Point> | GeoJSON.Point;
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon> | GeoJSON.Polygon;
-export type MultiPolygon = GeoJSON.Feature<GeoJSON.MultiPolygon> | GeoJSON.MultiPolygon;
-export type FeatureCollection = GeoJSON.FeatureCollection<GeoJSON.Point>;
+import { Feature, FeatureCollection, Coord, Point, Polygon, MultiPolygon } from '@turf/helpers'
 
 /**
- * http://turfjs.org/docs/#polygonTangents
+ * http://turfjs.org/docs/#polygontangents
  */
-export default function polygonTangents(point: Point, polygon: Polygon | MultiPolygon): FeatureCollection;
+export default function <T extends Polygon | MultiPolygon>(
+    point: Coord,
+    polygon: Feature<T> | T
+): FeatureCollection<Point>;

--- a/packages/turf-polygonize/index.d.ts
+++ b/packages/turf-polygonize/index.d.ts
@@ -1,9 +1,8 @@
-/// <reference types="geojson" />
-
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
-export type Geoms = GeoJSON.LineString | GeoJSON.MultiLineString;
+import { Feature, FeatureCollection, Coord, Polygon, LineString, MultiLineString } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#polygonize
  */
-export default function polygonize<Geom extends Geoms>(geojson: GeoJSON.Feature<Geom> | GeoJSON.FeatureCollection<Geom> | Geom): Polygons;
+export default function <T extends LineString | MultiLineString>(
+    geojson: Feature<T> | FeatureCollection<T> | T
+): FeatureCollection<Polygon>;

--- a/packages/turf-rhumb-bearing/index.d.ts
+++ b/packages/turf-rhumb-bearing/index.d.ts
@@ -1,11 +1,11 @@
-import { Point, Feature, Position } from '@turf/helpers'
+import { Coord } from '@turf/helpers'
 
 /**
- * http://turfjs.org/docs/#rhumb-bearing
+ * http://turfjs.org/docs/#rhumbbearing
  */
 export default function rhumbBearing(
-    start: Feature<Point> | Point | Position,
-    end: Feature<Point> | Point | Position,
+    start: Coord,
+    end: Coord,
     options?: {
         final?: boolean;
     }

--- a/packages/turf-rhumb-destination/index.d.ts
+++ b/packages/turf-rhumb-destination/index.d.ts
@@ -1,10 +1,10 @@
-import { Point, Feature, Units, Position } from '@turf/helpers';
+import { Point, Feature, Units, Coord } from '@turf/helpers';
 
 /**
- * http://turfjs.org/docs/#rhumb-destination
+ * http://turfjs.org/docs/#rhumbdestination
  */
 export default function rhumbDestination(
-    origin: Feature<Point> | Point | Position,
+    origin: Coord,
     distance: number,
     bearing: number,
     options?: {

--- a/packages/turf-rhumb-distance/index.d.ts
+++ b/packages/turf-rhumb-distance/index.d.ts
@@ -1,11 +1,11 @@
-import { Position, Point, Feature, Units } from '@turf/helpers';
+import { Coord, Units } from '@turf/helpers';
 
 /**
- * http://turfjs.org/docs/#rhumb-distance
+ * http://turfjs.org/docs/#rhumbdistance
  */
 export default function rhumbDistance(
-    from: Feature<Point> | Point | Position,
-    to: Feature<Point> | Point | Position,
+    from: Coord,
+    to: Coord,
     options?: {
         units?: Units;
     }

--- a/packages/turf-sample/index.d.ts
+++ b/packages/turf-sample/index.d.ts
@@ -1,8 +1,9 @@
-/// <reference types="geojson" />
+import { FeatureCollection, GeometryObject } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#sample
  */
-export default function sample<T extends GeoJSON.GeometryObject>(
-    features: GeoJSON.FeatureCollection<T>,
-    num: number): GeoJSON.FeatureCollection<T>;
+export default function sample<T extends GeometryObject>(
+    features: FeatureCollection<T>,
+    num: number
+): FeatureCollection<T>;

--- a/packages/turf-square/index.d.ts
+++ b/packages/turf-square/index.d.ts
@@ -1,8 +1,6 @@
-/// <reference types="geojson" />
-
-export type BBox = [number, number, number, number];
+import { BBox } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#square
  */
-export default function square(bbox: BBox): BBox;
+export default function (bbox: BBox): BBox;

--- a/packages/turf-tag/index.d.ts
+++ b/packages/turf-tag/index.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="geojson" />
-
-export type BBox = [number, number, number, number];
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+import { BBox, Point, FeatureCollection, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#tag
  */
-export default function tag(points: Points, polygons: Polygons, field: string, outField: string): Points;
+export default function tag(
+    points: FeatureCollection<Point>,
+    polygons: FeatureCollection<Polygon>,
+    field: string,
+    outField: string
+): FeatureCollection<Point>;

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@turf/clone": "^4.7.3",
+    "@turf/helpers": "^5.0.0",
     "@turf/inside": "^4.7.3",
     "@turf/meta": "^5.0.0"
   },

--- a/packages/turf-tesselate/index.d.ts
+++ b/packages/turf-tesselate/index.d.ts
@@ -1,9 +1,6 @@
-/// <reference types="geojson" />
-
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+import { Feature, FeatureCollection, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#tesselate
  */
-export default function tesselate(polygon: Polygon): Polygons;
+export default function (polygon: Feature<Polygon>): FeatureCollection<Polygon>;

--- a/packages/turf-tin/index.d.ts
+++ b/packages/turf-tin/index.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="geojson" />
-
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+import { Point, FeatureCollection, Polygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#tin
  */
-export default function tin(points: Points, z?: string): Polygons;
+export default function tin(
+    points: FeatureCollection<Point>,
+    z?: string
+): FeatureCollection<Polygon>;

--- a/packages/turf-union/index.d.ts
+++ b/packages/turf-union/index.d.ts
@@ -1,9 +1,8 @@
-/// <reference types="geojson" />
-
-export type Polygon = GeoJSON.Feature<GeoJSON.Polygon>;
-export type MultiPolygon = GeoJSON.Feature<GeoJSON.MultiPolygon>;
+import { Feature, Polygon, MultiPolygon } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#union
  */
-export default function union(...features: Polygon[]): Polygon | MultiPolygon;
+export default function (
+    ...features: Feature<Polygon>[]
+): Feature<Polygon | MultiPolygon>;

--- a/packages/turf-unkink-polygon/index.d.ts
+++ b/packages/turf-unkink-polygon/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="geojson" />
-
 import { Polygon, MultiPolygon, Feature, FeatureCollection } from '@turf/helpers';
 
 /**

--- a/packages/turf-within/index.d.ts
+++ b/packages/turf-within/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="geojson" />
-
-export type BBox = Array<number>;
-export type Points = GeoJSON.FeatureCollection<GeoJSON.Point>;
-export type Polygons = GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+import { FeatureCollection, Polygon, Point } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#within
  */
-export default function within(points: Points, polygons: Polygons): Points;
+export default function within(
+    points: FeatureCollection<Point>,
+    polygons: FeatureCollection<Polygon>
+): FeatureCollection<Point>;

--- a/packages/turf/test.js
+++ b/packages/turf/test.js
@@ -159,6 +159,7 @@ test('turf -- parsing dependencies from index.js', t => {
 // File Paths
 const testFilePath = path.join(__dirname, 'test.example.js');
 const turfModulesPath = path.join(__dirname, '..', 'turf-*', 'index.js');
+const turfTypescriptPath = path.join(__dirname, '..', 'turf-*', 'index.d.ts');
 
 // Test Strings
 const requireString = `const test = require('tape');
@@ -220,7 +221,14 @@ test('turf -- missing modules', t => {
     t.end();
 });
 
-// /// <reference types="geojson" />
+// TurfJS v5.0 Typescript definition uses @turf/helpers
+test('turf -- update to newer Typescript definitions', t => {
+    glob.sync(turfTypescriptPath).forEach(filepath => {
+        const typescript = fs.readFileSync(filepath, 'utf8');
+        if (typescript.includes('reference types="geojson"')) t.skip(filepath + ' update Typescript definition v5.0')
+    })
+    t.end()
+});
 
 // Iterate over each module and retrieve @example to build tests from them
 glob(turfModulesPath, (err, files) => {


### PR DESCRIPTION
Upgraded all Typescript definitions to use `@turf/helpers`

@rowanwins Creating a Typescript Guide is still on a "to-do" list 😜 

[`@turf/helpers`'s `index.d.ts`](https://github.com/Turfjs/turf/blob/master/packages/turf-helpers/index.d.ts) file is now a one stop shop for all TurfJS Typescript related types.

## Boolean example

```ts
import { Feature, GeometryObject } from '@turf/helpers'

/**
 * http://turfjs.org/docs/#booleanoverlap
 */
export default function (
    feature1: Feature<any> | GeometryObject,
    feature2: Feature<any> | GeometryObject
): boolean;
```

## Rhumb example

```ts
import { Coord } from '@turf/helpers'

/**
 * http://turfjs.org/docs/#rhumbbearing
 */
export default function rhumbBearing(
    start: Coord,
    end: Coord,
    options?: {
        final?: boolean;
    }
): number;
```

## Transform example

```ts
import { AllGeoJSON, Coord } from '@turf/helpers';

/**
 * http://turfjs.org/docs/#transformrotate
 */
export default function transformRotate<T extends AllGeoJSON>(
    geojson: T,
    angle: number,
    options?: {
        pivot?: Coord,
        mutate?: boolean
    }
): T;
```

## Notes

- Use the `<T extends AllGeoJSON>` when module supports all GeoJSON
- Use `Coord` for single point entries (Coord === `Array<number>|Feature<Point>|Point`)
- Bundle options inside methods, that way code hinting shows all available options.

<img width="772" alt="screen shot 2017-10-04 at 6 49 13 pm" src="https://user-images.githubusercontent.com/550895/31203358-c2fed092-a934-11e7-8f1c-75e3d9745c2a.png">
