### PR TITLE
turf-points-within-polygon: fixed typo + dedupe results + added test case

### DIFF
--- a/packages/turf-points-within-polygon/README.md
+++ b/packages/turf-points-within-polygon/README.md
@@ -9,7 +9,7 @@ Finds [Points](https://tools.ietf.org/html/rfc7946#section-3.1.2) that fall with
 **Parameters**
 
 -   `points` **(Feauture | [FeatureCollection](https://tools.ietf.org/html/rfc7946#section-3.3)&lt;[Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)>)** Points as input search
--   `polygons` **([FeatureCollection](https://tools.ietf.org/html/rfc7946#section-3.3) | Geoemtry | [Feature](https://tools.ietf.org/html/rfc7946#section-3.2)&lt;([Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) \| [MultiPolygon](https://tools.ietf.org/html/rfc7946#section-3.1.7))>)** Points must be within these (Multi)Polygon(s)
+-   `polygons` **([FeatureCollection](https://tools.ietf.org/html/rfc7946#section-3.3) \| [Geometry](https://tools.ietf.org/html/rfc7946#section-3.1) \| [Feature](https://tools.ietf.org/html/rfc7946#section-3.2)&lt;([Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) \| [MultiPolygon](https://tools.ietf.org/html/rfc7946#section-3.1.7))>)** Points must be within these (Multi)Polygon(s)
 
 **Examples**
 

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -39,15 +39,16 @@ import { geomEach, featureEach } from '@turf/meta';
  */
 function pointsWithinPolygon(points, polygons) {
     var results = [];
-    geomEach(polygons, function (polygon) {
-        featureEach(points, function (point) {
-            if (pointInPolygon(point, polygon)) results.push(point);
+    featureEach(points, function (point) {
+        var contained = false;
+        geomEach(polygons, function (polygon) {
+            if (pointInPolygon(point, polygon)) contained = true;
         });
+        if (contained) {
+            results.push(point);
+        }
     });
-    var unique = results.filter(function (point, pos, arr) {
-        return arr.indexOf(point) === pos;
-    });
-    return featureCollection(unique);
+    return featureCollection(results);
 }
 
 export default pointsWithinPolygon;

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -44,7 +44,10 @@ function pointsWithinPolygon(points, polygons) {
             if (pointInPolygon(point, polygon)) results.push(point);
         });
     });
-    return featureCollection(results);
+    var unique = results.filter(function (point, pos, arr) {
+        return arr.indexOf(point) === pos;
+    });
+    return featureCollection(unique);
 }
 
 export default pointsWithinPolygon;

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -7,7 +7,7 @@ import { geomEach, featureEach } from '@turf/meta';
  *
  * @name pointsWithinPolygon
  * @param {Feauture|FeatureCollection<Point>} points Points as input search
- * @param {FeatureCollection|Geoemtry|Feature<Polygon|MultiPolygon>} polygons Points must be within these (Multi)Polygon(s)
+ * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons Points must be within these (Multi)Polygon(s)
  * @returns {FeatureCollection<Point>} points that land within at least one polygon
  * @example
  * var points = turf.points([

--- a/packages/turf-points-within-polygon/test.js
+++ b/packages/turf-points-within-polygon/test.js
@@ -56,4 +56,16 @@ test('turf-points-within-polygon -- support extra geometry', t => {
     t.assert(pointsWithinPolygon(pts.features[0], searchWithin));
     t.assert(pointsWithinPolygon(pts, searchWithin.geometry));
     t.end()    
-})
+});
+
+test('turf-points-within-polygon -- no duplicates when multiple geometry contain a point', t => {
+    const poly1 = polygon([[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]);
+    const poly2 = polygon([[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]);
+    const polyFC = featureCollection([poly1, poly2]);
+    const pt1 = point([5, 5]);
+    const ptFC = featureCollection([pt1]);
+
+    const counted = pointsWithinPolygon(ptFC, polyFC);
+    t.equal(counted.features.length, 1, 'although point is contained by two polygons it is only counted once');
+    t.end();
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

First change: there was a typo in the parameter type (Geoemtry -> Geometry)
Second change: whenever you pass polygons that overlap to this function, and if a point is contained by both polygons, then the point would end up twice in the resulting array. I've added a test case which disallows this behavior and also implemented a fix.