### PR TITLE
Add input validation to @turf/bbox-polygon

### DIFF
--- a/packages/turf-bbox-polygon/bench.js
+++ b/packages/turf-bbox-polygon/bench.js
@@ -2,15 +2,13 @@ import fs from 'fs';
 import Benchmark from 'benchmark';
 import bboxpolygon from './';
 
-var suite = new Benchmark.Suite('turf-bbox-polygon');
-suite
-  .add('turf-bbox-polygon',function () {
-    bboxpolygon([0,0,10,10])
-  })
-  .on('cycle', function (event) {
-    console.log(String(event.target));
-  })
-  .on('complete', function () {
-
-  })
+/**
+ * Benchmark Results
+ *
+ * turf-bbox-polygon x 3,885,828 ops/sec ±1.20% (86 runs sampled)
+ */
+new Benchmark.Suite('turf-bbox-polygon')
+  .add('turf-bbox-polygon', () => bboxpolygon([0,0,10,10]))
+  .on('cycle', e => console.log(String(e.target)))
+  .on('complete', () => {})
   .run();

--- a/packages/turf-bbox-polygon/index.js
+++ b/packages/turf-bbox-polygon/index.js
@@ -1,4 +1,4 @@
-import { polygon } from '@turf/helpers';
+import { polygon, validateBBox } from '@turf/helpers';
 
 /**
  * Takes a bbox and returns an equivalent {@link Polygon|polygon}.
@@ -15,10 +15,18 @@ import { polygon } from '@turf/helpers';
  * var addToMap = [poly]
  */
 function bboxPolygon(bbox) {
-    var lowLeft = [bbox[0], bbox[1]];
-    var topLeft = [bbox[0], bbox[3]];
-    var topRight = [bbox[2], bbox[3]];
-    var lowRight = [bbox[2], bbox[1]];
+    validateBBox(bbox);
+    var west = Number(bbox[0]);
+    var south = Number(bbox[1]);
+    var east = Number(bbox[2]);
+    var north = Number(bbox[3]);
+
+    if (bbox.length === 6) throw new Error('@turf/bbox-polygon does not support BBox with 6 positions');
+
+    var lowLeft = [west, south];
+    var topLeft = [west, north];
+    var topRight = [east, north];
+    var lowRight = [east, south];
 
     return polygon([[
         lowLeft,

--- a/packages/turf-bbox-polygon/index.js
+++ b/packages/turf-bbox-polygon/index.js
@@ -16,6 +16,9 @@ import { polygon, validateBBox } from '@turf/helpers';
  */
 function bboxPolygon(bbox) {
     validateBBox(bbox);
+    // Convert BBox positions to Numbers
+    // No performance loss for including Number()
+    // https://github.com/Turfjs/turf/issues/1119
     var west = Number(bbox[0]);
     var south = Number(bbox[1]);
     var east = Number(bbox[2]);

--- a/packages/turf-bbox-polygon/test.js
+++ b/packages/turf-bbox-polygon/test.js
@@ -1,16 +1,15 @@
 import test from 'tape';
 import bboxPolygon from '.';
 
-test('bboxPolygon', t => {
-    t.plan(2);
-
+test('bbox-polygon', t => {
     const poly = bboxPolygon([0, 0, 10, 10]);
 
     t.ok(poly.geometry.coordinates, 'should take a bbox and return the equivalent polygon feature');
     t.equal(poly.geometry.type, 'Polygon', 'should be a Polygon geometry type');
+    t.end()
 });
 
-test('bboxPolygon valid geojson', t => {
+test('bbox-polygon -- valid geojson', t => {
     const poly = bboxPolygon([0, 0, 10, 10]);
     const coordinates = poly.geometry.coordinates;
 
@@ -20,3 +19,20 @@ test('bboxPolygon valid geojson', t => {
     t.equal(coordinates[0][0][1], coordinates[0][coordinates.length - 1][1]);
     t.end();
 });
+
+test('bbox-polygon -- handling String input/output', t => {
+    const poly = bboxPolygon(['0', '0', '10', '10'])
+
+    t.deepEqual(poly.geometry.coordinates[0][0], [0, 0], 'lowLeft')
+    t.deepEqual(poly.geometry.coordinates[0][1], [10, 0], 'lowRight')
+    t.deepEqual(poly.geometry.coordinates[0][2], [10, 10], 'topRight')
+    t.deepEqual(poly.geometry.coordinates[0][3], [0, 10], 'topLeft')
+    t.end();
+})
+
+test('bbox-polygon -- Error handling', t => {
+    t.throws(() => bboxPolygon([-110, 70, 5000, 50, 60, 3000]), '6 position BBox not supported');
+    t.throws(() => bboxPolygon(['foo', 'bar', 'hello', 'world']), 'invalid bbox');
+    t.throws(() => bboxPolygon(['foo', 'bar']), 'invalid bbox');
+    t.end();
+})

--- a/packages/turf-bbox-polygon/test.js
+++ b/packages/turf-bbox-polygon/test.js
@@ -20,6 +20,7 @@ test('bbox-polygon -- valid geojson', t => {
     t.end();
 });
 
+// https://github.com/Turfjs/turf/issues/1119
 test('bbox-polygon -- handling String input/output', t => {
     const poly = bboxPolygon(['0', '0', '10', '10'])
 

--- a/packages/turf-helpers/index.js
+++ b/packages/turf-helpers/index.js
@@ -688,6 +688,9 @@ export function validateBBox(bbox) {
     if (!bbox) throw new Error('bbox is required');
     if (!Array.isArray(bbox)) throw new Error('bbox must be an Array');
     if (bbox.length !== 4 && bbox.length !== 6) throw new Error('bbox must be an Array of 4 or 6 numbers');
+    bbox.forEach(function (num) {
+        if (!isNumber(num)) throw new Error('bbox must only contain numbers');
+    });
 }
 
 /**


### PR DESCRIPTION
## Add input validation to `@turf/bbox-polygon`

Fixes Issue #1119 

Now checks if BBox is valid and handles converts String to Numbers (if they are valid strings that are considered numbers).

## Example

```js
const poly = bboxPolygon(['0', '0', '10', '10'])
//= poly's coordinates are now Floats/Integers

bboxPolygon(['foo', 'bar', 'hello', 'world'])
//= throws Error since bbox has invalid inputs

bboxPolygon(['0', '0', '2000', '10', '10', '3000'])
//= throws Error - 6 position BBox is valid, however not widely supported in TurfJS
```