### PR TITLE
Add properties option to @turf/rhumb-destination

### DIFF
--- a/packages/turf-rhumb-destination/index.d.ts
+++ b/packages/turf-rhumb-destination/index.d.ts
@@ -1,4 +1,4 @@
-import { Point, Feature, Units, Coord } from '@turf/helpers';
+import { Point, Feature, Units, Coord, Properties } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#rhumbdestination
@@ -8,6 +8,7 @@ export default function rhumbDestination(
     distance: number,
     bearing: number,
     options?: {
-        units?: Units
+        units?: Units,
+        properties?: Properties
     }
 ): Feature<Point>;

--- a/packages/turf-rhumb-destination/index.js
+++ b/packages/turf-rhumb-destination/index.js
@@ -1,5 +1,5 @@
 // https://en.wikipedia.org/wiki/Rhumb_line
-import { earthRadius, point, convertDistance, degrees2radians } from '@turf/helpers';
+import { earthRadius, point, convertDistance, degrees2radians, isObject } from '@turf/helpers';
 import { getCoord } from '@turf/invariant';
 
 /**
@@ -12,6 +12,7 @@ import { getCoord } from '@turf/invariant';
  * @param {number} bearing varant bearing angle ranging from -180 to 180 degrees from north
  * @param {Object} [options={}] Optional parameters
  * @param {string} [options.units='kilometers'] can be degrees, radians, miles, or kilometers
+ * @param {Object} [options.properties={}] translate properties to destination point
  * @returns {Feature<Point>} Destination point.
  * @example
  * var pt = turf.point([-75.343, 39.984], {"marker-color": "F00"});
@@ -25,12 +26,17 @@ import { getCoord } from '@turf/invariant';
  * destination.properties['marker-color'] = '#00F';
  */
 function rhumbDestination(origin, distance, bearing, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var units = options.units;
+    var properties = options.properties;
+
     // validation
     if (!origin) throw new Error('origin is required');
     if (distance === undefined || distance === null) throw new Error('distance is required');
     if (bearing === undefined || bearing === null) throw new Error('bearing is required');
     if (!(distance >= 0)) throw new Error('distance must be greater than 0');
-    var units = (typeof options === 'object') ? options.units : options || 'kilometers';
 
     var distanceInMeters = convertDistance(distance, units, 'meters');
     var coords = getCoord(origin);
@@ -39,7 +45,7 @@ function rhumbDestination(origin, distance, bearing, options) {
     // compensate the crossing of the 180th meridian (https://macwright.org/2016/09/26/the-180th-meridian.html)
     // solution from https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678
     destination[0] += (destination[0] - coords[0] > 180) ? -360 : (coords[0] - destination[0] > 180) ? 360 : 0;
-    return point(destination);
+    return point(destination, properties);
 }
 
 /**

--- a/packages/turf-rhumb-destination/test.js
+++ b/packages/turf-rhumb-destination/test.js
@@ -17,33 +17,43 @@ const fixtures = fs.readdirSync(directories.in).map(filename => {
     return {
         filename,
         name: path.parse(filename).name,
-        inputPoint: load.sync(directories.in + filename)
+        geojson: load.sync(directories.in + filename)
     };
 });
 
 test('turf-rhumb-destination', t => {
-    for (const {filename, name, inputPoint}  of fixtures) {
-        let {bearing, dist, units} = inputPoint.properties || {};
+    for (const {filename, name, geojson} of fixtures) {
+        let {bearing, dist, units} = geojson.properties || {};
         bearing = (bearing !== undefined) ? bearing : 180;
         dist = (dist !== undefined) ? dist : 100;
-        units = units || 'kilometers';
 
-        const destinationPoint = rhumbDestination(inputPoint, dist, bearing, units);
-        const line = truncate(lineString([getCoords(inputPoint), getCoords(destinationPoint)], {'stroke': '#F00', 'stroke-width': 4}));
-        inputPoint.properties['marker-color'] = '#F00';
-        const result = featureCollection([line, inputPoint, destinationPoint]);
+        const destinationPoint = rhumbDestination(geojson, dist, bearing, {units: units});
+        const line = truncate(lineString([getCoords(geojson), getCoords(destinationPoint)], {'stroke': '#F00', 'stroke-width': 4}));
+        geojson.properties['marker-color'] = '#F00';
+        const result = featureCollection([line, geojson, destinationPoint]);
 
         if (process.env.REGEN) write.sync(directories.out + filename, result);
         t.deepEqual(result, load.sync(directories.out + filename), name);
     }
+    t.end();
+});
 
+test('turf-rhumb-destintation -- throws error', t => {
     const pt = point([12, -54]);
     t.assert(rhumbDestination(pt, 0, 45).geometry.coordinates[0], '0 distance is valid');
     t.assert(rhumbDestination(pt, 100, 0).geometry.coordinates[0], '0 bearing is valid');
-    t.throws(() => { rhumbDestination(pt, 100, 45, 'blah'); }, 'unknown option given to units');
-    t.throws(() => { rhumbDestination(pt, -200, 75); }, 'invalid distance');
-    t.throws(() => { rhumbDestination(pt, null, 75); }, 'missing distance');
-    t.throws(() => { rhumbDestination(pt, 'miles', 75); }, 'invalid distance - units param switched to distance');
-    t.throws(() => { rhumbDestination('point', 200, 75, 'miles'); }, 'invalid point');
+    t.throws(() => rhumbDestination(pt, 100, 45, 'blah'), 'unknown option given to units');
+    t.throws(() => rhumbDestination(pt, -200, 75), 'invalid distance');
+    t.throws(() => rhumbDestination(pt, null, 75), 'missing distance');
+    t.throws(() => rhumbDestination(pt, 'foo', 75), 'invalid distance - units param switched to distance');
+    t.throws(() => rhumbDestination('foo', 200, 75, {units: 'miles'}), 'invalid point');
+    t.end();
+});
+
+test('turf-rhumb-destintation -- add properties', t => {
+    const properties = {foo: 'bar'};
+    const pt = point([12, -54], properties);
+
+    t.deepEqual(rhumbDestination(pt, 0, 45, {properties}).properties, properties, 'add properties');
     t.end();
 });

--- a/packages/turf-transform-translate/index.js
+++ b/packages/turf-transform-translate/index.js
@@ -1,6 +1,7 @@
 import { coordEach } from '@turf/meta';
 import { isObject } from '@turf/helpers';
 import { getCoords } from '@turf/invariant';
+import clone from '@turf/clone';
 import rhumbDestination from '@turf/rhumb-destination';
 
 /**
@@ -50,11 +51,11 @@ function transformTranslate(geojson, distance, direction, options) {
     }
 
     // Clone geojson to avoid side effects
-    if (mutate === false || mutate === undefined) geojson = JSON.parse(JSON.stringify(geojson));
+    if (mutate === false || mutate === undefined) geojson = clone(geojson);
 
     // Translate each coordinate
     coordEach(geojson, function (pointCoords) {
-        var newCoords = getCoords(rhumbDestination(pointCoords, distance, direction, units));
+        var newCoords = getCoords(rhumbDestination(pointCoords, distance, direction, {units: units}));
         pointCoords[0] = newCoords[0];
         pointCoords[1] = newCoords[1];
         if (zTranslation && pointCoords.length === 3) pointCoords[2] += zTranslation;

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -48,6 +48,7 @@
     "@std/esm": "*"
   },
   "dependencies": {
+    "@turf/clone": "^4.7.3",
     "@turf/helpers": "^5.0.0",
     "@turf/invariant": "^5.0.0",
     "@turf/meta": "^5.0.0",


### PR DESCRIPTION
## Add properties option to `@turf/rhumb-destination`

```js
const destination = rhumbDestination([-110, 50], 0, 45, {properties: {foo: 'bar'}});
//=destination.properties => {foo: 'bar'}
```

Might help clean up the following code:
https://github.com/stebogit/matrix-to-grid/blob/master/index.js#L62-L66