### PR TITLE
turf-meta: fix geomEach type

### DIFF
--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -105,9 +105,9 @@ export function geomReduce<Reducer extends any, G extends Geometries, P = Proper
 /**
  * http://turfjs.org/docs/#geomeach
  */
-export function geomEach<G extends Geometries, P = Properties>(
+export function geomEach<G extends (Geometries | null), P = Properties>(
     geojson: Feature<G, P> | FeatureCollection<G, P> | G | GeometryCollection | Feature<GeometryCollection, P>,
-    callback: (currentGeometry: G | null,
+    callback: (currentGeometry: G,
                featureIndex: number,
                featureProperties: P,
                featureBBox: BBox,

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -107,7 +107,7 @@ export function geomReduce<Reducer extends any, G extends Geometries, P = Proper
  */
 export function geomEach<G extends Geometries, P = Properties>(
     geojson: Feature<G, P> | FeatureCollection<G, P> | G | GeometryCollection | Feature<GeometryCollection, P>,
-    callback: (currentGeometry: G,
+    callback: (currentGeometry: G | null,
                featureIndex: number,
                featureProperties: P,
                featureBBox: BBox,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

When calling geomEach with a null geometry feature, then the callback is invoked with null as the geometry. This is not reflected in the typings where only Geometries is mentioned. This PR adds possible null value to the type.