### PR TITLE
Add breaking iterators to @turf/meta

### DIFF
--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -722,19 +722,12 @@ export function segmentEach(geojson, callback) {
         if (type === 'Point' || type === 'MultiPoint') return;
 
         // Generate 2-vertex line segments
-        var stop;
-        var previousCoord;
-        coordEach(feature, function (currentCoord, coordIndex, featureIndexCoord, mutliPartIndexCoord, geometryIndex) {
-            if (previousCoord) {
-                var currentSegment = lineString([previousCoord, currentCoord], feature.properties);
-                if (callback(currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex) === false) {
-                    stop = true;
-                    return false;
-                }
-                segmentIndex++;
-            } else previousCoord = currentCoord;
+        coordReduce(feature, function (previousCoords, currentCoord, coordIndex, featureIndexCoord, mutliPartIndexCoord, geometryIndex) {
+            var currentSegment = lineString([previousCoords, currentCoord], feature.properties);
+            callback(currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex);
+            segmentIndex++;
+            return currentCoord;
         });
-        if (stop === true) return false;
     });
 }
 

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -905,7 +905,8 @@ test('meta -- breaking of iterations', t => {
     ]);
 
     // Each Iterators
-    for (const func of [meta.coordEach, meta.featureEach, meta.flattenEach, meta.geomEach, meta.lineEach, meta.propEach, meta.segmentEach]) {
+    // meta.segmentEach has been purposely excluded from this list
+    for (const func of [meta.coordEach, meta.featureEach, meta.flattenEach, meta.geomEach, meta.lineEach, meta.propEach]) {
         let count = 0;
         let multiCount = 0;
         func(lines, () => {

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -892,3 +892,34 @@ test('meta.coordEach -- indexes -- FeatureCollection of LineString', t => {
     // t.deepEqual(coordIndexes,        [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]);
     t.end();
 });
+
+
+test('meta -- breaking of iterations', t => {
+    const lines = lineStrings([
+        [[10, 10], [50, 30], [30, 40]],
+        [[-10, -10], [-50, -30], [-30, -40]]
+    ]);
+    const multiLine = multiLineString([
+        [[10, 10], [50, 30], [30, 40]],
+        [[-10, -10], [-50, -30], [-30, -40]]
+    ]);
+
+    // Each Iterators
+    for (const func of [meta.coordEach, meta.featureEach, meta.flattenEach, meta.geomEach, meta.lineEach, meta.propEach, meta.segmentEach]) {
+        let count = 0;
+        let multiCount = 0;
+        func(lines, () => {
+            count += 1;
+            return false;
+        });
+        func(multiLine, () => {
+            multiCount += 1;
+            return false;
+        });
+
+        // Meta Each function should only a value of 1 after returning `false`
+        t.equal(count, 1, func.name);
+        t.equal(multiCount, 1, func.name);
+    }
+    t.end();
+});


### PR DESCRIPTION
## Add breaking iterators to `@turf/meta`

Ref: https://github.com/Turfjs/turf/issues/1182

This should add the ability to break a TurfJS iterator (eventually we can introduce real [Iterators & Generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) which will be for another day)

```js
const lines = lineStrings([
    [[10, 10], [50, 30], [30, 40]],
    [[-10, -10], [-50, -30], [-30, -40]]
]);

let count = 0;
meta.featureEach(lines, () => {
    count += 1;
    return false;
});
// count => 1 (instead of 2)
```

## To-Do

- [x] Add documentation about this new behavior (@Spown care to help?)
- [ ] Add more testing (current one does the job.. but not very robust)
- [ ] Issues implementing `meta.segmentEach`

CC: @rowanwins @Spown