### PR TITLE
Add documentation yaml to turf main

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -1,0 +1,184 @@
+toc:
+  - name: Measurement
+  - along
+  - area
+  - bbox
+  - bboxClip
+  - bboxPolygon
+  - bearing
+  - center
+  - centerOfMass
+  - centroid
+  - destination
+  - distance
+  - envelope
+  - length
+  - midpoint
+  - pointOnFeature
+  - polygonTangents
+  - pointToLineDistance
+  - rhumbBearing
+  - rhumbDestination
+  - rhumbDistance
+  - square
+  - greatCircle
+  - name: Coordinate Mutation
+  - cleanCoords
+  - flip
+  - rewind
+  - round
+  - truncate
+  - name: Transformation
+  - bboxClip
+  - bezierSpline
+  - buffer
+  - circle
+  - clone
+  - concave
+  - convex
+  - difference
+  - dissolve
+  - intersect
+  - lineOffset
+  - simplify
+  - tesselate
+  - transformRotate
+  - transformTranslate
+  - transformScale
+  - union
+  - voronoi
+  - name: Feature Conversion
+  - combine
+  - explode
+  - flatten
+  - lineToPolygon
+  - polygonize
+  - polygonToLine
+  - name: Misc
+  - kinks
+  - lineArc
+  - lineChunk
+  - lineIntersect
+  - lineOverlap
+  - lineSegment
+  - lineSlice
+  - lineSliceAlong
+  - lineSplit
+  - mask
+  - nearestPointOnLine
+  - sector
+  - shortestPath
+  - unkinkPolygon
+  - name: Helper
+  - featureCollection
+  - feature
+  - geometryCollection
+  - lineString
+  - multiLineString
+  - multiPoint
+  - multiPolygon
+  - point
+  - polygon
+  - name: Random
+  - randomPosition
+  - randomPoint
+  - randomLineString
+  - randomPolygon
+  - name: Data
+  - sample
+  - name: Interpolation
+  - interpolate
+  - isobands
+  - isolines
+  - planepoint
+  - tin
+  - name: Joins
+  - pointsWithinPolygon
+  - tag
+  - name: Grids
+  - hexGrid
+  - pointGrid
+  - squareGrid
+  - triangleGrid
+  - name: Classification
+  - nearestPoint
+  - name: Aggregation
+  - collect
+  - clustersDbscan
+  - clustersKmeans
+  - name: Meta
+  - coordAll
+  - coordEach
+  - coordReduce
+  - featureEach
+  - featureReduce
+  - flattenEach
+  - flattenReduce
+  - getCoord
+  - getCoords
+  - getGeom
+  - getType
+  - geomEach
+  - geomReduce
+  - propEach
+  - propReduce
+  - segmentEach
+  - segmentReduce
+  - getCluster
+  - clusterEach
+  - clusterReduce
+  - name: Assertions
+  - collectionOf
+  - containsNumber
+  - geojsonType
+  - featureOf
+  - name: Booleans
+  - booleanClockwise
+  - booleanContains
+  - booleanCrosses
+  - booleanDisjoint
+  - booleanEqual
+  - booleanOverlap
+  - booleanParallel
+  - booleanPointInPolygon
+  - booleanPointOnLine
+  - booleanWithin
+  - name: Unit Conversion
+  - bearingToAzimuth
+  - convertArea
+  - convertLength
+  - degreesToRadians
+  - lengthToRadians
+  - lengthToDegrees
+  - radiansToLength
+  - radiansToDegrees
+  - toMercator
+  - toWgs84
+paths:
+    GeoJSON: 'http://geojson.org/geojson-spec.html#geojson-objects'
+    GeometryCollection: 'http://geojson.org/geojson-spec.html#geometrycollection'
+    Point: 'http://geojson.org/geojson-spec.html#point'
+    Points: 'http://geojson.org/geojson-spec.html#point'
+    (Multi)Point: 'http://geojson.org/geojson-spec.html#point'
+    (Multi)Points: 'http://geojson.org/geojson-spec.html#point'
+    (Multi)Point(s): 'http://geojson.org/geojson-spec.html#point'
+    MultiPoint: 'http://geojson.org/geojson-spec.html#multipoint'
+    MultiPoints: 'http://geojson.org/geojson-spec.html#multipoint'
+    LineString: 'http://geojson.org/geojson-spec.html#linestring'
+    LineStrings: 'http://geojson.org/geojson-spec.html#linestring'
+    (Multi)LineString: 'http://geojson.org/geojson-spec.html#linestring'
+    (Multi)LineStrings: 'http://geojson.org/geojson-spec.html#linestring'
+    (Multi)LineString(s): 'http://geojson.org/geojson-spec.html#linestring'
+    MultiLineString: 'http://geojson.org/geojson-spec.html#multilinestring'
+    MultiLineStrings: 'http://geojson.org/geojson-spec.html#multilinestring'
+    Polygon: 'http://geojson.org/geojson-spec.html#polygon'
+    Polygons: 'http://geojson.org/geojson-spec.html#polygon'
+    (Multi)Polygon: 'http://geojson.org/geojson-spec.html#polygon'
+    (Multi)Polygons: 'http://geojson.org/geojson-spec.html#polygon'
+    (Multi)Polygon(s): 'http://geojson.org/geojson-spec.html#polygon'
+    MultiPolygon: 'http://geojson.org/geojson-spec.html#multipolygon'
+    MultiPolygons: 'http://geojson.org/geojson-spec.html#multipolygon'
+    Geometry: 'http://geojson.org/geojson-spec.html#geometry'
+    Feature: 'http://geojson.org/geojson-spec.html#feature-objects'
+    Features: 'http://geojson.org/geojson-spec.html#feature-objects'
+    FeatureCollection: 'http://geojson.org/geojson-spec.html#feature-collection-objects'

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "@types/geojson": "*",
     "@types/node": "*",
     "@types/tape": "*",
