### PR TITLE
lineEach returns LineString including properties, bbox & id

### DIFF
--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -11,7 +11,10 @@ import {
     GeometryCollection,
     AllGeoJSON,
     FeatureGeometryCollection,
-    ExtendedFeatureCollection
+    ExtendedFeatureCollection,
+    Properties,
+    BBox,
+    Id
 } from '@turf/helpers';
 
 /**
@@ -34,7 +37,7 @@ export function coordEach(
 /**
  * http://turfjs.org/docs/#propeach
  */
-export function propEach<Props extends any>(
+export function propEach<Props extends Properties>(
     geojson: Feature<any> | FeatureCollection<any>,
     callback: (currentProperties: Props, featureIndex: number) => void
 ): void;
@@ -42,7 +45,7 @@ export function propEach<Props extends any>(
 /**
  * http://turfjs.org/docs/#propreduce
  */
-export function propReduce<Reducer extends any, Props extends any>(
+export function propReduce<Reducer extends any, Props extends Properties>(
     geojson: Feature<any> | FeatureCollection<any>,
     callback: (previousValue: Reducer, currentProperties: Props, featureIndex: number) => Reducer,
     initialValue?: Reducer
@@ -84,7 +87,7 @@ export function coordAll(geojson: AllGeoJSON): number[][];
  */
 export function geomReduce<Reducer extends any, Geom extends GeometryObject>(
     geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | GeometryCollection | FeatureGeometryCollection,
-    callback: (previousValue: Reducer, currentGeometry: Geom, featureIndex: number, currentProperties: any) => Reducer,
+    callback: (previousValue: Reducer, currentGeometry: Geom, featureIndex: number, currentProperties: Properties, currentBBox: BBox, currentId: Id) => Reducer,
     initialValue?: Reducer
 ): Reducer;
 
@@ -93,7 +96,7 @@ export function geomReduce<Reducer extends any, Geom extends GeometryObject>(
  */
 export function geomEach<Geom extends GeometryObject>(
     geojson: Feature<Geom> | FeatureCollection<Geom> | Geom | GeometryCollection | FeatureGeometryCollection,
-    callback: (currentGeometry: Geom, featureIndex: number, currentProperties: any) => void
+    callback: (currentGeometry: Geom, featureIndex: number, currentProperties: Properties, currentBBox: BBox, currentId: Id) => void
 ): void;
 
 /**

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -394,7 +394,7 @@ export function coordAll(geojson) {
  * @param {Geometry} currentGeometry The current geometry being processed.
  * @param {number} featureIndex The index of the current element being processed in the
  * array. Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
- * @param {object} featureProperties The current feature properties being processed.
+ * @param {Object} featureProperties The current feature properties being processed.
  * @param {Array<number>} featureBBox The current feature BBox being processed.
  * @param {number|string} featureId The current feature Id being processed.
  */

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -1,3 +1,5 @@
+import { feature, lineString } from '@turf/helpers';
+
 /**
  * Callback for coordEach
  *
@@ -390,9 +392,11 @@ export function coordAll(geojson) {
  *
  * @callback geomEachCallback
  * @param {Geometry} currentGeometry The current geometry being processed.
- * @param {number} currentIndex The index of the current element being processed in the
+ * @param {number} featureIndex The index of the current element being processed in the
  * array. Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
- * @param {number} currentProperties The current feature properties being processed.
+ * @param {object} featureProperties The current feature properties being processed.
+ * @param {Array<number>} featureBBox The current feature BBox being processed.
+ * @param {number|string} featureId The current feature Id being processed.
  */
 
 /**
@@ -417,7 +421,9 @@ export function geomEach(geojson, callback) {
     var i, j, g, geometry, stopG,
         geometryMaybeCollection,
         isGeometryCollection,
-        geometryProperties,
+        featureProperties,
+        featureBBox,
+        featureId,
         featureIndex = 0,
         isFeatureCollection = geojson.type === 'FeatureCollection',
         isFeature = geojson.type === 'Feature',
@@ -439,8 +445,12 @@ export function geomEach(geojson, callback) {
 
         geometryMaybeCollection = (isFeatureCollection ? geojson.features[i].geometry :
             (isFeature ? geojson.geometry : geojson));
-        geometryProperties = (isFeatureCollection ? geojson.features[i].properties :
+        featureProperties = (isFeatureCollection ? geojson.features[i].properties :
             (isFeature ? geojson.properties : {}));
+        featureBBox = (isFeatureCollection ? geojson.features[i].bbox :
+            (isFeature ? geojson.bbox : undefined));
+        featureId = (isFeatureCollection ? geojson.features[i].id :
+            (isFeature ? geojson.id : undefined));
         isGeometryCollection = (geometryMaybeCollection) ? geometryMaybeCollection.type === 'GeometryCollection' : false;
         stopG = isGeometryCollection ? geometryMaybeCollection.geometries.length : 1;
 
@@ -450,7 +460,7 @@ export function geomEach(geojson, callback) {
 
             // Handle null Geometry
             if (geometry === null) {
-                callback(null, featureIndex, geometryProperties);
+                callback(null, featureIndex, featureProperties, featureBBox, featureId);
                 continue;
             }
             switch (geometry.type) {
@@ -460,12 +470,12 @@ export function geomEach(geojson, callback) {
             case 'Polygon':
             case 'MultiLineString':
             case 'MultiPolygon': {
-                callback(geometry, featureIndex, geometryProperties);
+                callback(geometry, featureIndex, featureProperties, featureBBox, featureId);
                 break;
             }
             case 'GeometryCollection': {
                 for (j = 0; j < geometry.geometries.length; j++) {
-                    callback(geometry.geometries[j], featureIndex, geometryProperties);
+                    callback(geometry.geometries[j], featureIndex, featureProperties, featureBBox, featureId);
                 }
                 break;
             }
@@ -563,7 +573,7 @@ export function geomReduce(geojson, callback, initialValue) {
  * });
  */
 export function flattenEach(geojson, callback) {
-    geomEach(geojson, function (geometry, featureIndex, properties) {
+    geomEach(geojson, function (geometry, featureIndex, properties, bbox, id) {
         // Callback for single geometry
         var type = (geometry === null) ? null : geometry.type;
         switch (type) {
@@ -571,7 +581,7 @@ export function flattenEach(geojson, callback) {
         case 'Point':
         case 'LineString':
         case 'Polygon':
-            callback(feature(geometry, properties), featureIndex, 0);
+            callback(feature(geometry, properties, bbox, id), featureIndex, 0);
             return;
         }
 
@@ -774,52 +784,13 @@ export function segmentReduce(geojson, callback, initialValue) {
 }
 
 /**
- * Create Feature
- *
- * @private
- * @param {Geometry} geometry GeoJSON Geometry
- * @param {Object} properties Properties
- * @returns {Feature} GeoJSON Feature
- */
-function feature(geometry, properties) {
-    if (geometry === undefined) throw new Error('No geometry passed');
-
-    return {
-        type: 'Feature',
-        properties: properties || {},
-        geometry: geometry
-    };
-}
-
-/**
- * Create LineString
- *
- * @private
- * @param {Array<Array<number>>} coordinates Line Coordinates
- * @param {Object} properties Properties
- * @returns {Feature<LineString>} GeoJSON LineString Feature
- */
-function lineString(coordinates, properties) {
-    if (!coordinates) throw new Error('No coordinates passed');
-    if (coordinates.length < 2) throw new Error('Coordinates must be an array of two or more positions');
-
-    return {
-        type: 'Feature',
-        properties: properties || {},
-        geometry: {
-            type: 'LineString',
-            coordinates: coordinates
-        }
-    };
-}
-
-/**
  * Callback for lineEach
  *
  * @callback lineEachCallback
  * @param {Feature<LineString>} currentLine The current LineString|LinearRing being processed.
- * @param {number} lineIndex The index of the current element being processed in the array, starts at index 0.
- * @param {number} lineSubIndex The sub-index of the current line being processed at index 0
+ * @param {number} featureIndex The feature index of the current element being processed in the array, starts at index 0.
+ * @param {number} featureSubIndex The feature sub-index of the current line being processed at index 0
+ * @param {number} lineIndex The current line being processed at index 0
  */
 
 /**
@@ -852,11 +823,11 @@ export function lineEach(geojson, callback) {
         var coords = feature.geometry.coordinates;
         switch (type) {
         case 'LineString':
-            callback(coords, featureIndex, featureSubIndex, 0);
+            callback(feature, featureIndex, featureSubIndex, 0);
             break;
         case 'Polygon':
             for (var lineIndex = 0; lineIndex < coords.length; lineIndex++) {
-                callback(coords[lineIndex], featureIndex, featureSubIndex, lineIndex);
+                callback(lineString(coords[lineIndex], feature.properties), featureIndex, featureSubIndex, lineIndex);
             }
             break;
         }
@@ -881,9 +852,9 @@ export function lineEach(geojson, callback) {
  * @param {*} previousValue The accumulated value previously returned in the last invocation
  * of the callback, or initialValue, if supplied.
  * @param {Feature<LineString>} currentLine The current LineString|LinearRing being processed.
- * @param {number} lineIndex The index of the current element being processed in the
- * array. Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
- * @param {number} lineSubIndex The sub-index of the current line being processed at index 0
+ * @param {number} featureIndex The feature index of the current element being processed in the array, starts at index 0.
+ * @param {number} featureSubIndex The feature sub-index of the current line being processed at index 0
+ * @param {number} lineIndex The current line being processed at index 0
  */
 
 /**
@@ -900,19 +871,20 @@ export function lineEach(geojson, callback) {
  *   turf.polygon([[[5, 5], [0, 0], [2, 2], [4, 4], [5, 5]]])
  * ]);
  *
- * turf.lineReduce(mtp, function (previousValue, currentLine, lineIndex, lineSubIndex) {
+ * turf.lineReduce(mtp, function (previousValue, currentLine, featureIndex, featureSubIndex, lineIndex) {
  *   //=previousValue
  *   //=currentLine
+ *   //=featureIndex
+ *   //=featureSubIndex
  *   //=lineIndex
- *   //=lineSubIndex
  *   return currentLine
  * }, 2);
  */
 export function lineReduce(geojson, callback, initialValue) {
     var previousValue = initialValue;
-    lineEach(geojson, function (currentLine, lineIndex, lineSubIndex) {
-        if (lineIndex === 0 && initialValue === undefined) previousValue = currentLine;
-        else previousValue = callback(previousValue, currentLine, lineIndex, lineSubIndex);
+    lineEach(geojson, function (currentLine, featureIndex, featureSubIndex, lineIndex) {
+        if (featureIndex === 0 && initialValue === undefined) previousValue = currentLine;
+        else previousValue = callback(previousValue, currentLine, featureIndex, featureSubIndex, lineIndex);
     });
     return previousValue;
 }

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -653,3 +653,45 @@ test('lineEach & lineReduce -- assert', t => {
     meta.lineReduce(feature(null), () => {}); // Feature with null geometry is supported
     t.end();
 });
+
+test('geomEach -- callback BBox & Id', t => {
+    const properties = {foo: 'bar'};
+    const bbox = [0, 0, 0, 0];
+    const id = 'foo';
+    const pt = point([0, 0], properties, bbox, id);
+
+    meta.geomEach(pt, (currentGeometry, featureIndex, currentProperties, currentBBox, currentId) => {
+        t.equal(featureIndex, 0, 'featureIndex');
+        t.deepEqual(currentProperties, properties, 'currentProperties');
+        t.deepEqual(currentBBox, bbox, 'currentBBox');
+        t.deepEqual(currentId, id, 'currentId');
+    });
+    t.end();
+});
+
+test('lineEach -- callback BBox & Id', t => {
+    const properties = {foo: 'bar'};
+    const bbox = [0, 0, 10, 10];
+    const id = 'foo';
+    const line = lineString([[0, 0], [10, 10]], properties, bbox, id);
+
+    meta.lineEach(line, (currentLine, featureIndex) => {
+        t.equal(featureIndex, 0, 'featureIndex');
+        t.deepEqual(currentLine.properties, properties, 'currentProperties');
+        t.deepEqual(currentLine.bbox, bbox, 'currentBBox');
+        t.deepEqual(currentLine.id, id, 'currentId');
+    });
+    t.end();
+});
+
+test('lineEach -- return lineString', t => {
+    const properties = {foo: 'bar'};
+    const bbox = [0, 0, 10, 10];
+    const id = 'foo';
+    const line = lineString([[0, 0], [10, 10]], properties, bbox, id);
+
+    meta.lineEach(line, (currentLine) => {
+        t.deepEqual(line, currentLine, 'return itself');
+    });
+    t.end();
+});


### PR DESCRIPTION
## `lineEach` callback => LineString including properties, bbox & id

Don't know if this was intentional, but the `lineEach` method was only returning coordinates of a lineString instead of the `Feature<LineString>`. Not returning the Feature makes it difficult to extract things like Properties/id/BBox of the given feature.

## Example (once PR is merged)

```js
const properties = {foo: 'bar'};
const bbox = [0, 0, 10, 10];
const id = 'foo';
const line = lineString([[0, 0], [10, 10]], properties, bbox, id);

meta.lineEach(line, currentLine => {
  //= currentLine.id => 'foo'
  //= currentLine.bbox => [0, 0, 10, 10]
  //= currentLine.properties => {foo: 'bar'}
});
```

CC: @rowanwins @stebogit 