### PR TITLE
15% speed improvement using D3 accessor functions for turf-voronoi

### DIFF
--- a/packages/turf-voronoi/bench.js
+++ b/packages/turf-voronoi/bench.js
@@ -15,8 +15,8 @@ const fixtures = fs.readdirSync(directory).map(filename => {
 
 /**
  * Benchmark Results
- * ninepoints x 18,507 ops/sec ±1.68% (86 runs sampled)
- * simple x 122,562 ops/sec ±2.66% (83 runs sampled)
+ * ninepoints x 22,169 ops/sec ±1.47% (88 runs sampled)
+ * simple x 142,285 ops/sec ±3.02% (73 runs sampled)
  */
 const suite = new Benchmark.Suite('turf-voronoi');
 for (const {name, geojson} of fixtures) {

--- a/packages/turf-voronoi/index.js
+++ b/packages/turf-voronoi/index.js
@@ -1,5 +1,5 @@
 import { polygon, featureCollection } from '@turf/helpers';
-import { getCoords, collectionOf } from '@turf/invariant';
+import { collectionOf } from '@turf/invariant';
 import * as d3voronoi from 'd3-voronoi';
 
 /**
@@ -35,11 +35,12 @@ function voronoi(points, bbox) {
 
     // Inputs
     var extent = [[bbox[0], bbox[1]], [bbox[2], bbox[3]]];
-    var coords = points.features.map(getCoords);
 
     return featureCollection(
         d3voronoi.voronoi()
-            .extent(extent)(coords)
+            .x(function(feature) { return feature.geometry.coordinates[0]; })
+            .y(function(feature) { return feature.geometry.coordinates[1]; })
+            .extent(extent)(points.features)
             .polygons()
             .map(coordsToPolygon)
     );

--- a/packages/turf-voronoi/index.js
+++ b/packages/turf-voronoi/index.js
@@ -38,8 +38,8 @@ function voronoi(points, bbox) {
 
     return featureCollection(
         d3voronoi.voronoi()
-            .x(function(feature) { return feature.geometry.coordinates[0]; })
-            .y(function(feature) { return feature.geometry.coordinates[1]; })
+            .x(function (feature) { return feature.geometry.coordinates[0]; })
+            .y(function (feature) { return feature.geometry.coordinates[1]; })
             .extent(extent)(points.features)
             .polygons()
             .map(coordsToPolygon)


### PR DESCRIPTION
Sorry, just missed including this before the PR was accepted. Using D3's accessor functions (.x, .y) is a bit faster than pre-processing the input array. And less memory too, I guess.

Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [✓] Run `npm test` at the sub modules where changes have occurred.
- [✓] Run `npm run lint` to ensure code style at the turf module level.
