### PR TITLE
Rework `@turf/concave`

### DIFF
--- a/packages/turf-concave/bench.js
+++ b/packages/turf-concave/bench.js
@@ -32,17 +32,20 @@ for (const {name, geojson} of fixtures) {
 /**
  * Benchmark Results
  *
- * concave-hull x 812 ops/sec ±4.31% (83 runs sampled)
- * fiji x 2,640 ops/sec ±0.96% (90 runs sampled)
- * hole x 1,071 ops/sec ±1.15% (89 runs sampled)
- * issue-333 x 240 ops/sec ±3.62% (78 runs sampled)
- * pts1 x 4,003 ops/sec ±2.25% (84 runs sampled)
- * pts2 x 182 ops/sec ±1.95% (77 runs sampled)
- * pts3 x 11,262 ops/sec ±3.38% (83 runs sampled)
+ * concave-hull x 616 ops/sec ±5.02% (77 runs sampled)
+ * fiji x 1,815 ops/sec ±5.09% (80 runs sampled)
+ * hole x 801 ops/sec ±2.29% (84 runs sampled)
+ * issue-333 x 163 ops/sec ±10.20% (67 runs sampled)
+ * pts1 x 2,697 ops/sec ±5.40% (79 runs sampled)
+ * pts2 x 148 ops/sec ±2.66% (73 runs sampled)
+ * pts3 x 6,938 ops/sec ±6.21% (71 runs sampled)
+ * support-null-geometry x 3,110 ops/sec ±4.75% (74 runs sampled)
  */
 const suite = new Benchmark.Suite('turf-transform-scale');
 for (const {name, geojson} of fixtures) {
-    suite.add(name, () => concave(geojson, geojson.properties));
+    const options = geojson.properties;
+    options.mutate = true;
+    suite.add(name, () => concave(geojson, options));
 }
 
 suite

--- a/packages/turf-concave/index.js
+++ b/packages/turf-concave/index.js
@@ -1,5 +1,5 @@
 import tin from '@turf/tin';
-var dissolve = require('geojson-dissolve');
+import dissolve from './turf-dissolve';
 import distance from '@turf/distance';
 import { feature, featureCollection, isObject, isNumber } from '@turf/helpers';
 import { featureEach } from '@turf/meta';
@@ -58,7 +58,8 @@ function concave(points, options) {
     if (tinPolys.features.length < 1) return null;
 
     // merge the adjacent triangles
-    var dissolved = dissolve(tinPolys.features);
+    var dissolved = dissolve(tinPolys, options);
+
     // geojson-dissolve always returns a MultiPolygon
     if (dissolved.coordinates.length === 1) {
         dissolved.coordinates = dissolved.coordinates[0];

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -9,7 +9,10 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "main.js"
+    "main.js",
+    "turf-dissolve.js",
+    "turf-line-dissolve.js",
+    "turf-polygon-dissolve.js"
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
@@ -44,19 +47,22 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
+    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
-    "tape": "*",
-    "write-json-file": "*",
     "rollup": "*",
-    "@std/esm": "*"
+    "tape": "*",
+    "write-json-file": "*"
   },
   "dependencies": {
+    "@turf/clone": "^4.7.3",
     "@turf/distance": "^5.0.0",
     "@turf/helpers": "^5.0.0",
+    "@turf/invariant": "^5.0.0",
     "@turf/meta": "^5.0.0",
     "@turf/tin": "^4.7.3",
-    "geojson-dissolve": "3.1.0"
+    "topojson-client": "^3.0.0",
+    "topojson-server": "^3.0.0"
   },
   "@std/esm": {
     "esm": "js",

--- a/packages/turf-concave/turf-dissolve.js
+++ b/packages/turf-concave/turf-dissolve.js
@@ -1,0 +1,63 @@
+import clone from '@turf/clone';
+import { getType } from '@turf/invariant';
+import { flattenEach } from '@turf/meta';
+import { isObject } from '@turf/helpers';
+import lineDissolve from './turf-line-dissolve';
+import polygonDissolve from './turf-polygon-dissolve';
+
+/**
+ * Transform function: attempts to dissolve geojson objects where possible
+ * [GeoJSON] -> GeoJSON geometry
+ *
+ * @private
+ * @param {FeatureCollection<LineString|MultiLineString|Polygon|MultiPolygon>} geojson Features to dissolved
+ * @param {Object} [options={}] Optional parameters
+ * @param {boolean} [options.mutate=false] Prevent input mutation
+ * @returns {Feature<MultiLineString|MultiPolygon>} Dissolved Features
+ */
+function dissolve(geojson, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var mutate = options.mutate;
+
+    // Validation
+    if (getType(geojson) !== 'FeatureCollection') throw new Error('geojson must be a FeatureCollection');
+    if (!geojson.features.length) throw new Error('geojson is empty');
+
+    // Clone geojson to avoid side effects
+    // Topojson modifies in place, so we need to deep clone first
+    if (mutate === false || mutate === undefined) geojson = clone(geojson);
+
+    // Assert homogenity
+    var type = getHomogenousType(geojson);
+    if (!type) throw new Error('geojson must be homogenous');
+
+    switch (type) {
+    case 'LineString':
+        return lineDissolve(geojson, options);
+    case 'Polygon':
+        return polygonDissolve(geojson, options);
+    default:
+        throw new Error(type + ' is not supported');
+    }
+}
+
+/**
+ * Checks if GeoJSON is Homogenous
+ *
+ * @private
+ * @param {GeoJSON} geojson GeoJSON
+ * @returns {string|null} Homogenous type or null if multiple types
+ */
+function getHomogenousType(geojson) {
+    var types = {};
+    flattenEach(geojson, function (feature) {
+        types[feature.geometry.type] = true;
+    });
+    var keys = Object.keys(types);
+    if (keys.length === 1) return keys[0];
+    return null;
+}
+
+export default dissolve;

--- a/packages/turf-concave/turf-line-dissolve.js
+++ b/packages/turf-concave/turf-line-dissolve.js
@@ -1,0 +1,87 @@
+import { lineReduce } from '@turf/meta';
+import { getType } from '@turf/invariant';
+import { isObject, multiLineString, lineString } from '@turf/helpers';
+import clone from '@turf/clone';
+
+/**
+ * Merges all connected (non-forking, non-junctioning) line strings into single lineStrings.
+ * [LineString] -> LineString|MultiLineString
+ *
+ * @param {FeatureCollection<LineString|MultiLineString>} geojson Lines to dissolve
+ * @param {Object} [options={}] Optional parameters
+ * @param {boolean} [options.mutate=false] Prevent input mutation
+ * @returns {Feature<LineString|MultiLineString>} Dissolved lines
+ */
+function lineDissolve(geojson, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var mutate = options.mutate;
+
+    // Validation
+    if (getType(geojson) !== 'FeatureCollection') throw new Error('geojson must be a FeatureCollection');
+    if (!geojson.features.length) throw new Error('geojson is empty');
+
+    // Clone geojson to avoid side effects
+    if (mutate === false || mutate === undefined) geojson = clone(geojson);
+
+    var result = [];
+    var lastLine = lineReduce(geojson, function (previousLine, currentLine) {
+        // Attempt to merge this LineString with the other LineStrings, updating
+        // the reference as it is merged with others and grows.
+        var merged = mergeLineStrings(previousLine, currentLine);
+
+        // Accumulate the merged LineString
+        if (merged) return merged;
+
+        // Put the unmerged LineString back into the list
+        else {
+            result.push(previousLine);
+            return currentLine;
+        }
+    });
+    // Append the last line
+    if (lastLine) result.push(lastLine);
+
+    // Return null if no lines were dissolved
+    if (!result.length) return null;
+    // Return LineString if only 1 line was dissolved
+    else if (result.length === 1) return result[0];
+    // Return MultiLineString if multiple lines were dissolved with gaps
+    else return multiLineString(result.map(function (line) { return line.coordinates; }));
+}
+
+// [Number, Number] -> String
+function coordId(coord) {
+    return coord[0].toString() + ',' + coord[1].toString();
+}
+
+/**
+ * LineString, LineString -> LineString
+ *
+ * @private
+ * @param {Feature<LineString>} a line1
+ * @param {Feature<LineString>} b line2
+ * @returns {Feature<LineString>|null} Merged LineString
+ */
+function mergeLineStrings(a, b) {
+    var coords1 = a.geometry.coordinates;
+    var coords2 = b.geometry.coordinates;
+
+    var s1 = coordId(coords1[0]);
+    var e1 = coordId(coords1[coords1.length - 1]);
+    var s2 = coordId(coords2[0]);
+    var e2 = coordId(coords2[coords2.length - 1]);
+
+    // TODO: handle case where more than one of these is true!
+    var coords;
+    if (s1 === e2) coords = coords2.concat(coords1.slice(1));
+    else if (s2 === e1) coords = coords1.concat(coords2.slice(1));
+    else if (s1 === s2) coords = coords1.slice(1).reverse().concat(coords2);
+    else if (e1 === e2) coords = coords1.concat(coords2.reverse().slice(1));
+    else return null;
+
+    return lineString(coords);
+}
+
+export default lineDissolve;

--- a/packages/turf-concave/turf-polygon-dissolve.js
+++ b/packages/turf-concave/turf-polygon-dissolve.js
@@ -1,0 +1,38 @@
+import { merge } from 'topojson-client';
+import { topology } from 'topojson-server';
+import { getType } from '@turf/invariant';
+import { isObject, geometryCollection } from '@turf/helpers';
+import { flattenEach } from '@turf/meta';
+import clone from '@turf/clone';
+
+/**
+ * Dissolves all overlapping (Multi)Polygon
+ *
+ * @param {FeatureCollection<Polygon|MultiPolygon>} geojson Polygons to dissolve
+ * @param {Object} [options={}] Optional parameters
+ * @param {boolean} [options.mutate=false] Prevent input mutation
+ * @returns {Feature<Polygon|MultiPolygon>} Dissolved Polygons
+ */
+function polygonDissolve(geojson, options) {
+    // Optional parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var mutate = options.mutate;
+
+    // Validation
+    if (getType(geojson) !== 'FeatureCollection') throw new Error('geojson must be a FeatureCollection');
+    if (!geojson.features.length) throw new Error('geojson is empty');
+
+    // Clone geojson to avoid side effects
+    // Topojson modifies in place, so we need to deep clone first
+    if (mutate === false || mutate === undefined) geojson = clone(geojson);
+
+    var geoms = [];
+    flattenEach(geojson, function (feature) {
+        geoms.push(feature.geometry);
+    });
+    var topo = topology({geoms: geometryCollection(geoms).geometry});
+    return merge(topo, topo.objects.geoms.geometries);
+}
+
+export default polygonDissolve;

--- a/packages/turf-concave/yarn.lock
+++ b/packages/turf-concave/yarn.lock
@@ -6,6 +6,10 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.11.0.tgz#f5562c6723a2eae5d6f95c3b35ff1338c586ae4e"
 
+"@turf/clone@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-4.7.3.tgz#6e507be4d648fa62c5e6ce926f7e83a22f53ae69"
+
 "@turf/distance@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-5.0.0.tgz#f4db3dcfa160213fdaaf82b2153e1a479efaba6b"

--- a/packages/turf/test.js
+++ b/packages/turf/test.js
@@ -119,7 +119,7 @@ test('turf -- pre-defined attributes in package.json', t => {
 
 test('turf -- parsing dependencies from index.js', t => {
     for (const {name, dir, dependencies} of modules) {
-        var index
+        var index;
         if (fs.existsSync(path.join(dir, 'main.js'))) index = fs.readFileSync(path.join(dir, 'main.js'), 'utf8');
         else index = fs.readFileSync(path.join(dir, 'index.js'), 'utf8');
 
@@ -140,6 +140,8 @@ test('turf -- parsing dependencies from index.js', t => {
             case '@turf/invariant':
             case '@turf/meta':
             case 'rbush':
+            case 'topojson-client':
+            case 'topojson-server':
                 continue;
             }
             if (!dependenciesUsed.has(dependencyName)) t.fail(`${name} ${dependencyName} is not required in index.js`);
@@ -225,9 +227,9 @@ test('turf -- missing modules', t => {
 test('turf -- update to newer Typescript definitions', t => {
     glob.sync(turfTypescriptPath).forEach(filepath => {
         const typescript = fs.readFileSync(filepath, 'utf8');
-        if (typescript.includes('reference types="geojson"')) t.skip(filepath + ' update Typescript definition v5.0')
-    })
-    t.end()
+        if (typescript.includes('reference types="geojson"')) t.skip(filepath + ' update Typescript definition v5.0');
+    });
+    t.end();
 });
 
 // Iterate over each module and retrieve @example to build tests from them


### PR DESCRIPTION
Ref: https://github.com/Turfjs/turf/issues/1027

Convert `@turf/concave` to fully support ES modules.

## Internalized modules:

> Should be included in the next release `v5.1`

- `@turf/polygon-dissolve`
- `@turf/line-dissolve`
- `@turf/dissolve`
- `homogenous()`
