### PR TITLE
Add validateId + validateBBox & add options to @turf/helpers

### DIFF
--- a/packages/turf-bbox/README.md
+++ b/packages/turf-bbox/README.md
@@ -8,7 +8,7 @@ Takes a set of features, calculates the bbox of all input features, and returns 
 
 **Parameters**
 
--   `geojson` **([FeatureCollection](http://geojson.org/geojson-spec.html#feature-collection-objects) \| [Feature](http://geojson.org/geojson-spec.html#feature-objects) \| [Geometry](http://geojson.org/geojson-spec.html#geometry))** any GeoJSON object
+-   `geojson` **[GeoJSON](http://geojson.org/geojson-spec.html#geojson-objects)** any GeoJSON object
 
 **Examples**
 

--- a/packages/turf-clone/test.js
+++ b/packages/turf-clone/test.js
@@ -97,7 +97,7 @@ test('turf-clone -- Preserve Foreign Members -- Feature', t => {
     const properties = {foo: 'bar'};
     const bbox = [0, 20, 0, 20];
     const id = 12345;
-    const pt = point([0, 20], properties, bbox, id);
+    const pt = point([0, 20], properties, {bbox, id});
     pt.custom = 'foreign members';
 
     const cloned = clone(pt);
@@ -112,7 +112,7 @@ test('turf-clone -- Preserve Foreign Members -- FeatureCollection', t => {
     const properties = {foo: 'bar'};
     const bbox = [0, 20, 0, 20];
     const id = 12345;
-    const fc = featureCollection([point([0, 20])], bbox, id);
+    const fc = featureCollection([point([0, 20])], {bbox, id});
     fc.custom = 'foreign members';
     fc.properties = properties;
 
@@ -136,7 +136,7 @@ test('turf-clone -- Preserve all properties -- Feature', t => {
         nullity: null,
         boolean: true
     };
-    const pt = point([0, 20], properties, bbox, id);
+    const pt = point([0, 20], properties, {bbox, id});
     pt.hello = 'world'; // Foreign member
 
     // Clone and mutate
@@ -176,7 +176,9 @@ test('turf-clone -- Preserve all properties -- Feature', t => {
 });
 
 test('turf-clone -- Preserve all properties -- FeatureCollection', t => {
-    const fc = featureCollection([point([0, 20])], [0, 20, 0, 20], 12345);
+    const bbox = [0, 20, 0, 20];
+    const id = 12345;
+    const fc = featureCollection([point([0, 20])], {bbox, id});
     fc.hello = 'world'; // Foreign member
 
     // Clone and mutate

--- a/packages/turf-helpers/README.md
+++ b/packages/turf-helpers/README.md
@@ -26,8 +26,9 @@ Wraps a GeoJSON [Geometry](http://geojson.org/geojson-spec.html#geometry) in a G
 
 -   `geometry` **[Geometry](http://geojson.org/geojson-spec.html#geometry)** input geometry
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -53,7 +54,8 @@ For GeometryCollection type use `helpers.geometryCollection`
 
 -   `type` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Geometry Type
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Coordinates
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
 
 **Examples**
 
@@ -76,8 +78,9 @@ Takes coordinates and properties (optional) and returns a new [Point](http://geo
 
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** longitude, latitude position (each in decimal degrees)
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -97,8 +100,9 @@ Takes an array of LinearRings and optionally an [Object](https://developer.mozil
 
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>>>** an array of LinearRings
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -128,8 +132,9 @@ coordinate array. Properties can be added optionally.
 
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>>** an array of Positions
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -163,8 +168,9 @@ Takes one or more [Features](http://geojson.org/geojson-spec.html#feature-object
 **Parameters**
 
 -   `features` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Feature](http://geojson.org/geojson-spec.html#feature-objects)>** input features
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -191,8 +197,9 @@ coordinate array. Properties can be added optionally.
 
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>>>** an array of LineStrings
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -215,8 +222,9 @@ coordinate array. Properties can be added optionally.
 
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>>** an array of Positions
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -239,8 +247,9 @@ coordinate array. Properties can be added optionally.
 
 -   `coordinates` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>>>>** an array of Polygons
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 
@@ -263,8 +272,9 @@ coordinate array. Properties can be added optionally.
 
 -   `geometries` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Geometry](http://geojson.org/geojson-spec.html#geometry)>** an array of GeoJSON Geometries
 -   `properties` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** an Object of key-value pairs to add as properties (optional, default `{}`)
--   `bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
--   `id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional Parameters (optional, default `{}`)
+    -   `options.bbox` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** BBox [west, south, east, north]
+    -   `options.id` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))?** Identifier
 
 **Examples**
 

--- a/packages/turf-helpers/index.d.ts
+++ b/packages/turf-helpers/index.d.ts
@@ -41,62 +41,71 @@ export interface ExtendedFeatureCollection<Feat extends Feature<any>> {
 }
 export type AllGeoJSON = Feature<any> | FeatureCollection<any> | FeatureGeometryCollection | GeometryObject | GeometryCollection;
 
+interface FeatureOptions {
+    id?: Id;
+    bbox?: BBox;
+}
+
+interface GeometryOptions {
+    bbox?: BBox;
+}
+
 /**
  * http://turfjs.org/docs/#feature
  */
-export function feature<T extends GeometryObject>(geometry: T, properties?: Properties, bbox?: BBox, id?: Id): Feature<T>;
+export function feature<T extends GeometryObject>(geometry: T, properties?: Properties, options?: FeatureOptions): Feature<T>;
 
 /**
  * http://turfjs.org/docs/#featurecollection
  */
-export function featureCollection<Geom extends GeometryObject>(features: Feature<Geom>[], bbox?: BBox, id?: Id): FeatureCollection<Geom>;
-export function featureCollection(features: Feature<any>[], bbox?: BBox, id?: Id): FeatureCollection<any>;
+export function featureCollection<Geom extends GeometryObject>(features: Feature<Geom>[], options?: FeatureOptions): FeatureCollection<Geom>;
+export function featureCollection(features: Feature<any>[], options?: FeatureOptions): FeatureCollection<any>;
 
 /**
  * http://turfjs.org/docs/#geometry
  */
-export function geometry(type: 'Point', coordinates: Position, bbox?: BBox): Point;
-export function geometry(type: 'LineString', coordinates: Position[], bbox?: BBox): LineString;
-export function geometry(type: 'Polygon', coordinates: Position[][], bbox?: BBox): Polygon;
-export function geometry(type: 'MultiPoint', coordinates: Position[], bbox?: BBox): MultiPoint;
-export function geometry(type: 'MultiLineString', coordinates: Position[][], bbox?: BBox): MultiLineString;
-export function geometry(type: 'MultiPolygon', coordinates: Position[][][], bbox?: BBox): MultiPolygon;
-export function geometry(type: Geometry | string, coordinates: any[], bbox?: BBox): GeometryObject;
+export function geometry(type: 'Point', coordinates: Position, options?: GeometryOptions): Point;
+export function geometry(type: 'LineString', coordinates: Position[], options?: GeometryOptions): LineString;
+export function geometry(type: 'Polygon', coordinates: Position[][], options?: GeometryOptions): Polygon;
+export function geometry(type: 'MultiPoint', coordinates: Position[], options?: GeometryOptions): MultiPoint;
+export function geometry(type: 'MultiLineString', coordinates: Position[][], options?: GeometryOptions): MultiLineString;
+export function geometry(type: 'MultiPolygon', coordinates: Position[][][], options?: GeometryOptions): MultiPolygon;
+export function geometry(type: Geometry | string, coordinates: any[], options?: GeometryOptions): GeometryObject;
 
 /**
  * http://turfjs.org/docs/#point
  */
-export function point(coordinates: Position, properties?: Properties, bbox?: BBox, id?: Id): Feature<Point>;
+export function point(coordinates: Position, properties?: Properties, options?: FeatureOptions): Feature<Point>;
 
 /**
  * http://turfjs.org/docs/#polygon
  */
-export function polygon(coordinates: Position[][], properties?: Properties, bbox?: BBox, id?: Id): Feature<Polygon>;
+export function polygon(coordinates: Position[][], properties?: Properties, options?: FeatureOptions): Feature<Polygon>;
 
 /**
  * http://turfjs.org/docs/#linestring
  */
-export function lineString(coordinates: Position[], properties?: Properties, bbox?: BBox, id?: Id): Feature<LineString>;
+export function lineString(coordinates: Position[], properties?: Properties, options?: FeatureOptions): Feature<LineString>;
 
 /**
  * http://turfjs.org/docs/#multilinestring
  */
-export function multiLineString(coordinates: Position[][], properties?: Properties, bbox?: BBox, id?: Id): Feature<MultiLineString>;
+export function multiLineString(coordinates: Position[][], properties?: Properties, options?: FeatureOptions): Feature<MultiLineString>;
 
 /**
  * http://turfjs.org/docs/#multipoint
  */
-export function multiPoint(coordinates: Position[], properties?: Properties, bbox?: BBox, id?: Id): Feature<MultiPoint>;
+export function multiPoint(coordinates: Position[], properties?: Properties, options?: FeatureOptions): Feature<MultiPoint>;
 
 /**
  * http://turfjs.org/docs/#multipolygon
  */
-export function multiPolygon(coordinates: Position[][][], properties?: Properties, bbox?: BBox, id?: Id): Feature<MultiPolygon>;
+export function multiPolygon(coordinates: Position[][][], properties?: Properties, options?: FeatureOptions): Feature<MultiPolygon>;
 
 /**
  * http://turfjs.org/docs/#geometrycollection
  */
-export function geometryCollection(geometries: GeometryObject[], properties?: Properties, bbox?: BBox, id?: Id): FeatureGeometryCollection;
+export function geometryCollection(geometries: GeometryObject[], properties?: Properties, options?: FeatureOptions): FeatureGeometryCollection;
 
 /**
  * http://turfjs.org/docs/#radianstolength
@@ -204,3 +213,13 @@ export const areaFactors: {
     feet: number
     inches: number
 };
+
+/**
+ * Validate Id
+ */
+export function validateId(id: Id): void;
+
+/**
+ * Validate BBox
+ */
+export function validateBBox(bbox: BBox): void;

--- a/packages/turf-helpers/index.js
+++ b/packages/turf-helpers/index.js
@@ -70,8 +70,9 @@ export var areaFactors = {
  * @name feature
  * @param {Geometry} geometry input geometry
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature} a GeoJSON Feature
  * @example
  * var geometry = {
@@ -83,15 +84,20 @@ export var areaFactors = {
  *
  * //=feature
  */
-export function feature(geometry, properties, bbox, id) {
+export function feature(geometry, properties, options) {
+    // Optional Parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var bbox = options.bbox;
+    var id = options.id;
+
+    // Validation
     if (geometry === undefined) throw new Error('geometry is required');
     if (properties && properties.constructor !== Object) throw new Error('properties must be an Object');
-    if (bbox) {
-        if (!Array.isArray(bbox)) throw new Error('bbox must be an Array');
-        if (bbox.length !== 4) throw new Error('bbox must be an Array of 4 numbers');
-    }
-    if (id && ['string', 'number'].indexOf(typeof id) === -1) throw new Error('id must be a number or a string');
+    if (bbox) validateBBox(bbox);
+    if (id) validateId(id);
 
+    // Main
     var feat = {type: 'Feature'};
     if (id) feat.id = id;
     if (bbox) feat.bbox = bbox;
@@ -107,7 +113,8 @@ export function feature(geometry, properties, bbox, id) {
  * @name geometry
  * @param {string} type Geometry Type
  * @param {Array<number>} coordinates Coordinates
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
  * @returns {Geometry} a GeoJSON Geometry
  * @example
  * var type = 'Point';
@@ -117,13 +124,19 @@ export function feature(geometry, properties, bbox, id) {
  *
  * //=geometry
  */
-export function geometry(type, coordinates, bbox) {
+export function geometry(type, coordinates, options) {
+    // Optional Parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var bbox = options.bbox;
+
     // Validation
     if (!type) throw new Error('type is required');
     if (!coordinates) throw new Error('coordinates is required');
     if (!Array.isArray(coordinates)) throw new Error('coordinates must be an Array');
-    if (bbox && bbox.length !== 4) throw new Error('bbox must be an Array of 4 numbers');
+    if (bbox) validateBBox(bbox);
 
+    // Main
     var geom;
     switch (type) {
     case 'Point': geom = point(coordinates).geometry; break;
@@ -144,15 +157,16 @@ export function geometry(type, coordinates, bbox) {
  * @name point
  * @param {Array<number>} coordinates longitude, latitude position (each in decimal degrees)
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<Point>} a Point feature
  * @example
  * var point = turf.point([-75.343, 39.984]);
  *
  * //=point
  */
-export function point(coordinates, properties, bbox, id) {
+export function point(coordinates, properties, options) {
     if (!coordinates) throw new Error('No coordinates passed');
     if (!Array.isArray(coordinates)) throw new Error('Coordinates must be an Array');
     if (coordinates.length < 2) throw new Error('Coordinates must be at least 2 numbers long');
@@ -161,7 +175,7 @@ export function point(coordinates, properties, bbox, id) {
     return feature({
         type: 'Point',
         coordinates: coordinates
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -170,8 +184,9 @@ export function point(coordinates, properties, bbox, id) {
  * @name polygon
  * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<Polygon>} a Polygon feature
  * @throws {Error} throw an error if a LinearRing of the polygon has too few positions
  * or if a LinearRing of the Polygon does not have matching Positions at the beginning & end.
@@ -186,7 +201,7 @@ export function point(coordinates, properties, bbox, id) {
  *
  * //=polygon
  */
-export function polygon(coordinates, properties, bbox, id) {
+export function polygon(coordinates, properties, options) {
     if (!coordinates) throw new Error('No coordinates passed');
 
     for (var i = 0; i < coordinates.length; i++) {
@@ -206,7 +221,7 @@ export function polygon(coordinates, properties, bbox, id) {
     return feature({
         type: 'Polygon',
         coordinates: coordinates
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -216,8 +231,9 @@ export function polygon(coordinates, properties, bbox, id) {
  * @name lineString
  * @param {Array<Array<number>>} coordinates an array of Positions
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<LineString>} a LineString feature
  * @throws {Error} if no coordinates are passed
  * @example
@@ -238,7 +254,7 @@ export function polygon(coordinates, properties, bbox, id) {
  *
  * //=linestring2
  */
-export function lineString(coordinates, properties, bbox, id) {
+export function lineString(coordinates, properties, options) {
     if (!coordinates) throw new Error('No coordinates passed');
     if (coordinates.length < 2) throw new Error('Coordinates must be an array of two or more positions');
     // Check if first point of LineString contains two numbers
@@ -247,7 +263,7 @@ export function lineString(coordinates, properties, bbox, id) {
     return feature({
         type: 'LineString',
         coordinates: coordinates
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -255,8 +271,9 @@ export function lineString(coordinates, properties, bbox, id) {
  *
  * @name featureCollection
  * @param {Feature[]} features input features
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {FeatureCollection} a FeatureCollection of input features
  * @example
  * var features = [
@@ -269,12 +286,20 @@ export function lineString(coordinates, properties, bbox, id) {
  *
  * //=collection
  */
-export function featureCollection(features, bbox, id) {
+export function featureCollection(features, options) {
+    // Optional Parameters
+    options = options || {};
+    if (!isObject(options)) throw new Error('options is invalid');
+    var bbox = options.bbox;
+    var id = options.id;
+
+    // Validation
     if (!features) throw new Error('No features passed');
     if (!Array.isArray(features)) throw new Error('features must be an Array');
-    if (bbox && bbox.length !== 4) throw new Error('bbox must be an Array of 4 numbers');
-    if (id && ['string', 'number'].indexOf(typeof id) === -1) throw new Error('id must be a number or a string');
+    if (bbox) validateBBox(bbox);
+    if (id) validateId(id);
 
+    // Main
     var fc = {type: 'FeatureCollection'};
     if (id) fc.id = id;
     if (bbox) fc.bbox = bbox;
@@ -289,8 +314,9 @@ export function featureCollection(features, bbox, id) {
  * @name multiLineString
  * @param {Array<Array<Array<number>>>} coordinates an array of LineStrings
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<MultiLineString>} a MultiLineString feature
  * @throws {Error} if no coordinates are passed
  * @example
@@ -298,13 +324,13 @@ export function featureCollection(features, bbox, id) {
  *
  * //=multiLine
  */
-export function multiLineString(coordinates, properties, bbox, id) {
+export function multiLineString(coordinates, properties, options) {
     if (!coordinates) throw new Error('No coordinates passed');
 
     return feature({
         type: 'MultiLineString',
         coordinates: coordinates
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -314,8 +340,9 @@ export function multiLineString(coordinates, properties, bbox, id) {
  * @name multiPoint
  * @param {Array<Array<number>>} coordinates an array of Positions
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<MultiPoint>} a MultiPoint feature
  * @throws {Error} if no coordinates are passed
  * @example
@@ -323,13 +350,13 @@ export function multiLineString(coordinates, properties, bbox, id) {
  *
  * //=multiPt
  */
-export function multiPoint(coordinates, properties, bbox, id) {
+export function multiPoint(coordinates, properties, options) {
     if (!coordinates) throw new Error('No coordinates passed');
 
     return feature({
         type: 'MultiPoint',
         coordinates: coordinates
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -339,8 +366,9 @@ export function multiPoint(coordinates, properties, bbox, id) {
  * @name multiPolygon
  * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygons
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<MultiPolygon>} a multipolygon feature
  * @throws {Error} if no coordinates are passed
  * @example
@@ -349,13 +377,13 @@ export function multiPoint(coordinates, properties, bbox, id) {
  * //=multiPoly
  *
  */
-export function multiPolygon(coordinates, properties, bbox, id) {
+export function multiPolygon(coordinates, properties, options) {
     if (!coordinates) throw new Error('No coordinates passed');
 
     return feature({
         type: 'MultiPolygon',
         coordinates: coordinates
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -365,8 +393,9 @@ export function multiPolygon(coordinates, properties, bbox, id) {
  * @name geometryCollection
  * @param {Array<Geometry>} geometries an array of GeoJSON Geometries
  * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Array<number>} [bbox] BBox [west, south, east, north]
- * @param {string|number} [id] Identifier
+ * @param {Object} [options={}] Optional Parameters
+ * @param {Array<number>} [options.bbox] BBox [west, south, east, north]
+ * @param {string|number} [options.id] Identifier
  * @returns {Feature<GeometryCollection>} a GeoJSON GeometryCollection Feature
  * @example
  * var pt = {
@@ -381,14 +410,14 @@ export function multiPolygon(coordinates, properties, bbox, id) {
  *
  * //=collection
  */
-export function geometryCollection(geometries, properties, bbox, id) {
+export function geometryCollection(geometries, properties, options) {
     if (!geometries) throw new Error('geometries is required');
     if (!Array.isArray(geometries)) throw new Error('geometries must be an Array');
 
     return feature({
         type: 'GeometryCollection',
         geometries: geometries
-    }, properties, bbox, id);
+    }, properties, options);
 }
 
 /**
@@ -569,6 +598,59 @@ export function isNumber(num) {
  */
 export function isObject(input) {
     return (!!input) && (input.constructor === Object);
+}
+
+/**
+ * Validate BBox
+ *
+ * @private
+ * @param {Array<number>} bbox BBox to validate
+ * @returns {void}
+ * @throws Error if BBox is not valid
+ * @example
+ * validateBBox([-180, -40, 110, 50])
+ * //=OK
+ * validateBBox([-180, -40])
+ * //=Error
+ * validateBBox('Foo')
+ * //=Error
+ * validateBBox(5)
+ * //=Error
+ * validateBBox(null)
+ * //=Error
+ * validateBBox(undefined)
+ * //=Error
+ */
+export function validateBBox(bbox) {
+    if (!bbox) throw new Error('bbox is required');
+    if (!Array.isArray(bbox)) throw new Error('bbox must be an Array');
+    if (bbox.length !== 4 && bbox.length !== 6) throw new Error('bbox must be an Array of 4 or 6 numbers');
+}
+
+/**
+ * Validate Id
+ *
+ * @private
+ * @param {string|number} id Id to validate
+ * @returns {void}
+ * @throws Error if Id is not valid
+ * @example
+ * validateId([-180, -40, 110, 50])
+ * //=Error
+ * validateId([-180, -40])
+ * //=Error
+ * validateId('Foo')
+ * //=OK
+ * validateId(5)
+ * //=OK
+ * validateId(null)
+ * //=Error
+ * validateId(undefined)
+ * //=Error
+ */
+export function validateId(id) {
+    if (!id) throw new Error('id is required');
+    if (['string', 'number'].indexOf(typeof id) === -1) throw new Error('id must be a number or a string');
 }
 
 // Deprecated methods

--- a/packages/turf-helpers/test.js
+++ b/packages/turf-helpers/test.js
@@ -402,16 +402,16 @@ test('null geometries', t => {
 test('turf-helpers -- Handle Id & BBox properties', t => {
     const id = 12345;
     const bbox = [10, 30, 10, 30];
-    const pt = point([10, 30], {}, bbox, id);
-    const fc = featureCollection([pt], bbox, id);
+    const pt = point([10, 30], {}, {bbox, id});
+    const fc = featureCollection([pt], {bbox, id});
     t.equal(pt.id, id, 'feature id');
     t.equal(pt.bbox, bbox, 'feature bbox');
     t.equal(fc.id, id, 'featureCollection id');
     t.equal(fc.bbox, bbox, 'featureCollection bbox');
-    t.throws(() => point([10, 30], {}, [0], id), 'throws invalid bbox');
-    t.throws(() => point([10, 30], {}, bbox, {invalid: 'id'}), 'throws invalid id');
-    t.throws(() => featureCollection([pt], [0], id), 'throws invalid bbox');
-    t.throws(() => featureCollection([pt], [0], {invalid: 'id'}), 'throws invalid id');
+    t.throws(() => point([10, 30], {}, {bbox: [0], id}), 'throws invalid bbox');
+    t.throws(() => point([10, 30], {}, {bbox, id: {invalid: 'id'}}), 'throws invalid id');
+    t.throws(() => featureCollection([pt], {bbox: [0], id}), 'throws invalid bbox');
+    t.throws(() => featureCollection([pt], {bbox: [0], id: {invalid: 'id'}}), 'throws invalid id');
     t.end();
 });
 

--- a/packages/turf-helpers/types.ts
+++ b/packages/turf-helpers/types.ts
@@ -95,13 +95,13 @@ const geomCollection = helpers.geometryCollection([pt.geometry])
 geomCollection.geometry.geometries
 
 // bbox & id
-helpers.point(pt.geometry.coordinates, properties, bbox, 1)
-helpers.lineString(line.geometry.coordinates, properties, bbox, 1)
-helpers.polygon(poly.geometry.coordinates, properties, bbox, 1)
-helpers.multiPoint(multiPt.geometry.coordinates, properties, bbox, 1)
-helpers.multiLineString(multiLine.geometry.coordinates, properties, bbox, 1)
-helpers.multiPolygon(multiPoly.geometry.coordinates, properties, bbox, 1)
-helpers.geometryCollection([pt.geometry], properties, bbox, 1)
+helpers.point(pt.geometry.coordinates, properties, {bbox, id: 1})
+helpers.lineString(line.geometry.coordinates, properties, {bbox, id: 1})
+helpers.polygon(poly.geometry.coordinates, properties, {bbox, id: 1})
+helpers.multiPoint(multiPt.geometry.coordinates, properties, {bbox, id: 1})
+helpers.multiLineString(multiLine.geometry.coordinates, properties, {bbox, id: 1})
+helpers.multiPolygon(multiPoly.geometry.coordinates, properties, {bbox, id: 1})
+helpers.geometryCollection([pt.geometry], properties, {bbox, id: 1})
 
 // properties
 helpers.point(pt.geometry.coordinates, {foo: 'bar'})

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -586,7 +586,7 @@ export function flattenEach(geojson, callback) {
         case 'Point':
         case 'LineString':
         case 'Polygon':
-            callback(feature(geometry, properties, bbox, id), featureIndex, 0);
+            callback(feature(geometry, properties, {bbox, id}), featureIndex, 0);
             return;
         }
 

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -666,7 +666,7 @@ test('geomEach -- callback BBox & Id', t => {
     const properties = {foo: 'bar'};
     const bbox = [0, 0, 0, 0];
     const id = 'foo';
-    const pt = point([0, 0], properties, bbox, id);
+    const pt = point([0, 0], properties, {bbox, id});
 
     meta.geomEach(pt, (currentGeometry, featureIndex, currentProperties, currentBBox, currentId) => {
         t.equal(featureIndex, 0, 'featureIndex');
@@ -681,7 +681,7 @@ test('lineEach -- callback BBox & Id', t => {
     const properties = {foo: 'bar'};
     const bbox = [0, 0, 10, 10];
     const id = 'foo';
-    const line = lineString([[0, 0], [10, 10]], properties, bbox, id);
+    const line = lineString([[0, 0], [10, 10]], properties, {bbox, id});
 
     meta.lineEach(line, (currentLine, featureIndex) => {
         t.equal(featureIndex, 0, 'featureIndex');
@@ -696,7 +696,7 @@ test('lineEach -- return lineString', t => {
     const properties = {foo: 'bar'};
     const bbox = [0, 0, 10, 10];
     const id = 'foo';
-    const line = lineString([[0, 0], [10, 10]], properties, bbox, id);
+    const line = lineString([[0, 0], [10, 10]], properties, {bbox, id});
 
     meta.lineEach(line, (currentLine) => {
         t.deepEqual(line, currentLine, 'return itself');

--- a/packages/turf-simplify/test.js
+++ b/packages/turf-simplify/test.js
@@ -52,7 +52,7 @@ test('simplify -- removes ID & BBox from properties', t => {
     const properties = {foo: 'bar'};
     const id = 12345;
     const bbox = [0, 0, 2, 2];
-    const poly = polygon([[[0, 0], [2, 2], [2, 0], [0, 0]]], properties, bbox, id);
+    const poly = polygon([[[0, 0], [2, 2], [2, 0], [0, 0]]], properties, {bbox, id});
     const simple = simplify(poly, {tolerance: 0.1});
 
     t.equal(simple.id, id);


### PR DESCRIPTION
### Add `validateId` + `validateBBox` & add options to `@turf/helpers` ⚠️ 

Convert some of the helper methods to the new `Options` syntax from v5.0 update.

Kept `properties` as it's own param since it would break too backwards compatible.

Internally I've added `validateBBox` & `validateId` to keep the errors consistent.

This change will rollout in the breaking change of the newly release of v5.0.