### PR TITLE
Update geojson-rbush to ES modules

### DIFF
--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -39,7 +39,7 @@
     "@std/esm": "*"
   },
   "dependencies": {
-    "@turf/helpers": "*",
+    "@turf/helpers": "^5.0.0",
     "@turf/invariant": "^5.0.0"
   },
   "@std/esm": {

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -51,7 +51,7 @@
     "@turf/invariant": "^5.0.0",
     "@turf/line-segment": "^5.0.0",
     "@turf/meta": "^5.0.0",
-    "geojson-rbush": "2.0.1"
+    "geojson-rbush": "2.1.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -52,7 +52,7 @@
     "@turf/line-segment": "^5.0.0",
     "@turf/meta": "^5.0.0",
     "@turf/point-on-line": "^5.0.0",
-    "geojson-rbush": "2.0.1"
+    "geojson-rbush": "2.1.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-line-split/index.js
+++ b/packages/turf-line-split/index.js
@@ -1,12 +1,12 @@
-import { featureEach, featureReduce} from '@turf/meta';
 import rbush from 'geojson-rbush';
-import { lineString, featureCollection } from '@turf/helpers';
 import flatten from '@turf/flatten';
 import truncate from '@turf/truncate';
-import { getCoords, getType } from '@turf/invariant';
 import lineSegment from '@turf/line-segment';
 import pointOnLine from '@turf/point-on-line';
 import lineIntersect from '@turf/line-intersect';
+import { getCoords, getType } from '@turf/invariant';
+import { featureEach, featureReduce} from '@turf/meta';
+import { lineString, featureCollection } from '@turf/helpers';
 
 /**
  * Split a LineString by another GeoJSON Feature.

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -53,7 +53,7 @@
     "@turf/meta": "^5.0.0",
     "@turf/point-on-line": "^5.0.0",
     "@turf/truncate": "^4.7.3",
-    "geojson-rbush": "2.0.1"
+    "geojson-rbush": "2.1.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf/test.js
+++ b/packages/turf/test.js
@@ -50,7 +50,7 @@ test('turf -- invalid dependencies', t => {
 test('turf -- strict version dependencies', t => {
     for (const {name, dependencies} of modules) {
         if (dependencies['jsts'] && dependencies['jsts'] !== '1.4.0') t.fail(name + ' jsts must use v1.4.0');
-        if (dependencies['geojson-rbush'] && dependencies['geojson-rbush'] !== '2.0.1') t.fail(name + ' geojson-rbush must use v2.0.1');
+        if (dependencies['geojson-rbush'] && dependencies['geojson-rbush'] !== '2.1.0') t.fail(name + ' geojson-rbush must use v2.1.0');
     }
     t.end();
 });

--- a/scripts/update-to-es-modules.js
+++ b/scripts/update-to-es-modules.js
@@ -38,6 +38,9 @@ function updateDependencies(pckg) {
             case 'jsts':
                 dependencies[name] = '1.4.0';
                 break;
+            case 'geojson-rbush':
+                dependencies[name] = '2.1.0';
+                break;
             default:
                 dependencies[name] = version;
             }


### PR DESCRIPTION
## Update [`geojson-rbush`](https://github.com/DenisCarriere/geojson-rbush) to ES modules

`geojson-rbush` now uses Rollup to create the CommonJS & ES Modules.

Ref: https://github.com/Turfjs/turf/issues/962#issuecomment-336920324