+    "babel-plugin-external-helpers": "*",
+    "babel-preset-env": "*",
     "camelcase": "*",
     "d3-queue": "*",
     "decamelize": "*",
@@ -65,10 +67,9 @@
     "load-json-file": "*",
     "meow": "*",
     "progress": "*",
-    "babel-plugin-external-helpers": "*",
-    "babel-preset-env": "*",
     "tape": "*",
-    "typescript": "*"
+    "typescript": "*",
+    "yamljs": "*"
   },
   "@std/esm": {
     "esm": "js",

--- a/scripts/generate-readmes
+++ b/scripts/generate-readmes
@@ -5,6 +5,7 @@ const glob = require('glob');
 const path = require('path');
 const load = require('load-json-file');
 const documentation = require('documentation');
+const yaml = require('yamljs');
 
 /**
  * When firing `npm run docs`:
@@ -19,34 +20,7 @@ const packages = currentFolder.includes('turf-') ?
 // Template for README Markdown
 const postfix = fs.readFileSync(path.join(__dirname, 'postfix.md'), 'utf8');
 
-const paths = {
-    GeoJSON: 'http://geojson.org/geojson-spec.html#geojson-objects',
-    GeometryCollection: 'http://geojson.org/geojson-spec.html#geometrycollection',
-    Point: 'http://geojson.org/geojson-spec.html#point',
-    Points: 'http://geojson.org/geojson-spec.html#point',
-    '(Multi)Point': 'http://geojson.org/geojson-spec.html#point',
-    '(Multi)Points': 'http://geojson.org/geojson-spec.html#point',
-    '(Multi)Point(s)': 'http://geojson.org/geojson-spec.html#point',
-    MultiPoint: 'http://geojson.org/geojson-spec.html#multipoint',
-    MultiPoints: 'http://geojson.org/geojson-spec.html#multipoint',
-    LineString: 'http://geojson.org/geojson-spec.html#linestring',
-    LineStrings: 'http://geojson.org/geojson-spec.html#linestring',
-    '(Multi)LineString': 'http://geojson.org/geojson-spec.html#linestring',
-    '(Multi)LineStrings': 'http://geojson.org/geojson-spec.html#linestring',
-    '(Multi)LineString(s)': 'http://geojson.org/geojson-spec.html#linestring',
-    MultiLineString: 'http://geojson.org/geojson-spec.html#multilinestring',
-    MultiLineStrings: 'http://geojson.org/geojson-spec.html#multilinestring',
-    Polygon: 'http://geojson.org/geojson-spec.html#polygon',
-    Polygons: 'http://geojson.org/geojson-spec.html#polygon',
-    '(Multi)Polygon': 'http://geojson.org/geojson-spec.html#polygon',
-    '(Multi)Polygons': 'http://geojson.org/geojson-spec.html#polygon',
-    '(Multi)Polygon(s)': 'http://geojson.org/geojson-spec.html#polygon',
-    MultiPolygon: 'http://geojson.org/geojson-spec.html#multipolygon',
-    MultiPolygons: 'http://geojson.org/geojson-spec.html#multipolygon',
-    Geometry: 'http://geojson.org/geojson-spec.html#geometry',
-    Feature: 'http://geojson.org/geojson-spec.html#feature-objects',
-    FeatureCollection: 'http://geojson.org/geojson-spec.html#feature-collection-objects'
-};
+const paths = yaml.parse(fs.readFileSync(path.join(__dirname, '..', 'documentation.yml'), 'utf8')).paths;
 
 packages.forEach(packagePath => {
     const directory = path.parse(packagePath).dir;


### PR DESCRIPTION
## Add documentation yaml to turf main

Ref: https://github.com/Turfjs/turf/issues/1146

To prevent any missing links or incorrect links between Turf's README & the website, it's better to maintain a single `documentation.yml` in the main TurfJS repo.

Both [`scripts/generate-readmes`](https://github.com/Turfjs/turf/blob/master/scripts/generate-readmes) & [`scripts/create-config.js`](https://github.com/Turfjs/turf-www/blob/master/scripts/create-config.js) will now depend on the same YAML config file.