### PR TITLE
Change Rollup process to `pretest`.

### DIFF
--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-bezier/package.json
+++ b/packages/turf-bezier/package.json
@@ -13,8 +13,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
     "@std/esm": "*",
-    "@turf/truncate": "^4.7.3",
+    "@turf/truncate": "*",
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -13,8 +13,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-idw/package.json
+++ b/packages/turf-idw/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-inside/package.json
+++ b/packages/turf-inside/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {
@@ -42,7 +42,7 @@
   "dependencies": {
     "@turf/clean-coords": "*",
     "@turf/helpers": "^5.0.0",
-    "@turf/invariant": "*",
+    "@turf/invariant": "^5.0.0",
     "@turf/truncate": "^4.7.3",
     "jsts": "1.4.0"
   },

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -14,8 +14,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {
@@ -45,7 +45,7 @@
     "@turf/envelope": "*",
     "@turf/point-grid": "*",
     "@turf/random": "*",
-    "@turf/rhumb-destination": "^5.0.0",
+    "@turf/rhumb-destination": "*",
     "@turf/truncate": "*",
     "benchmark": "*",
     "chroma-js": "*",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -14,8 +14,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {
@@ -44,7 +44,7 @@
     "@turf/envelope": "*",
     "@turf/point-grid": "*",
     "@turf/random": "*",
-    "@turf/rhumb-destination": "^5.0.0",
+    "@turf/rhumb-destination": "*",
     "@turf/truncate": "*",
     "benchmark": "*",
     "load-json-file": "*",

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-distance/package.json
+++ b/packages/turf-line-distance/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -13,8 +13,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -13,8 +13,8 @@
     "deep-equal.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-linestring-to-polygon/package.json
+++ b/packages/turf-linestring-to-polygon/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-nearest/package.json
+++ b/packages/turf-nearest/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-point-on-line/package.json
+++ b/packages/turf-point-on-line/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-point-on-surface/package.json
+++ b/packages/turf-point-on-surface/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-polygon-to-linestring/package.json
+++ b/packages/turf-polygon-to-linestring/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -14,8 +14,8 @@
     "geojson-polygon-self-intersections.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/packages/turf-within/package.json
+++ b/packages/turf-within/package.json
@@ -12,8 +12,8 @@
     "main.js"
   ],
   "scripts": {
+    "pretest": "rollup -c ../../rollup.config.js",
     "test": "node -r @std/esm test.js",
-    "posttest": "rollup -c ../../rollup.config.js",
     "bench": "node -r @std/esm bench.js"
   },
   "repository": {

--- a/scripts/update-to-es-modules.js
+++ b/scripts/update-to-es-modules.js
@@ -94,8 +94,8 @@ glob.sync(path.join(__dirname, '..', 'packages', 'turf-*', 'package.json')).forE
         types: 'index.d.ts',
         files: [...files],
         scripts: {
+            'pretest': 'rollup -c ../../rollup.config.js',
             'test': 'node -r @std/esm test.js',
-            'posttest': 'rollup -c ../../rollup.config.js',
             'bench': 'node -r @std/esm bench.js'
         },
         repository: {


### PR DESCRIPTION
# Change Rollup process to `pretest`.

If `main.js` is already created and attempt to test the module using `node -r @std/esm test.js` the `index.js` isn't being used instead it uses `main.js` which is outdated since the rollup build is after `npm test`.
