### PR TITLE
Update typescript definitions

### DIFF
--- a/packages/turf-bearing/index.d.ts
+++ b/packages/turf-bearing/index.d.ts
@@ -1,11 +1,11 @@
-import { Point, Feature, Position } from '@turf/helpers'
+import { Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#bearing
  */
 export default function bearing(
-    start: Feature<Point> | Point | Position,
-    end: Feature<Point> | Point | Position,
+    start: Coord,
+    end: Coord,
     options?: {
         final?: boolean
     }

--- a/packages/turf-circle/index.d.ts
+++ b/packages/turf-circle/index.d.ts
@@ -1,14 +1,14 @@
-import { Feature, Point, Polygon, Units, Position } from '@turf/helpers'
+import { Feature, Coord, Polygon, Units, Properties } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#circle
  */
 export default function (
-  center: Feature<Point> | Point | Position,
-  radius: number,
-  options?: {
-    steps?: number;
-    units?: Units;
-    properties?: object;
-  }
+    center: Coord,
+    radius: number,
+    options?: {
+        steps?: number;
+        units?: Units;
+        properties?: Properties;
+    }
 ): Feature<Polygon>;

--- a/packages/turf-destination/index.d.ts
+++ b/packages/turf-destination/index.d.ts
@@ -1,10 +1,10 @@
-import { Feature, Point, Units, Position } from '@turf/helpers'
+import { Feature, Point, Units, Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#destination
  */
 export default function destination(
-    origin: Feature<Point> | Point | Position,
+    origin: Coord,
     distance: number,
     bearing: number,
     options?: {

--- a/packages/turf-distance/index.d.ts
+++ b/packages/turf-distance/index.d.ts
@@ -1,11 +1,11 @@
-import { Units, Point, Feature, Position } from '@turf/helpers'
+import { Units, Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#distance
  */
 export default function distance(
-    from: Feature<Point> | Point | Position,
-    to: Feature<Point> | Point | Position,
+    from: Coord,
+    to: Coord,
     options?: {
         units?: Units
     }

--- a/packages/turf-flatten/index.d.ts
+++ b/packages/turf-flatten/index.d.ts
@@ -6,10 +6,8 @@ import {
     Polygon,
     MultiPolygon,
     Feature,
-    GeometryObject,
     FeatureCollection,
-    GeometryCollection,
-    FeatureGeometryCollection
+    AllGeoJSON
 } from '@turf/helpers'
 
 /**
@@ -18,6 +16,6 @@ import {
 declare function flatten<T extends Point | MultiPoint>(geojson: Feature<T> | FeatureCollection<T> | T): FeatureCollection<Point>;
 declare function flatten<T extends LineString | MultiLineString>(geojson: Feature<T> | FeatureCollection<T> | T): FeatureCollection<LineString>;
 declare function flatten<T extends Polygon | MultiPolygon>(geojson: Feature<T> | FeatureCollection<T> | T): FeatureCollection<Polygon>;
-declare function flatten(geojson: FeatureCollection<any> | Feature<any> | FeatureGeometryCollection | GeometryCollection | GeometryObject): FeatureCollection<any>;
+declare function flatten(geojson: AllGeoJSON): FeatureCollection<any>;
 
 export default flatten;

--- a/packages/turf-flip/index.d.ts
+++ b/packages/turf-flip/index.d.ts
@@ -1,8 +1,8 @@
-import { Feature, FeatureCollection, GeometryObject, GeometryCollection, FeatureGeometryCollection } from '@turf/helpers'
+import { AllGeoJSON } from '@turf/helpers'
 
-export default function flip<T extends Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection | FeatureGeometryCollection>(
+export default function flip<T extends AllGeoJSON>(
     geojson: T,
     options?: {
-      mutate?: boolean
+        mutate?: boolean
     }
 ): T

--- a/packages/turf-flip/types.ts
+++ b/packages/turf-flip/types.ts
@@ -15,5 +15,5 @@ flip(line)
 flip(lineGeom)
 flip(lines)
 flip(points)
-flip(geomCollection)
+flip(geomCollection, {mutate: true})
 

--- a/packages/turf-great-circle/index.d.ts
+++ b/packages/turf-great-circle/index.d.ts
@@ -1,13 +1,13 @@
-import { Point, LineString, Feature, Position } from '@turf/helpers'
+import { LineString, Feature, Coord, Properties } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#greatcircle
  */
 export default function greatCircle(
-    start: Feature<Point> | Point | Position,
-    end: Feature<Point> | Point | Position,
+    start: Coord,
+    end: Coord,
     options?: {
-        properties?: object,
+        properties?: Properties,
         npoints?: number,
         offset?: number
     }

--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -12,7 +12,8 @@ export type Coord = Feature<Point> | Point | Position;
 export type Units = 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres';
 export type Geometry = 'Point' | 'LineString' | 'Polygon' | 'MultiPoint' | 'MultiLineString' | 'MultiPolygon';
 export type Grid = 'point' | 'square' | 'hex' | 'triangle';
-export type Types = Geometry | 'Feature' | 'FeatureCollection'
+export type Collection = 'FeatureCollection' | 'GeometryCollection';
+export type Types = 'Feature' | Geometry | Collection;
 export type Corners = 'sw' | 'se' | 'nw' | 'ne' | 'center' | 'centroid';
 
 
@@ -24,6 +25,7 @@ export type MultiLineString = GeoJSON.MultiLineString;
 export type LineString = GeoJSON.LineString;
 export type Polygon = GeoJSON.Polygon;
 export type MultiPolygon = GeoJSON.MultiPolygon;
+export type Geometries = Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon;
 export type GeometryObject = GeoJSON.GeometryObject;
 export type GeometryCollection = GeoJSON.GeometryCollection;
 

--- a/packages/turf-inside/index.d.ts
+++ b/packages/turf-inside/index.d.ts
@@ -1,12 +1,12 @@
-import { Point, MultiPolygon, Polygon, Feature, Position } from '@turf/helpers'
+import { MultiPolygon, Polygon, Feature, Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#inside
  */
 export default function inside<T extends Polygon | MultiPolygon>(
-    point: Feature<Point> | Point | Position,
+    point: Coord,
     polygon: Feature<T> | T,
     options?: {
-      ignoreBoundary?: boolean
+        ignoreBoundary?: boolean
     }
 ): boolean;

--- a/packages/turf-invariant/index.d.ts
+++ b/packages/turf-invariant/index.d.ts
@@ -1,10 +1,14 @@
 import {
     GeometryObject,
     GeometryCollection,
+    FeatureGeometryCollection,
     Feature,
     FeatureCollection,
     Geometry,
-    Types
+    Types,
+    Collection,
+    AllGeoJSON,
+    Geometries
 } from '@turf/helpers'
 
 /**
@@ -20,7 +24,7 @@ export function getCoords(obj: Feature<any> | GeometryObject | any[]): any[];
 /**
  * http://turfjs.org/docs/#geojsontype
  */
-export function geojsonType(value: FeatureCollection<any>, type: string, name: string): void;
+export function geojsonType(value: AllGeoJSON, type: string, name: string): void;
 
 /**
  * http://turfjs.org/docs/#featureof
@@ -40,10 +44,14 @@ export function containsNumber(coordinates: any[]): boolean;
 /**
  * http://turfjs.org/docs/#getgeom
  */
-export function getGeom(geojson: GeometryCollection | GeometryObject | Feature<any>): GeometryObject;
+export function getGeom<T extends Geometries>(geojson: T | Feature<T>): T;
+export function getGeom(geojson: GeometryObject | Feature<Geometries>): GeometryObject;
+export function getGeom(geojson: FeatureGeometryCollection | GeometryCollection): GeometryCollection;
+export function getGeom(geojson: Feature<any>): GeometryObject | GeometryCollection;
 
 /**
  * http://turfjs.org/docs/#gettype
  */
-export function getType(geojson: GeometryObject | Feature<any>): Geometry;
-export function getType(geojson: GeometryCollection | GeometryObject | Feature<any> | FeatureCollection<any>): Types;
+export function getType(geojson: GeometryObject | Feature<Geometries>): Geometry;
+export function getType(geojson: FeatureCollection<any> | FeatureGeometryCollection | GeometryCollection): Collection;
+export function getType(geojson: AllGeoJSON): Types;

--- a/packages/turf-invariant/types.ts
+++ b/packages/turf-invariant/types.ts
@@ -6,7 +6,11 @@ import {
     geometryCollection,
     featureCollection,
     Geometry,
-    Types
+    Types,
+    GeometryCollection,
+    Point,
+    LineString,
+    Polygon
 } from '@turf/helpers'
 import {
     getCoord,
@@ -33,18 +37,18 @@ const fc = featureCollection([pt, line, poly])
  */
 // invariant.getGeom(fc) // Argument of type 'FeatureCollection<any>' is not assignable to parameter of type
 getGeom(gc)
-invariant.getGeom(gc)
-invariant.getGeom(pt)
-invariant.getGeom(line)
-invariant.getGeom(poly)
+const gcGeom: GeometryCollection  = invariant.getGeom(gc)
+const pointGeom: Point = invariant.getGeom(pt)
+const lineGeom: LineString = invariant.getGeom(line)
+const polyGeom: Polygon = invariant.getGeom(poly)
 invariant.getGeom(pt.geometry)
 
 /**
  * invariant.getType
  */
 const type: Geometry = invariant.getType(pt)
-getType(gc)
-invariant.getType(gc)
-invariant.getType(line)
-invariant.getType(poly)
-invariant.getType(pt.geometry)
+if (getType(gc) === 'GeometryCollection') console;
+if (getType(line) === 'LineString') console;
+if (getType(poly) === 'Polygon') console;
+if (getType(pt.geometry) === 'Point') console;
+if (getType(fc) === 'FeatureCollection') console;

--- a/packages/turf-line-arc/index.d.ts
+++ b/packages/turf-line-arc/index.d.ts
@@ -1,10 +1,10 @@
-import { Point, Position, Feature, LineString, Units } from '@turf/helpers';
+import { Coord, Feature, LineString, Units } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#linearc
  */
 export default function lineArc(
-    center: Feature<Point> | Point | Position,
+    center: Coord,
     radius: number,
     bearing1: number,
     bearing2: number,

--- a/packages/turf-line-slice/index.d.ts
+++ b/packages/turf-line-slice/index.d.ts
@@ -1,4 +1,4 @@
-import { Point, Feature, LineString, Position, Coord } from '@turf/helpers'
+import { Feature, LineString, Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#lineslice

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -38,7 +38,7 @@ export function coordEach(
  * http://turfjs.org/docs/#propeach
  */
 export function propEach<Props extends Properties>(
-    geojson: Feature<any> | FeatureCollection<any>,
+    geojson: Feature<any> | FeatureCollection<any> | FeatureGeometryCollection,
     callback: (currentProperties: Props, featureIndex: number) => void
 ): void;
 
@@ -46,7 +46,7 @@ export function propEach<Props extends Properties>(
  * http://turfjs.org/docs/#propreduce
  */
 export function propReduce<Reducer extends any, Props extends Properties>(
-    geojson: Feature<any> | FeatureCollection<any>,
+    geojson: Feature<any> | FeatureCollection<any> | FeatureGeometryCollection,
     callback: (previousValue: Reducer, currentProperties: Props, featureIndex: number) => Reducer,
     initialValue?: Reducer
 ): Reducer;
@@ -136,8 +136,8 @@ export function segmentEach(
 /**
  * http://turfjs.org/docs/#linereduce
  */
-export function lineReduce<Reducer extends any, Geom extends LineString | MultiLineString | Polygon | MultiPolygon>(
-    geojson: Feature<Geom> | Geom,
+export function lineReduce<Reducer extends any>(
+    geojson: AllGeoJSON,
     callback: (previousValue?: Reducer, currentLine?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number, lineIndex?: number) => Reducer,
     initialValue?: Reducer
 ): Reducer;
@@ -145,7 +145,15 @@ export function lineReduce<Reducer extends any, Geom extends LineString | MultiL
 /**
  * http://turfjs.org/docs/#lineeach
  */
-export function lineEach<Geom extends LineString | MultiLineString | Polygon | MultiPolygon>(
-    geojson: Feature<Geom> | Geom,
+export function lineEach<T extends LineString | MultiLineString | Polygon | MultiPolygon>(
+    geojson: Feature<T> | T,
+    callback: (currentLine?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number, lineIndex?: number) => void
+): void;
+export function lineEach<Feat extends Feature<LineString>>(
+    geojson: Feat | ExtendedFeatureCollection<Feat>,
+    callback: (currentLine?: Feat, featureIndex?: number, featureSubIndex?: number, lineIndex?: number) => void
+): void;
+export function lineEach<Feat extends Feature<MultiLineString | Polygon | MultiPolygon>>(
+    geojson: Feat | ExtendedFeatureCollection<Feat>,
     callback: (currentLine?: Feature<LineString>, featureIndex?: number, featureSubIndex?: number, lineIndex?: number) => void
 ): void;

--- a/packages/turf-point-grid/index.d.ts
+++ b/packages/turf-point-grid/index.d.ts
@@ -1,4 +1,4 @@
-import { Units, BBox, Feature, FeatureCollection, Point } from '@turf/helpers';
+import { Units, BBox, Feature, FeatureCollection, Point, Properties} from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#pointgrid
@@ -8,7 +8,7 @@ export default function pointGrid(
     cellSide: number,
     options?: {
         units?: Units,
-        properties?: object,
+        properties?: Properties,
         bboxIsMask?: boolean;
     }
 ): FeatureCollection<Point>;

--- a/packages/turf-point-on-line/index.d.ts
+++ b/packages/turf-point-on-line/index.d.ts
@@ -1,4 +1,4 @@
-import { Point, Feature, Units, Position, LineString, MultiLineString } from '@turf/helpers'
+import { Point, Feature, Units, Coord, LineString, MultiLineString } from '@turf/helpers'
 
 export interface PointOnLine extends Feature<Point> {
     properties: {
@@ -14,7 +14,7 @@ export interface PointOnLine extends Feature<Point> {
  */
 export default function pointOnLine<T extends MultiLineString | LineString>(
     line: Feature<T> | T,
-    point: Feature<Point> | Point | Position,
+    point: Coord,
     options?: {
         units?: Units
     }

--- a/packages/turf-point-to-line-distance/index.d.ts
+++ b/packages/turf-point-to-line-distance/index.d.ts
@@ -1,10 +1,10 @@
-import { Feature, LineString, Point, Units, Position } from '@turf/helpers'
+import { Feature, LineString, Units, Coord } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#pointtolinedistance
  */
 export default function pointToLineDistance(
-    pt: Feature<Point> | Point | Position,
+    pt: Coord,
     line: Feature<LineString> | LineString,
     options?: {
         units?: Units,

--- a/packages/turf-polygon-to-linestring/index.d.ts
+++ b/packages/turf-polygon-to-linestring/index.d.ts
@@ -6,7 +6,8 @@ import {
     LineString,
     MultiLineString,
     GeometryCollection,
-    FeatureGeometryCollection
+    FeatureGeometryCollection,
+    Properties
 } from '@turf/helpers';
 
 /**
@@ -17,7 +18,7 @@ import {
 declare function polygonToLineString<T extends Polygon | MultiPolygon>(
     polygon: Feature<T> | T,
     options?: {
-        properties?: object
+        properties?: Properties
     }
 ): Feature<LineString>;
 
@@ -29,7 +30,7 @@ declare function polygonToLineString<T extends Polygon | MultiPolygon>(
 declare function polygonToLineString<T extends Polygon | MultiPolygon>(
     polygon: FeatureCollection<T> | GeometryCollection | FeatureGeometryCollection,
     options?: {
-        properties?: object
+        properties?: Properties
     }
 ): Feature<MultiLineString>;
 

--- a/packages/turf-projection/index.d.ts
+++ b/packages/turf-projection/index.d.ts
@@ -1,9 +1,9 @@
-import { Feature, FeatureCollection, GeometryObject, GeometryCollection, FeatureGeometryCollection, Position} from '@turf/helpers';
+import { AllGeoJSON, Position} from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#toMercator
  */
-export function toMercator<T extends Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection>(
+export function toMercator<T extends AllGeoJSON | Position>(
     geojson: T,
     options?: {
         mutate?: boolean
@@ -13,7 +13,7 @@ export function toMercator<T extends Feature<any> | FeatureCollection<any> | Geo
 /**
  * http://turfjs.org/docs/#toWgs84
  */
-export function toWgs84<T extends Feature<any> | FeatureCollection<any> | GeometryObject | GeometryCollection>(
+export function toWgs84<T extends AllGeoJSON | Position>(
     geojson: T,
     options?: {
         mutate?: boolean


### PR DESCRIPTION
# Update Typescript definitions

Update the following Typescript syntax:

- [x] `AllGeoJSON` (for every geojson possibility)
- [x] `Coord` (for single point)
- [x] `Properties` (to normalize GeoJSON Properties, at the moment defined as `object`)
- [x] Updates to `@turf/meta` & `@turf/invariant`