### PR TITLE
Backwards compatible v4 renamed modules/methods

### DIFF
--- a/packages/turf-helpers/index.js
+++ b/packages/turf-helpers/index.js
@@ -573,29 +573,29 @@ export function isObject(input) {
 
 // Deprecated methods
 export function radians2degrees() {
-    throw new Error('Method deprecated in favor of helpers.radiansToDegrees');
+    throw new Error('method has been renamed to `radiansToDegrees`');
 }
 
 export function degrees2radians() {
-    throw new Error('Method deprecated in favor of helpers.degreesToRadians');
+    throw new Error('method has been renamed to `degreesToRadians`');
 }
 
 export function distanceToDegrees() {
-    throw new Error('Method deprecated in favor of helpers.lengthToDegrees');
+    throw new Error('method has been renamed to `lengthToDegrees`');
 }
 
 export function distanceToRadians() {
-    throw new Error('Method deprecated in favor of helpers.lengthToRadians');
+    throw new Error('method has been renamed to `lengthToRadians`');
 }
 
 export function radiansToDistance() {
-    throw new Error('Method deprecated in favor of helpers.radiansToLength');
+    throw new Error('method has been renamed to `radiansToLength`');
 }
 
 export function bearingToAngle() {
-    throw new Error('Method deprecated in favor of helpers.bearingToAzimuth');
+    throw new Error('method has been renamed to `bearingToAzimuth`');
 }
 
 export function convertDistance() {
-    throw new Error('Method deprecated in favor of helpers.convertLength');
+    throw new Error('method has been renamed to `convertLength`');
 }

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -108,3 +108,25 @@ import * as helpers from '@turf/helpers';
 import * as invariant from '@turf/invariant';
 import * as meta from '@turf/meta';
 export {projection, random, clusters, helpers, invariant, meta};
+
+// Renamed modules (Backwards compatitble with v4.0)
+export {default as pointOnSurface} from '@turf/point-on-feature';
+export {default as polygonToLineString} from '@turf/polygon-to-line';
+export {default as lineStringToPolygon} from '@turf/line-to-polygon';
+export {default as inside} from '@turf/boolean-point-in-polygon';
+export {default as within} from '@turf/points-within-polygon';
+export {default as bezier} from '@turf/bezier-spline';
+export {default as nearest} from '@turf/nearest-point';
+export {default as pointOnLine} from '@turf/nearest-point-on-line';
+export {default as lineDistance} from '@turf/length';
+
+// Renamed methods (Backwards compatitble with v4.0)
+export {
+    radiansToDegrees as radians2degrees,
+    degreesToRadians as degrees2radians,
+    lengthToDegrees as distanceToDegrees,
+    lengthToRadians as distanceToRadians,
+    radiansToLength as radiansToDistance,
+    bearingToAzimuth as bearingToAngle,
+    convertLength as convertDistance
+} from '@turf/helpers';

--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -110,6 +110,7 @@ import * as meta from '@turf/meta';
 export {projection, random, clusters, helpers, invariant, meta};
 
 // Renamed modules (Backwards compatitble with v4.0)
+// https://github.com/Turfjs/turf/issues/860
 export {default as pointOnSurface} from '@turf/point-on-feature';
 export {default as polygonToLineString} from '@turf/polygon-to-line';
 export {default as lineStringToPolygon} from '@turf/line-to-polygon';
@@ -121,6 +122,7 @@ export {default as pointOnLine} from '@turf/nearest-point-on-line';
 export {default as lineDistance} from '@turf/length';
 
 // Renamed methods (Backwards compatitble with v4.0)
+// https://github.com/Turfjs/turf/issues/860
 export {
     radiansToDegrees as radians2degrees,
     degreesToRadians as degrees2radians,

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -108,3 +108,25 @@ import * as helpers from '@turf/helpers';
 import * as invariant from '@turf/invariant';
 import * as meta from '@turf/meta';
 export {projection, random, clusters, helpers, invariant, meta};
+
+// Renamed modules (Backwards compatitble with v4.0)
+export {default as pointOnSurface} from '@turf/point-on-feature';
+export {default as polygonToLineString} from '@turf/polygon-to-line';
+export {default as lineStringToPolygon} from '@turf/line-to-polygon';
+export {default as inside} from '@turf/boolean-point-in-polygon';
+export {default as within} from '@turf/points-within-polygon';
+export {default as bezier} from '@turf/bezier-spline';
+export {default as nearest} from '@turf/nearest-point';
+export {default as pointOnLine} from '@turf/nearest-point-on-line';
+export {default as lineDistance} from '@turf/length';
+
+// Renamed methods (Backwards compatitble with v4.0)
+export {
+    radiansToDegrees as radians2degrees,
+    degreesToRadians as degrees2radians,
+    lengthToDegrees as distanceToDegrees,
+    lengthToRadians as distanceToRadians,
+    radiansToLength as radiansToDistance,
+    bearingToAzimuth as bearingToAngle,
+    convertLength as convertDistance
+} from '@turf/helpers';

--- a/packages/turf/index.js
+++ b/packages/turf/index.js
@@ -110,6 +110,7 @@ import * as meta from '@turf/meta';
 export {projection, random, clusters, helpers, invariant, meta};
 
 // Renamed modules (Backwards compatitble with v4.0)
+// https://github.com/Turfjs/turf/issues/860
 export {default as pointOnSurface} from '@turf/point-on-feature';
 export {default as polygonToLineString} from '@turf/polygon-to-line';
 export {default as lineStringToPolygon} from '@turf/line-to-polygon';
@@ -121,6 +122,7 @@ export {default as pointOnLine} from '@turf/nearest-point-on-line';
 export {default as lineDistance} from '@turf/length';
 
 // Renamed methods (Backwards compatitble with v4.0)
+// https://github.com/Turfjs/turf/issues/860
 export {
     radiansToDegrees as radians2degrees,
     degreesToRadians as degrees2radians,

--- a/packages/turf/test.js
+++ b/packages/turf/test.js
@@ -31,7 +31,7 @@ modules = modules.filter(({name}) => name !== 'turf');
 
 test('turf -- required files', t => {
     for (const {name, dir} of modules) {
-        for (const filename of ['test.js', 'bench.js', 'index.js', 'index.d.ts', 'LICENSE', 'README.md', 'yarn.lock']) {
+        for (const filename of ['test.js', 'index.js', 'index.d.ts', 'LICENSE', 'README.md']) {
             if (!fs.existsSync(path.join(dir, filename))) t.fail(`${name} ${filename} is required`);
         }
         // if (!fs.existsSync(path.join(dir, 'types.ts'))) t.fail(`${name} types.ts is required`);


### PR DESCRIPTION
## Backwards compatible v4 renamed modules/methods

Since there has been a lot of renamed modules in this next `v5.0` release, decided to keep the old module exposed in the global `@turf/turf` package.

Noticed Mapbox's "Analysis with Turf" help website would be broken without this change.

https://www.mapbox.com/help/analysis-with-turf/

## Backwards compatible

```js
require('@turf/turf').radians2degrees(1)
// => 57.29577951308232
```

```js
require('@turf/turf').inside
[Function: booleanPointInPolygon]
```

## Not backwards compatible using module directly

```js
require('@turf/helpers').radians2degrees(1)
// => Error: method has been renamed to radiansToDegrees
```

```bash
$ npm install @turf/inside
npm WARN deprecated @turf/inside@5.0.0: Module has been renamed to @turf/boolean-point-in-polygon
```