### PR TITLE
Enforce strict options params for v5.0 modules

### DIFF
--- a/packages/turf-along/index.js
+++ b/packages/turf-along/index.js
@@ -1,7 +1,7 @@
 import bearing from '@turf/bearing';
 import destination from '@turf/destination';
 import measureDistance from '@turf/distance';
-import { point, isNumber } from '@turf/helpers';
+import { point, isNumber, isObject } from '@turf/helpers';
 
 /**
  * Takes a {@link LineString|line} and returns a {@link Point|point} at a specified distance along the line.
@@ -21,8 +21,10 @@ import { point, isNumber } from '@turf/helpers';
  * var addToMap = [along, line]
  */
 function along(line, distance, options) {
-    // Backwards compatible with v4.0
-    var units = (typeof options === 'object') ? options.units : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var units = options.units;
 
     // Validation
     var coords;

--- a/packages/turf-along/index.js
+++ b/packages/turf-along/index.js
@@ -14,8 +14,9 @@ import { point, isNumber, isObject } from '@turf/helpers';
  * @returns {Feature<Point>} Point `distance` `units` along the line
  * @example
  * var line = turf.lineString([[-83, 30], [-84, 36], [-78, 41]]);
+ * var options = {units: 'miles'};
  *
- * var along = turf.along(line, 200, 'miles');
+ * var along = turf.along(line, 200, options);
  *
  * //addToMap
  * var addToMap = [along, line]
@@ -24,7 +25,6 @@ function along(line, distance, options) {
     // Optional parameters
     options = options || {};
     if (!isObject(options)) throw new Error('options is invalid');
-    var units = options.units;
 
     // Validation
     var coords;
@@ -41,11 +41,11 @@ function along(line, distance, options) {
             if (!overshot) return point(coords[i]);
             else {
                 var direction = bearing(coords[i], coords[i - 1]) - 180;
-                var interpolated = destination(coords[i], overshot, direction, units);
+                var interpolated = destination(coords[i], overshot, direction, options);
                 return interpolated;
             }
         } else {
-            travelled += measureDistance(coords[i], coords[i + 1], units);
+            travelled += measureDistance(coords[i], coords[i + 1], options);
         }
     }
     return point(coords[coords.length - 1]);

--- a/packages/turf-along/test.js
+++ b/packages/turf-along/test.js
@@ -7,14 +7,15 @@ import along from '.';
 const line = load.sync(path.join(__dirname, 'test', 'fixtures', 'dc-line.geojson'));
 
 test('turf-along', t => {
-    const pt1 = along(line, 1, 'miles');
-    const pt2 = along(line.geometry, 1.2, 'miles');
-    const pt3 = along(line, 1.4, 'miles');
-    const pt4 = along(line.geometry, 1.6, 'miles');
-    const pt5 = along(line, 1.8, 'miles');
-    const pt6 = along(line.geometry, 2, 'miles');
-    const pt7 = along(line, 100, 'miles');
-    const pt8 = along(line.geometry, 0, 'miles');
+    const options = {units: 'miles'}
+    const pt1 = along(line, 1, options);
+    const pt2 = along(line.geometry, 1.2, options);
+    const pt3 = along(line, 1.4, options);
+    const pt4 = along(line.geometry, 1.6, options);
+    const pt5 = along(line, 1.8, options);
+    const pt6 = along(line.geometry, 2, options);
+    const pt7 = along(line, 100, options);
+    const pt8 = along(line.geometry, 0, options);
     const fc = featureCollection([pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8]);
 
     fc.features.forEach(f => {

--- a/packages/turf-bearing/bench.js
+++ b/packages/turf-bearing/bench.js
@@ -1,14 +1,13 @@
 import Benchmark from 'benchmark';
-import { point } from '@turf/helpers';
 import bearing from './';
 
-var start = point([-75.4, 39.4]);
-var end = point([-75.534, 39.123]);
+var start = [-75.4, 39.4];
+var end = [-75.534, 39.123];
 
 var suite = new Benchmark.Suite('turf-bearing');
 suite
-    .add('initial bearing', () => { bearing(start, end); })
-    .add('final bearing', () => { bearing(start, end, true); })
+    .add('initial bearing', () => bearing(start, end) )
+    .add('final bearing', () => bearing(start, end, {final: true}) )
     .on('cycle', e => console.log(String(e.target)))
     .on('complete', () => {})
     .run();

--- a/packages/turf-bearing/index.js
+++ b/packages/turf-bearing/index.js
@@ -1,4 +1,6 @@
 import { getCoord } from '@turf/invariant';
+import { isObject } from '@turf/helpers';
+
 //http://en.wikipedia.org/wiki/Haversine_formula
 //http://www.movable-type.co.uk/scripts/latlong.html
 
@@ -25,8 +27,12 @@ import { getCoord } from '@turf/invariant';
  * point1.properties.bearing = bearing
  */
 function bearing(start, end, options) {
-    // Backwards compatible with v4.0
-    var final = (typeof options === 'object') ? options.final : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var final = options.final;
+
+    // Reverse calculation
     if (final === true) return calculateFinalBearing(start, end);
 
     var degrees2radians = Math.PI / 180;

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -32,7 +32,6 @@
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
     "@turf/destination": "*",
-    "@turf/helpers": "*",
     "benchmark": "*",
     "tape": "*",
     "write-json-file": "*",
@@ -40,6 +39,7 @@
     "@std/esm": "*"
   },
   "dependencies": {
+    "@turf/helpers": "*",
     "@turf/invariant": "^5.0.0"
   },
   "@std/esm": {

--- a/packages/turf-bearing/test.js
+++ b/packages/turf-bearing/test.js
@@ -14,7 +14,7 @@ test('bearing', t => {
     const initialBearing = bearing(start, end);
     t.equal(initialBearing.toFixed(2), '37.75', 'initial bearing');
 
-    const finalBearing = bearing(start, end, true);
+    const finalBearing = bearing(start, end, {final: true});
     t.equal(finalBearing.toFixed(2), '120.01', 'final bearing');
     t.end();
 

--- a/packages/turf-circle/index.js
+++ b/packages/turf-circle/index.js
@@ -25,7 +25,6 @@ function circle(center, radius, options) {
     // Optional params
     options = options || {};
     var steps = options.steps || 64;
-    var units = options.units;
     var properties = options.properties;
 
     // validation
@@ -40,7 +39,7 @@ function circle(center, radius, options) {
 
     var coordinates = [];
     for (var i = 0; i < steps; i++) {
-        coordinates.push(destination(center, radius, i * -360 / steps, units).geometry.coordinates);
+        coordinates.push(destination(center, radius, i * -360 / steps, options).geometry.coordinates);
     }
     coordinates.push(coordinates[0]);
 

--- a/packages/turf-concave/bench.js
+++ b/packages/turf-concave/bench.js
@@ -26,7 +26,7 @@ const fixtures = fs.readdirSync(directory).map(filename => {
 for (const {name, geojson} of fixtures) {
     const {maxEdge, units} = geojson.properties || {maxEdge: 1};
     console.time(name);
-    concave(geojson, maxEdge, units);
+    concave(geojson, maxEdge, {units});
     console.timeEnd(name);
 }
 
@@ -44,7 +44,7 @@ for (const {name, geojson} of fixtures) {
 const suite = new Benchmark.Suite('turf-transform-scale');
 for (const {name, geojson} of fixtures) {
     const {maxEdge, units} = geojson.properties || {maxEdge: 1};
-    suite.add(name, () => concave(geojson, maxEdge, units));
+    suite.add(name, () => concave(geojson, maxEdge, {units}));
 }
 
 suite

--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -23,8 +23,9 @@ import { featureEach } from '@turf/meta';
  *   turf.point([-63.587665, 44.64533]),
  *   turf.point([-63.595218, 44.64765])
  * ]);
+ * var options = {units: 'miles'};
  *
- * var hull = turf.concave(points, 1, 'miles');
+ * var hull = turf.concave(points, 1, options);
  *
  * //addToMap
  * var addToMap = [points, hull]

--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -1,7 +1,7 @@
 import tin from '@turf/tin';
 var dissolve = require('geojson-dissolve');
 import distance from '@turf/distance';
-import { feature, featureCollection } from '@turf/helpers';
+import { feature, featureCollection, isObject } from '@turf/helpers';
 import { featureEach } from '@turf/meta';
 
 /**
@@ -30,8 +30,9 @@ import { featureEach } from '@turf/meta';
  * var addToMap = [points, hull]
  */
 function concave(points, maxEdge, options) {
-    // Backwards compatible with v4.0
-    var units = (typeof options === 'object') ? options.units : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
 
     // validation
     if (!points) throw new Error('points is required');
@@ -47,9 +48,9 @@ function concave(points, maxEdge, options) {
         var pt1 = triangle.geometry.coordinates[0][0];
         var pt2 = triangle.geometry.coordinates[0][1];
         var pt3 = triangle.geometry.coordinates[0][2];
-        var dist1 = distance(pt1, pt2, units);
-        var dist2 = distance(pt2, pt3, units);
-        var dist3 = distance(pt1, pt3, units);
+        var dist1 = distance(pt1, pt2, options);
+        var dist2 = distance(pt2, pt3, options);
+        var dist3 = distance(pt1, pt3, options);
         return (dist1 <= maxEdge && dist2 <= maxEdge && dist3 <= maxEdge);
     });
 

--- a/packages/turf-destination/bench.js
+++ b/packages/turf-destination/bench.js
@@ -2,22 +2,13 @@ import fs from 'fs';
 import Benchmark from 'benchmark';
 import destination from './';
 
-var pt1 = {
-    type: "Feature",
-    geometry: {type: "Point", coordinates: [-75.0, 39.0]}
-  };
+var pt1 = [-75.0, 39.0]
 var dist = 100;
 var bear = 180;
 
 var suite = new Benchmark.Suite('turf-destination');
 suite
-  .add('turf-destination',function () {
-    destination(pt1, dist, bear, 'kilometers');
-  })
-  .on('cycle', function (event) {
-    console.log(String(event.target));
-  })
-  .on('complete', function () {
-
-  })
+  .add('turf-destination',() => destination(pt1, dist, bear))
+  .on('cycle', e => console.log(String(e.target)))
+  .on('complete', () => {})
   .run();

--- a/packages/turf-destination/index.js
+++ b/packages/turf-destination/index.js
@@ -17,9 +17,9 @@ import { point, distanceToRadians, isObject } from '@turf/helpers';
  * var point = turf.point([-75.343, 39.984]);
  * var distance = 50;
  * var bearing = 90;
- * var units = 'miles';
+ * var options = {units: 'miles'};
  *
- * var destination = turf.destination(point, distance, bearing, units);
+ * var destination = turf.destination(point, distance, bearing, options);
  *
  * //addToMap
  * var addToMap = [point, destination]

--- a/packages/turf-destination/index.js
+++ b/packages/turf-destination/index.js
@@ -1,7 +1,7 @@
 //http://en.wikipedia.org/wiki/Haversine_formula
 //http://www.movable-type.co.uk/scripts/latlong.html
 import { getCoord } from '@turf/invariant';
-import { point, distanceToRadians } from '@turf/helpers';
+import { point, distanceToRadians, isObject } from '@turf/helpers';
 
 /**
  * Takes a {@link Point} and calculates the location of a destination point given a distance in degrees, radians, miles, or kilometers; and bearing in degrees. This uses the [Haversine formula](http://en.wikipedia.org/wiki/Haversine_formula) to account for global curvature.
@@ -27,8 +27,10 @@ import { point, distanceToRadians } from '@turf/helpers';
  * point.properties['marker-color'] = '#0f0';
  */
 function destination(origin, distance, bearing, options) {
-    // Backwards compatible with v4.0
-    var units = (typeof options === 'object') ? options.units : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var units = options.units;
 
     var degrees2radians = Math.PI / 180;
     var radians2degrees = 180 / Math.PI;

--- a/packages/turf-dissolve/index.js
+++ b/packages/turf-dissolve/index.js
@@ -1,7 +1,8 @@
-import turfUnion from '@turf/union';
-import booleanOverlap from '@turf/boolean-overlap';
-import turfbbox from '@turf/bbox';
 import clone from '@turf/clone';
+import turfUnion from '@turf/union';
+import turfbbox from '@turf/bbox';
+import booleanOverlap from '@turf/boolean-overlap';
+import { isObject } from '@turf/helpers';
 var Rbush = require('rbush');
 var gju = require('geojson-utils');
 var getClosest = require('get-closest');
@@ -20,15 +21,18 @@ var getClosest = require('get-closest');
  *   turf.polygon([[[0, -1], [0, 0], [1, 0], [1, -1], [0,-1]]], {"combine": "yes"}),
  *   turf.polygon([[[1,-1],[1, 0], [2, 0], [2, -1], [1, -1]]], {"combine": "no"}),
  * ]);
+ * var options = {propertyName: 'combine'};
  *
- * var dissolved = turf.dissolve(features, 'combine');
+ * var dissolved = turf.dissolve(features, options);
  *
  * //addToMap
  * var addToMap = [features, dissolved]
  */
 function dissolve(featureCollection, options) {
-    // Backwards compatible with v4.0
-    var propertyName = (typeof options === 'object') ? options.propertyName : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var propertyName = options.propertyName;
 
     var originalIndexOfItemsRemoved = [];
     var treeItems = [];

--- a/packages/turf-dissolve/index.js
+++ b/packages/turf-dissolve/index.js
@@ -1,6 +1,7 @@
 import turfUnion from '@turf/union';
 import booleanOverlap from '@turf/boolean-overlap';
 import turfbbox from '@turf/bbox';
+import clone from '@turf/clone';
 var Rbush = require('rbush');
 var gju = require('geojson-utils');
 var getClosest = require('get-closest');
@@ -89,10 +90,8 @@ function dissolve(featureCollection, options) {
             var overlapCheck = booleanOverlap(polygon, matchFeature);
 
             if (!overlapCheck) {
-                var polyClone = JSON.stringify(polygon);
-                var polyBeingCheckedClone = JSON.stringify(matchFeature);
-                var linestring1 = toLinestring(JSON.parse(polyClone));
-                var linestring2 = toLinestring(JSON.parse(polyBeingCheckedClone));
+                var linestring1 = toLinestring(clone(polygon));
+                var linestring2 = toLinestring(clone(matchFeature));
                 overlapCheck = gju.lineStringsIntersect(linestring1.geometry, linestring2.geometry);
             }
             if (!overlapCheck) {

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@turf/bbox": "^5.0.0",
     "@turf/boolean-overlap": "^4.7.3",
+    "@turf/clone": "^4.7.3",
     "@turf/helpers": "^5.0.0",
     "@turf/union": "^4.7.3",
     "geojson-utils": "^1.1.0",

--- a/packages/turf-distance/bench.js
+++ b/packages/turf-distance/bench.js
@@ -1,24 +1,12 @@
 import Benchmark from 'benchmark';
-import fs from 'fs';
 import distance from './';
 
-var pt1 = {
-    type: "Feature",
-    geometry: {type: "Point", coordinates: [-75.4, 39.4]}
-  };
-var pt2 = {
-  type: "Feature",
-  geometry: {type: "Point", coordinates: [-75.534, 39.123]}
-};
+var pt1 = [-75.4, 39.4];
+var pt2 = [-75.534, 39.123];
 
 var suite = new Benchmark.Suite('turf-distance');
 suite
-  .add('turf-distance',function () {
-    distance(pt1, pt2, 'miles');
-  })
-  .on('cycle', function (event) {
-    console.log(String(event.target));
-  })
-  .on('complete', function () {
-  })
+  .add('turf-distance',() => distance(pt1, pt2))
+  .on('cycle', e => console.log(String(e.target)))
+  .on('complete', () => {})
   .run();

--- a/packages/turf-distance/index.js
+++ b/packages/turf-distance/index.js
@@ -19,8 +19,9 @@ import { radiansToDistance, isObject } from '@turf/helpers';
  * @example
  * var from = turf.point([-75.343, 39.984]);
  * var to = turf.point([-75.534, 39.123]);
+ * var options = {units: 'miles'};
  *
- * var distance = turf.distance(from, to, "miles");
+ * var distance = turf.distance(from, to, options);
  *
  * //addToMap
  * var addToMap = [from, to];

--- a/packages/turf-distance/index.js
+++ b/packages/turf-distance/index.js
@@ -1,5 +1,5 @@
 import { getCoord } from '@turf/invariant';
-import { radiansToDistance } from '@turf/helpers';
+import { radiansToDistance, isObject } from '@turf/helpers';
 
 //http://en.wikipedia.org/wiki/Haversine_formula
 //http://www.movable-type.co.uk/scripts/latlong.html
@@ -28,8 +28,10 @@ import { radiansToDistance } from '@turf/helpers';
  * to.properties.distance = distance;
  */
 function distance(from, to, options) {
-    // Backwards compatible with v4.0
-    var units = (typeof options === 'object') ? options.units : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var units = options.units;
 
     var degrees2radians = Math.PI / 180;
     var coordinates1 = getCoord(from);

--- a/packages/turf-distance/test.js
+++ b/packages/turf-distance/test.js
@@ -26,11 +26,11 @@ test('distance', t => {
         const pt1 = geojson.features[0];
         const pt2 = geojson.features[1];
         const distances = {
-            miles: distance(pt1, pt2, 'miles'),
-            nauticalmiles: distance(pt1, pt2, 'nauticalmiles'),
-            kilometers: distance(pt1, pt2, 'kilometers'),
-            radians: distance(pt1, pt2, 'radians'),
-            degrees: distance(pt1, pt2, 'degrees')
+            miles: distance(pt1, pt2, {units: 'miles'}),
+            nauticalmiles: distance(pt1, pt2, {units: 'nauticalmiles'}),
+            kilometers: distance(pt1, pt2, {units: 'kilometers'}),
+            radians: distance(pt1, pt2, {units: 'radians'}),
+            degrees: distance(pt1, pt2, {units: 'degrees'})
         };
         if (process.env.REGEN) write.sync(directories.out + name + '.json', distances);
         t.deepEqual(distances, load.sync(directories.out + name + '.json'), name);
@@ -45,6 +45,6 @@ test('distance -- Issue #758', t => {
 });
 
 test('distance -- throws', t => {
-    t.throws(() => distance(point([0, 0]), point([10, 10]), 'blah'), /units is invalid/);
+    t.throws(() => distance(point([0, 0]), point([10, 10]), {units: 'foo'}), /units is invalid/);
     t.end();
 });

--- a/packages/turf-flip/index.js
+++ b/packages/turf-flip/index.js
@@ -1,13 +1,15 @@
 import { coordEach } from '@turf/meta';
+import { isObject } from '@turf/helpers';
+import clone from '@turf/clone';
 
 /**
  * Takes input features and flips all of their coordinates from `[x, y]` to `[y, x]`.
  *
  * @name flip
- * @param {FeatureCollection|Feature<any>} geojson input features
+ * @param {GeoJSON} geojson input features
  * @param {Object} [options={}] Optional parameters
  * @param {boolean} [options.mutate=false] allows GeoJSON input to be mutated (significant performance increase if true)
- * @returns {FeatureCollection|Feature<any>} a feature or set of features of the same type as `input` with flipped coordinates
+ * @returns {GeoJSON} a feature or set of features of the same type as `input` with flipped coordinates
  * @example
  * var serbia = turf.point([20.566406, 43.421008]);
  *
@@ -17,14 +19,16 @@ import { coordEach } from '@turf/meta';
  * var addToMap = [serbia, saudiArabia];
  */
 function flip(geojson, options) {
-    // Backwards compatible with v4.0
-    var mutate = (typeof options === 'object') ? options.mutate : options;
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var mutate = options.mutate;
 
     if (!geojson) throw new Error('geojson is required');
     // ensure that we don't modify features in-place and changes to the
     // output do not change the previous feature, including changes to nested
     // properties.
-    if (mutate === false || mutate === undefined) geojson = JSON.parse(JSON.stringify(geojson));
+    if (mutate === false || mutate === undefined) geojson = clone(geojson);
 
     coordEach(geojson, function (coord) {
         var x = coord[0];

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -41,6 +41,7 @@
     "@std/esm": "*"
   },
   "dependencies": {
+    "@turf/clone": "^4.7.3",
     "@turf/helpers": "^5.0.0",
     "@turf/meta": "^5.0.0"
   },

--- a/packages/turf-flip/test.js
+++ b/packages/turf-flip/test.js
@@ -36,7 +36,7 @@ test('turf-flip - handle input mutation', t => {
     const geojson = point([120, 40]);
     flip(geojson);
     t.deepEqual(geojson, point([120, 40]), 'does not mutate input');
-    flip(geojson, true);
+    flip(geojson, {mutate: true});
     t.deepEqual(geojson, point([40, 120]), 'does mutate input');
     t.end();
 });

--- a/packages/turf-hex-grid/index.js
+++ b/packages/turf-hex-grid/index.js
@@ -36,7 +36,6 @@ function hexGrid(bbox, cellDiameter, options) {
     // Optional parameters
     options = options || {};
     if (typeof options !== 'object') throw new Error('options is invalid');
-    var units = options.units;
     var triangles = options.triangles;
 
     var west = bbox[0];
@@ -47,9 +46,9 @@ function hexGrid(bbox, cellDiameter, options) {
     var centerX = (west + east) / 2;
 
     // https://github.com/Turfjs/turf/issues/758
-    var xFraction = cellDiameter / (distance(point([west, centerY]), point([east, centerY]), units));
+    var xFraction = cellDiameter / (distance(point([west, centerY]), point([east, centerY]), options));
     var cellWidth = xFraction * (east - west);
-    var yFraction = cellDiameter / (distance(point([centerX, south]), point([centerX, north]), units));
+    var yFraction = cellDiameter / (distance(point([centerX, south]), point([centerX, north]), options));
     var cellHeight = yFraction * (north - south);
     var radius = cellWidth / 2;
 

--- a/packages/turf-hex-grid/test.js
+++ b/packages/turf-hex-grid/test.js
@@ -22,8 +22,8 @@ test('hex-grid', t => {
     const grid1 = truncate(hexGrid(bbox1, 50, {units: 'miles'}));
     const grid2 = truncate(hexGrid(bbox2, 5, {units: 'miles'}));
     const grid3 = truncate(hexGrid(bbox3, 2, {units: 'miles'}));
-    const grid4 = truncate(hexGrid(bbox4, 50, {units: 'kilometers'}));
-    const grid5 = truncate(hexGrid(bbox5, 500, {units: 'kilometers'}));
+    const grid4 = truncate(hexGrid(bbox4, 50));
+    const grid5 = truncate(hexGrid(bbox5, 500));
 
     t.ok(grid1.features.length, '50mi grid');
     t.ok(grid2.features.length, '5mi grid');
@@ -82,7 +82,7 @@ test('hex-tri-grid', t => {
 
 test('longitude (13141439571036224) - issue #758', t => {
     const bbox = [-179, -90, 179, 90];
-    const grid = hexGrid(bbox, 500, {units: 'kilometers'});
+    const grid = hexGrid(bbox, 500);
 
     const coords = [];
     grid.features.forEach(feature => feature.geometry.coordinates[0].forEach(coord => coords.push(coord)));
@@ -101,11 +101,11 @@ test('longitude (13141439571036224) - issue #758', t => {
 test('hexagon size - issue #623', t => {
     const bbox = [9.244, 45.538, 9.115, 45.439];
     const cellDiameter = 1;
-    const grid = hexGrid(bbox, 1, {units: 'kilometers'});
+    const grid = hexGrid(bbox, 1);
 
     const tile1 = grid.features[0];
     const tile2 = grid.features[1];
-    var dist = distance(centroid(tile1), centroid(tile2), 'kilometers');
+    var dist = distance(centroid(tile1), centroid(tile2));
 
     t.equal(round(dist, 10), round(Math.sqrt(3) * cellDiameter / 2, 10));
 

--- a/packages/turf-interpolate/index.js
+++ b/packages/turf-interpolate/index.js
@@ -1,6 +1,6 @@
 import bbox from '@turf/bbox';
 import hexGrid from '@turf/hex-grid';
-import poinGrid from '@turf/point-grid';
+import pointGrid from '@turf/point-grid';
 import distance from '@turf/distance';
 import centroid from '@turf/centroid';
 import squareGrid from '@turf/square-grid';
@@ -41,7 +41,6 @@ function interpolate(points, cellSize, options) {
     if (typeof options !== 'object') throw new Error('options is invalid');
     var gridType = options.gridType;
     var property = options.property;
-    var units = options.units;
     var weight = options.weight;
 
     // validation
@@ -60,19 +59,19 @@ function interpolate(points, cellSize, options) {
     switch (gridType) {
     case 'point':
     case 'points':
-        grid = poinGrid(box, cellSize, {units: units, bboxIsMask: true});
+        grid = pointGrid(box, cellSize, options);
         break;
     case 'square':
     case 'squares':
-        grid = squareGrid(box, cellSize, {units: units});
+        grid = squareGrid(box, cellSize, options);
         break;
     case 'hex':
     case 'hexes':
-        grid = hexGrid(box, cellSize, {units: units});
+        grid = hexGrid(box, cellSize, options);
         break;
     case 'triangle':
     case 'triangles':
-        grid = triangleGrid(box, cellSize, {units: units});
+        grid = triangleGrid(box, cellSize, options);
         break;
     default:
         throw new Error('invalid gridType');
@@ -84,7 +83,7 @@ function interpolate(points, cellSize, options) {
         // calculate the distance from each input point to the grid points
         featureEach(points, function (point) {
             var gridPoint = (gridType === 'point') ? gridFeature : centroid(gridFeature);
-            var d = distance(gridPoint, point, units);
+            var d = distance(gridPoint, point, options);
             var zValue;
             // property has priority for zValue, fallbacks to 3rd coordinate from geometry
             if (property !== undefined) zValue = point.properties[property];

--- a/packages/turf-line-distance/index.js
+++ b/packages/turf-line-distance/index.js
@@ -6,7 +6,7 @@ import { isObject } from '@turf/helpers';
  * Takes a {@link GeoJSON} and measures its length in the specified units, {@link (Multi)Point|Point}'s distance are ignored.
  *
  * @name lineDistance
- * @param {FeatureCollection|Feature|Geometry} geojson GeoJSON to measure
+ * @param {GeoJSON} geojson GeoJSON to measure
  * @param {Object} [options={}] Optional parameters
  * @param {string} [options.units=kilometers] can be degrees, radians, miles, or kilometers
  * @returns {number} length of GeoJSON
@@ -22,7 +22,6 @@ function lineDistance(geojson, options) {
     // Optional parameters
     options = options || {};
     if (!isObject(options)) throw new Error('options is invalid');
-    var units = options.units;
 
     // Input Validation
     if (!geojson) throw new Error('geojson is required');
@@ -30,7 +29,7 @@ function lineDistance(geojson, options) {
     // Calculate distance from 2-vertex line segements
     return segmentReduce(geojson, function (previousValue, segment) {
         var coords = segment.geometry.coordinates;
-        return previousValue + distance(coords[0], coords[1], units);
+        return previousValue + distance(coords[0], coords[1], options);
     }, 0);
 }
 

--- a/packages/turf-line-slice-along/index.js
+++ b/packages/turf-line-slice-along/index.js
@@ -30,7 +30,6 @@ function lineSliceAlong(line, startDist, stopDist, options) {
     // Optional parameters
     options = options || {};
     if (!isObject(options)) throw new Error('options is invalid');
-    var units = options.units;
 
     var coords;
     var slice = [];
@@ -51,7 +50,7 @@ function lineSliceAlong(line, startDist, stopDist, options) {
                 return lineString(slice);
             }
             direction = bearing(coords[i], coords[i - 1]) - 180;
-            interpolated = destination(coords[i], overshot, direction, units);
+            interpolated = destination(coords[i], overshot, direction, options);
             slice.push(interpolated.geometry.coordinates);
         }
 
@@ -62,7 +61,7 @@ function lineSliceAlong(line, startDist, stopDist, options) {
                 return lineString(slice);
             }
             direction = bearing(coords[i], coords[i - 1]) - 180;
-            interpolated = destination(coords[i], overshot, direction, units);
+            interpolated = destination(coords[i], overshot, direction, options);
             slice.push(interpolated.geometry.coordinates);
             return lineString(slice);
         }
@@ -75,7 +74,7 @@ function lineSliceAlong(line, startDist, stopDist, options) {
             return lineString(slice);
         }
 
-        travelled += distance(coords[i], coords[i + 1], units);
+        travelled += distance(coords[i], coords[i + 1], options);
     }
     return lineString(coords[coords.length - 1]);
 }

--- a/packages/turf-line-slice-along/test.js
+++ b/packages/turf-line-slice-along/test.js
@@ -11,11 +11,11 @@ var route2 = load.sync(path.join(__dirname, 'test', 'fixtures', 'route2.geojson'
 test('turf-line-slice -- line1', function (t) {
     var start = 500;
     var stop = 750;
-    var units = 'miles';
+    var options = {units: 'miles'};
 
-    var start_point = along(line1, start, units);
-    var end_point = along(line1, stop, units);
-    var sliced = lineSliceAlong(line1, start, stop, {units: units});
+    var start_point = along(line1, start, options);
+    var end_point = along(line1, stop, options);
+    var sliced = lineSliceAlong(line1, start, stop, options);
     t.equal(sliced.type, 'Feature');
     t.equal(sliced.geometry.type, 'LineString');
     t.deepEqual(sliced.geometry.coordinates[0], start_point.geometry.coordinates);
@@ -26,11 +26,11 @@ test('turf-line-slice -- line1', function (t) {
 test('turf-line-slice -- line1 overshoot', function (t) {
     var start = 500;
     var stop = 1500;
-    var units = 'miles';
+    var options = {units: 'miles'};
 
-    var start_point = along(line1, start, units);
-    var end_point = along(line1, stop, units);
-    var sliced = lineSliceAlong(line1, start, stop, {units: units});
+    var start_point = along(line1, start, options);
+    var end_point = along(line1, stop, options);
+    var sliced = lineSliceAlong(line1, start, stop, options);
     t.equal(sliced.type, 'Feature');
     t.equal(sliced.geometry.type, 'LineString');
     t.deepEqual(sliced.geometry.coordinates[0], start_point.geometry.coordinates);
@@ -41,11 +41,11 @@ test('turf-line-slice -- line1 overshoot', function (t) {
 test('turf-line-slice-along -- route1', function (t) {
     var start = 500;
     var stop = 750;
-    var units = 'miles';
+    var options = {units: 'miles'};
 
-    var start_point = along(route1, start, units);
-    var end_point = along(route1, stop, units);
-    var sliced = lineSliceAlong(route1, start, stop, {units: units});
+    var start_point = along(route1, start, options);
+    var end_point = along(route1, stop, options);
+    var sliced = lineSliceAlong(route1, start, stop, options);
     t.equal(sliced.type, 'Feature');
     t.equal(sliced.geometry.type, 'LineString');
     t.deepEqual(sliced.geometry.coordinates[0], start_point.geometry.coordinates);
@@ -56,11 +56,11 @@ test('turf-line-slice-along -- route1', function (t) {
 test('turf-line-slice-along -- route2', function (t) {
     var start = 25;
     var stop = 50;
-    var units = 'miles';
+    var options = {units: 'miles'};
 
-    var start_point = along(route2, start, units);
-    var end_point = along(route2, stop, units);
-    var sliced = lineSliceAlong(route2, start, stop, {units: units});
+    var start_point = along(route2, start, options);
+    var end_point = along(route2, stop, options);
+    var sliced = lineSliceAlong(route2, start, stop, options);
     t.equal(sliced.type, 'Feature');
     t.equal(sliced.geometry.type, 'LineString');
     t.deepEqual(sliced.geometry.coordinates[0], start_point.geometry.coordinates);

--- a/packages/turf-meta/types.ts
+++ b/packages/turf-meta/types.ts
@@ -2,8 +2,10 @@ import * as helpers from '@turf/helpers'
 import {
     featureCollection,
     point,
+    lineString,
     Feature,
-    Point
+    Point,
+    LineString
 } from '@turf/helpers'
 import * as meta from './'
 import {
@@ -37,6 +39,36 @@ interface CustomProps {
     foo: string
     bar: number
 }
+
+// Custom fixtures
+interface CustomLineString extends Feature<LineString> {
+    properties: {
+        foo: string
+        bar: string
+    }
+}
+
+interface CustomLineStrings {
+    type: 'FeatureCollection';
+    features: CustomLineString[]
+}
+
+interface CustomPoint extends Feature<Point> {
+    properties: {
+        foo: string
+        bar: number
+    }
+}
+
+interface CustomPoints {
+    type: 'FeatureCollection';
+    features: CustomPoint[]
+}
+
+const customPoint = point([10, 20], {foo: 'abc', bar: 123})
+const customPoints: CustomPoints = featureCollection([customPoint, point([0, 0])])
+const customLineString = lineString([[0, 0], [10, 20]], {foo: 'abc', bar: 123})
+const customLineStrings: CustomLineStrings = featureCollection([customLineString, point([0, 0])])
 
 /**
  * meta.coordEach
@@ -105,6 +137,12 @@ featureEach(features, feature => feature)
 meta.featureEach(features, feature => feature)
 meta.featureEach(poly, (feature, index) => feature)
 meta.featureEach(geomCollection, (feature, index) => feature)
+
+// Access custom properties
+featureEach(customPoints, pt => {
+    pt.properties.bar
+    // pt.properties.hello // [ts] Property 'hello' does not exist on type '{ foo: string; bar: number; }'.
+})
 
 /**
  * meta.geomReduce
@@ -180,6 +218,13 @@ meta.lineEach(poly, currentLine => currentLine)
 meta.lineEach(poly, (currentLine, featureIndex, featureSubIndex, lineIndex) => currentLine)
 meta.lineEach(multiPoly, (currentLine, featureIndex, featureSubIndex, lineIndex) => currentLine)
 
+// Able to load custom LineStrings
+lineEach(customLineString, line => {})
+lineEach(customLineStrings, line => {
+    line.properties.bar
+    // line.properties.hello // [ts] Property 'hello' does not exist on type '{ foo: string; bar: string; }'.
+})
+
 /**
  * meta.lineReduce
  */
@@ -196,26 +241,3 @@ meta.lineReduce(poly, (previousValue, currentLine, featureIndex, featureSubIndex
 meta.lineReduce(poly, (previousValue, currentLine, featureIndex, featureSubIndex) => 1 + 1, 1)
 meta.lineReduce(multiPoly, (previousValue, currentLine, featureIndex, featureSubIndex, lineIndex) => currentLine)
 meta.lineReduce(multiPoly, (previousValue, currentLine, featureIndex, featureSubIndex, lineIndex) => 1 + 1, 1)
-
-/**
- * Translate Feature Properties
- */
-interface CustomPoint extends Feature<Point> {
-    properties: {
-        foo: string
-        bar: number
-        [key: string]: any
-    }
-}
-
-interface CustomPoints {
-    type: 'FeatureCollection';
-    features: CustomPoint[]
-}
-
-const customPoint = point([10, 20], {foo: 'abc', bar: 123})
-const customPoints: CustomPoints = featureCollection([customPoint, point([0, 0])])
-
-featureEach(customPoints, pt => {
-    pt.properties.bar
-})

--- a/packages/turf-midpoint/index.js
+++ b/packages/turf-midpoint/index.js
@@ -21,9 +21,9 @@ import distance from '@turf/distance';
  * midpoint.properties['marker-color'] = '#f00';
  */
 function midpoint(point1, point2) {
-    var dist = distance(point1, point2, 'miles');
+    var dist = distance(point1, point2);
     var heading = bearing(point1, point2);
-    var midpoint = destination(point1, dist / 2, heading, 'miles');
+    var midpoint = destination(point1, dist / 2, heading);
 
     return midpoint;
 }

--- a/packages/turf-midpoint/test.js
+++ b/packages/turf-midpoint/test.js
@@ -3,15 +3,13 @@ import midpoint from '.';
 import distance from '@turf/distance';
 import { point } from '@turf/helpers';
 
-var units = 'miles';
-
 test('midpoint -- horizontal equator', function (t) {
     var pt1 = point([0, 0]);
     var pt2 = point([10, 0]);
 
     var mid = midpoint(pt1, pt2);
 
-    t.equal(distance(pt1, mid, units).toFixed(6), distance(pt2, mid, units).toFixed(6));
+    t.equal(distance(pt1, mid).toFixed(6), distance(pt2, mid).toFixed(6));
 
     t.end();
 });
@@ -22,7 +20,7 @@ test('midpoint -- vertical from equator', function (t) {
 
     var mid = midpoint(pt1, pt2);
 
-    t.equal(distance(pt1, mid, units).toFixed(6), distance(pt2, mid, units).toFixed(6));
+    t.equal(distance(pt1, mid).toFixed(6), distance(pt2, mid).toFixed(6));
 
     t.end();
 });
@@ -33,7 +31,7 @@ test('midpoint -- vertical to equator', function (t) {
 
     var mid = midpoint(pt1, pt2);
 
-    t.equal(distance(pt1, mid, units).toFixed(6), distance(pt2, mid, units).toFixed(6));
+    t.equal(distance(pt1, mid).toFixed(6), distance(pt2, mid).toFixed(6));
 
     t.end();
 });
@@ -44,7 +42,7 @@ test('midpoint -- diagonal back over equator', function (t) {
 
     var mid = midpoint(pt1, pt2);
 
-    t.equal(distance(pt1, mid, units).toFixed(6), distance(pt2, mid, units).toFixed(6));
+    t.equal(distance(pt1, mid).toFixed(6), distance(pt2, mid).toFixed(6));
 
     t.end();
 });
@@ -55,7 +53,7 @@ test('midpoint -- diagonal forward over equator', function (t) {
 
     var mid = midpoint(pt1, pt2);
 
-    t.equal(distance(pt1, mid, units).toFixed(6), distance(pt2, mid, units).toFixed(6));
+    t.equal(distance(pt1, mid).toFixed(6), distance(pt2, mid).toFixed(6));
 
     t.end();
 });
@@ -66,7 +64,7 @@ test('midpoint -- long distance', function (t) {
 
     var mid = midpoint(pt1, pt2);
 
-    t.equal(distance(pt1, mid, units).toFixed(6), distance(pt2, mid, units).toFixed(6));
+    t.equal(distance(pt1, mid).toFixed(6), distance(pt2, mid).toFixed(6));
 
     t.end();
 });

--- a/packages/turf-nearest/bench.js
+++ b/packages/turf-nearest/bench.js
@@ -1,19 +1,14 @@
 import fs from 'fs';
+import path from 'path';
 import Benchmark from 'benchmark';
 import nearest from './';
 
-var pt = JSON.parse(fs.readFileSync(__dirname+'/test/pt.geojson'));
-var pts = JSON.parse(fs.readFileSync(__dirname+'/test/pts.geojson'));
+var pt = JSON.parse(fs.readFileSync(path.join(__dirname, 'test', 'pt.geojson')));
+var pts = JSON.parse(fs.readFileSync(path.join(__dirname, 'test', 'pts.geojson')));
 
 var suite = new Benchmark.Suite('turf-nearest');
 suite
-  .add('turf-nearest',function () {
-    nearest(pt, pts);
-  })
-  .on('cycle', function (event) {
-    console.log(String(event.target));
-  })
-  .on('complete', function () {
-
-  })
+  .add('turf-nearest', () => nearest(pt, pts))
+  .on('cycle', e => console.log(String(e.target)))
+  .on('complete', () => {})
   .run();

--- a/packages/turf-nearest/index.js
+++ b/packages/turf-nearest/index.js
@@ -27,7 +27,7 @@ import distance from '@turf/distance';
 function nearest(targetPoint, points) {
     var nearestPoint, minDist = Infinity;
     for (var i = 0; i < points.features.length; i++) {
-        var distanceToPoint = distance(targetPoint, points.features[i], 'miles');
+        var distanceToPoint = distance(targetPoint, points.features[i]);
         if (distanceToPoint < minDist) {
             nearestPoint = points.features[i];
             minDist = distanceToPoint;

--- a/packages/turf-point-grid/index.d.ts
+++ b/packages/turf-point-grid/index.d.ts
@@ -1,10 +1,10 @@
-import { Units, BBox, Feature, FeatureCollection, Point, Properties} from '@turf/helpers';
+import { Units, BBox, AllGeoJSON, FeatureCollection, Point, Properties } from '@turf/helpers';
 
 /**
  * http://turfjs.org/docs/#pointgrid
  */
 export default function pointGrid(
-    bbox: BBox | Feature<any> | FeatureCollection<any>,
+    bbox: BBox | AllGeoJSON,
     cellSide: number,
     options?: {
         units?: Units,

--- a/packages/turf-point-grid/index.js
+++ b/packages/turf-point-grid/index.js
@@ -8,7 +8,7 @@ import { getType } from '@turf/invariant';
  * Creates a {@link Point} grid from a bounding box, {@link FeatureCollection} or {@link Feature}.
  *
  * @name pointGrid
- * @param {BBox|FeatureCollection|Feature} bbox extent in [minX, minY, maxX, maxY] order
+ * @param {BBox|GeoJSON} bbox extent in [minX, minY, maxX, maxY] order
  * @param {number} cellSide the distance between points
  * @param {Object} [options={}] Optional parameters
  * @param {string} [options.units="kilometers"] used in calculating cellSide, can be degrees, radians, miles, or kilometers
@@ -28,7 +28,6 @@ function pointGrid(bbox, cellSide, options) {
     // Optional parameters
     options = options || {};
     if (typeof options !== 'object') throw new Error('options is invalid');
-    var units = options.units;
     var bboxIsMask = options.bboxIsMask || false;
     var properties = options.properties || {};
 
@@ -47,9 +46,9 @@ function pointGrid(bbox, cellSide, options) {
     var  east = bbox[2];
     var  north = bbox[3];
 
-    var  xFraction = cellSide / (distance(point([west, south]), point([east, south]), units));
+    var  xFraction = cellSide / (distance(point([west, south]), point([east, south]), options));
     var  cellWidth = xFraction * (east - west);
-    var  yFraction = cellSide / (distance(point([west, south]), point([west, north]), units));
+    var  yFraction = cellSide / (distance(point([west, south]), point([west, north]), options));
     var  cellHeight = yFraction * (north - south);
 
     var  bboxHorizontalSide = (east - west);

--- a/packages/turf-point-on-line/index.js
+++ b/packages/turf-point-on-line/index.js
@@ -36,7 +36,6 @@ function pointOnLine(lines, pt, options) {
     // Optional parameters
     options = options || {};
     if (!isObject(options)) throw new Error('options is invalid');
-    var units = options.units;
 
     // validation
     var type = (lines.geometry) ? lines.geometry.type : lines.type;
@@ -55,23 +54,26 @@ function pointOnLine(lines, pt, options) {
         for (var i = 0; i < coords.length - 1; i++) {
             //start
             var start = point(coords[i]);
-            start.properties.dist = distance(pt, start, units);
+            start.properties.dist = distance(pt, start, options);
             //stop
             var stop = point(coords[i + 1]);
-            stop.properties.dist = distance(pt, stop, units);
+            stop.properties.dist = distance(pt, stop, options);
             // sectionLength
-            var sectionLength = distance(start, stop, units);
+            var sectionLength = distance(start, stop, options);
             //perpendicular
             var heightDistance = Math.max(start.properties.dist, stop.properties.dist);
             var direction = bearing(start, stop);
-            var perpendicularPt1 = destination(pt, heightDistance, direction + 90, units);
-            var perpendicularPt2 = destination(pt, heightDistance, direction - 90, units);
-            var intersect = lineIntersects(lineString([perpendicularPt1.geometry.coordinates, perpendicularPt2.geometry.coordinates]), lineString([start.geometry.coordinates, stop.geometry.coordinates]));
+            var perpendicularPt1 = destination(pt, heightDistance, direction + 90, options);
+            var perpendicularPt2 = destination(pt, heightDistance, direction - 90, options);
+            var intersect = lineIntersects(
+                lineString([perpendicularPt1.geometry.coordinates, perpendicularPt2.geometry.coordinates]),
+                lineString([start.geometry.coordinates, stop.geometry.coordinates])
+            );
             var intersectPt = null;
             if (intersect.features.length > 0) {
                 intersectPt = intersect.features[0];
-                intersectPt.properties.dist = distance(pt, intersectPt, units);
-                intersectPt.properties.location = length + distance(start, intersectPt, units);
+                intersectPt.properties.dist = distance(pt, intersectPt, options);
+                intersectPt.properties.location = length + distance(start, intersectPt, options);
             }
 
             if (start.properties.dist < closestPt.properties.dist) {

--- a/packages/turf-point-on-surface/index.js
+++ b/packages/turf-point-on-surface/index.js
@@ -1,5 +1,5 @@
 import centroid from '@turf/center';
-import distance from '@turf/distance';
+import nearest from '@turf/nearest';
 import inside from '@turf/inside';
 import explode from '@turf/explode';
 import { featureCollection } from '@turf/helpers';
@@ -116,16 +116,7 @@ function pointOnSurface(fc) {
         for (i = 0; i < fc.features.length; i++) {
             vertices.features = vertices.features.concat(explode(fc.features[i]).features);
         }
-        var closestVertex;
-        var closestDistance = Infinity;
-        for (i = 0; i < vertices.features.length; i++) {
-            var dist = distance(cent, vertices.features[i], 'miles');
-            if (dist < closestDistance) {
-                closestDistance = dist;
-                closestVertex = vertices.features[i];
-            }
-        }
-        return closestVertex;
+        return nearest(cent, vertices);
     }
 }
 

--- a/packages/turf-point-on-surface/package.json
+++ b/packages/turf-point-on-surface/package.json
@@ -42,10 +42,10 @@
   },
   "dependencies": {
     "@turf/center": "^4.7.3",
-    "@turf/distance": "^5.0.0",
     "@turf/explode": "^4.7.3",
     "@turf/helpers": "^5.0.0",
-    "@turf/inside": "^4.7.3"
+    "@turf/inside": "^4.7.3",
+    "@turf/nearest": "^4.7.3"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-rhumb-bearing/index.js
+++ b/packages/turf-rhumb-bearing/index.js
@@ -1,6 +1,6 @@
 // https://en.wikipedia.org/wiki/Rhumb_line
 import {getCoord} from '@turf/invariant';
-import {radians2degrees, degrees2radians} from '@turf/helpers';
+import {radians2degrees, degrees2radians, isObject} from '@turf/helpers';
 
 /**
  * Takes two {@link Point|points} and finds the bearing angle between them along a Rhumb line
@@ -24,10 +24,14 @@ import {radians2degrees, degrees2radians} from '@turf/helpers';
  * point2.properties.bearing = bearing;
  */
 function rhumbBearing(start, end, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var final = options.final;
+
     // validation
     if (!start) throw new Error('start point is required');
     if (!end) throw new Error('end point is required');
-    var final = (typeof options === 'object') ? options.final : options;
 
     var bear360;
 

--- a/packages/turf-rhumb-bearing/test.js
+++ b/packages/turf-rhumb-bearing/test.js
@@ -36,7 +36,7 @@ test('bearing', t => {
         const end = geojson.features[1];
 
         const initialBearing = rhumbBearing(start, end);
-        const finalBearing = rhumbBearing(start, end, true);
+        const finalBearing = rhumbBearing(start, end, {final: true});
 
         const result = {
             'initialBearing': initialBearing,

--- a/packages/turf-rhumb-destination/index.js
+++ b/packages/turf-rhumb-destination/index.js
@@ -18,8 +18,9 @@ import { getCoord } from '@turf/invariant';
  * var pt = turf.point([-75.343, 39.984], {"marker-color": "F00"});
  * var distance = 50;
  * var bearing = 90;
+ * var options = {units: 'miles'};
  *
- * var destination = turf.rhumbDestination(pt, distance, bearing, {units: 'miles'});
+ * var destination = turf.rhumbDestination(pt, distance, bearing, options);
  *
  * //addToMap
  * var addToMap = [pt, destination]

--- a/packages/turf-rhumb-distance/index.js
+++ b/packages/turf-rhumb-distance/index.js
@@ -15,8 +15,9 @@ import { getCoord } from '@turf/invariant';
  * @example
  * var from = turf.point([-75.343, 39.984]);
  * var to = turf.point([-75.534, 39.123]);
+ * var options = {units: 'miles'};
  *
- * var distance = turf.rhumbDistance(from, to, "miles");
+ * var distance = turf.rhumbDistance(from, to, options);
  *
  * //addToMap
  * var addToMap = [from, to];

--- a/packages/turf-rhumb-distance/index.js
+++ b/packages/turf-rhumb-distance/index.js
@@ -1,5 +1,5 @@
 // https://en.wikipedia.org/wiki/Rhumb_line
-import { convertDistance, earthRadius } from '@turf/helpers';
+import { convertDistance, earthRadius, isObject } from '@turf/helpers';
 import { getCoord } from '@turf/invariant';
 
 /**
@@ -24,10 +24,14 @@ import { getCoord } from '@turf/invariant';
  * to.properties.distance = distance;
  */
 function rhumbDistance(from, to, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var units = options.units;
+
     // validation
     if (!from) throw new Error('from point is required');
     if (!to) throw new Error('to point is required');
-    var units = (typeof options === 'object') ? options.units : options || 'kilometers';
 
     var origin = getCoord(from);
     var destination = getCoord(to);

--- a/packages/turf-rhumb-distance/test.js
+++ b/packages/turf-rhumb-distance/test.js
@@ -28,12 +28,12 @@ test('rhumb-distance', t => {
         const pt2 = geojson.features[1];
 
         const distances = {
-            miles: round(rhumbDistance(pt1, pt2, 'miles'), 6),
-            nauticalmiles: round(rhumbDistance(pt1, pt2, 'nauticalmiles'), 6),
-            kilometers: round(rhumbDistance(pt1, pt2, 'kilometers'), 6),
-            greatCircleDistance: round(distance(pt1, pt2, 'kilometers'), 6),
-            radians: round(rhumbDistance(pt1, pt2, 'radians'), 6),
-            degrees: round(rhumbDistance(pt1, pt2, 'degrees'), 6)
+            miles: round(rhumbDistance(pt1, pt2, {units: 'miles'}), 6),
+            nauticalmiles: round(rhumbDistance(pt1, pt2, {units: 'nauticalmiles'}), 6),
+            kilometers: round(rhumbDistance(pt1, pt2, {units: 'kilometers'}), 6),
+            greatCircleDistance: round(distance(pt1, pt2, {units: 'kilometers'}), 6),
+            radians: round(rhumbDistance(pt1, pt2, {units: 'radians'}), 6),
+            degrees: round(rhumbDistance(pt1, pt2, {units: 'degrees'}), 6)
         };
 
         if (process.env.REGEN) write.sync(directories.out + name + '.json', distances);
@@ -44,9 +44,9 @@ test('rhumb-distance', t => {
     // TODO: to be added once earth radius is updated to 6371km
     // t.ok(distances.kilometers > distances.greatCircleDistance, name + ' distance comparison');
 
-    t.throws(() => rhumbDistance(point([0, 0]), point([1, 1]), 'blah'), 'unknown option given to units');
+    t.throws(() => rhumbDistance(point([0, 0]), point([1, 1]), {units: 'foo'}), 'unknown option given to units');
     t.throws(() => rhumbDistance(null, point([1, 1])), 'null point');
-    t.throws(() => rhumbDistance(point([1, 1]), 'point', 'miles'), 'invalid point');
+    t.throws(() => rhumbDistance(point([1, 1]), 'point'), 'invalid point');
 
     t.end();
 });

--- a/packages/turf-square-grid/index.js
+++ b/packages/turf-square-grid/index.js
@@ -25,7 +25,6 @@ function squareGrid(bbox, cellSize, options) {
     // Optional parameters
     options = options || {};
     if (!isObject(options)) throw new Error('options is invalid');
-    var units = options.units;
     var completelyWithin = options.completelyWithin;
 
     // Containers
@@ -42,8 +41,8 @@ function squareGrid(bbox, cellSize, options) {
     var north = bbox[3];
 
     // distance
-    var xDistance = distance(point([west, south]), point([east, south]), units);
-    var yDistance = distance(point([west, south]), point([west, north]), units);
+    var xDistance = distance(point([west, south]), point([east, south]), options);
+    var yDistance = distance(point([west, south]), point([west, north]), options);
 
     // rows & columns
     var columns = Math.ceil(xDistance / cellSize);

--- a/packages/turf-transform-rotate/index.js
+++ b/packages/turf-transform-rotate/index.js
@@ -2,6 +2,7 @@ import centroid from '@turf/centroid';
 import rhumbBearing from '@turf/rhumb-bearing';
 import rhumbDistance from '@turf/rhumb-distance';
 import rhumbDestination from '@turf/rhumb-destination';
+import clone from '@turf/clone';
 import { coordEach } from '@turf/meta';
 import { getCoords } from '@turf/invariant';
 import { isObject } from '@turf/helpers';
@@ -44,7 +45,7 @@ function transformRotate(geojson, angle, options) {
     if (!pivot) pivot = centroid(geojson);
 
     // Clone geojson to avoid side effects
-    if (mutate === false || mutate === undefined) geojson = JSON.parse(JSON.stringify(geojson));
+    if (mutate === false || mutate === undefined) geojson = clone(geojson);
 
     // Rotate each coordinate
     coordEach(geojson, function (pointCoords) {

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@turf/centroid": "^4.7.3",
+    "@turf/clone": "^4.7.3",
     "@turf/helpers": "^5.0.0",
     "@turf/invariant": "^5.0.0",
     "@turf/meta": "^5.0.0",

--- a/packages/turf-triangle-grid/index.js
+++ b/packages/turf-triangle-grid/index.js
@@ -8,7 +8,7 @@ import { polygon, featureCollection } from '@turf/helpers';
  * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
  * @param {number} cellSize dimension of each cell
  * @param {Object} [options={}] Optional parameters
- * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
+ * @param {string} [units='kilometers'] used in calculating cellSize, can be degrees, radians, miles, or kilometers
  * @returns {FeatureCollection<Polygon>} grid of polygons
  * @example
  * var bbox = [-95, 30 ,-85, 40];
@@ -23,12 +23,11 @@ function triangleGrid(bbox, cellSize, options) {
     // Optional parameters
     options = options || {};
     if (typeof options !== 'object') throw new Error('options is invalid');
-    var units = options.units;
 
     var fc = featureCollection([]);
-    var xFraction = cellSize / (distance([bbox[0], bbox[1]], [bbox[2], bbox[1]], units));
+    var xFraction = cellSize / (distance([bbox[0], bbox[1]], [bbox[2], bbox[1]], options));
     var cellWidth = xFraction * (bbox[2] - bbox[0]);
-    var yFraction = cellSize / (distance([bbox[0], bbox[1]], [bbox[0], bbox[3]], units));
+    var yFraction = cellSize / (distance([bbox[0], bbox[1]], [bbox[0], bbox[3]], options));
     var cellHeight = yFraction * (bbox[3] - bbox[1]);
 
     var xi = 0;

--- a/packages/turf-triangle-grid/test.js
+++ b/packages/turf-triangle-grid/test.js
@@ -1,7 +1,7 @@
-import test from 'tape';
-import triangleGrid from '.';
 import fs from 'fs';
+import test from 'tape';
 import bboxPolygon from '@turf/bbox-polygon';
+import triangleGrid from '.';
 
 test('triangle-grid', function (t) {
     var bbox1 = [


### PR DESCRIPTION
## Enforce strict options params for v5.0 modules

Ref: https://github.com/Turfjs/turf-www/issues/115#issuecomment-335674628

### Dropped v4.0 compatible modules

- `@turf/along`
- `@turf/distance`
- `@turf/bearing`
- `@turf/destination`
- `@turf/dissolve`
- `@turf/flip`
- `@turf/rhumb-rotate`
- `@turf/rhumb-bearing`
- `@turf/rhumb-distance`
- `@turf/concave`

CC: @stebogit 