### PR TITLE
Add mutate options to clusters & update Typescript definitions

### DIFF
--- a/packages/turf-clusters-dbscan/index.d.ts
+++ b/packages/turf-clusters-dbscan/index.d.ts
@@ -1,17 +1,9 @@
-import { Units, FeatureCollection, Point, Feature } from '@turf/helpers';
+import { Units, FeatureCollection, Properties, Point, Feature } from '@turf/helpers';
 
 export type Dbscan = 'core' | 'edge' | 'noise'
-export interface DbscanProps {
+export interface DbscanProps extends Properties {
     dbscan?: Dbscan;
     cluster?: number;
-    [key: string]: any;
-}
-export interface DbscanPoint extends Feature<Point> {
-    properties: DbscanProps
-}
-export interface DbscanPoints {
-    type: 'FeatureCollection'
-    features: DbscanPoint[];
 }
 
 /**
@@ -22,7 +14,8 @@ export default function (
     maxDistance: number,
     options?: {
         units?: Units,
-        minPoints?: number
+        minPoints?: number,
+        mutate?: boolean
     }
-): DbscanPoints;
+): FeatureCollection<Point, DbscanProps>;
 

--- a/packages/turf-clusters-dbscan/index.js
+++ b/packages/turf-clusters-dbscan/index.js
@@ -12,7 +12,8 @@ import clustering from 'density-clustering';
  * @param {FeatureCollection<Point>} points to be clustered
  * @param {number} maxDistance Maximum Distance between any point of the cluster to generate the clusters (kilometers only)
  * @param {Object} [options={}] Optional parameters
- * @param {string} [options.units=kilometers] in which `maxDistance` is expressed, can be degrees, radians, miles, or kilometers
+ * @param {string} [options.units="kilometers"] in which `maxDistance` is expressed, can be degrees, radians, miles, or kilometers
+ * @param {boolean} [options.mutate=false] Allows GeoJSON input to be mutated
  * @param {number} [options.minPoints=3] Minimum number of points to generate a single cluster,
  * points which do not meet this requirement will be classified as an 'edge' or 'noise'.
  * @returns {FeatureCollection<Point>} Clustered Points with an additional two properties associated to each Feature:
@@ -32,23 +33,22 @@ function clustersDbscan(points, maxDistance, options) {
     options = options || {};
     if (typeof options !== 'object') throw new Error('options is invalid');
     var minPoints = options.minPoints;
-    var units = options.units;
 
     // Input validation
-    collectionOf(points, 'Point', 'Input must contain Points');
+    collectionOf(points, 'Point', 'points must consist of a FeatureCollection of only Points');
     if (maxDistance === null || maxDistance === undefined) throw new Error('maxDistance is required');
-    if (!(Math.sign(maxDistance) > 0)) throw new Error('Invalid maxDistance');
-    if (!(minPoints === undefined || minPoints === null || Math.sign(minPoints) > 0)) throw new Error('Invalid minPoints');
+    if (!(Math.sign(maxDistance) > 0)) throw new Error('maxDistance is invalid');
+    if (!(minPoints === undefined || minPoints === null || Math.sign(minPoints) > 0)) throw new Error('options.minPoints is invalid');
 
     // Clone points to prevent any mutations
-    points = clone(points, true);
+    if (options.mutate !== true) points = clone(points, true);
 
     // Defaults
     minPoints = minPoints || 3;
 
     // create clustered ids
     var dbscan = new clustering.DBSCAN();
-    var clusteredIds = dbscan.run(coordAll(points), convertLength(maxDistance, units), minPoints, distance);
+    var clusteredIds = dbscan.run(coordAll(points), convertLength(maxDistance, options.units), minPoints, distance);
 
     // Tag points to Clusters ID
     var clusterId = -1;

--- a/packages/turf-clusters-dbscan/test.js
+++ b/packages/turf-clusters-dbscan/test.js
@@ -53,13 +53,13 @@ const points = featureCollection([
 
 test('clusters-dbscan -- throws', t => {
     const poly = polygon([[[0, 0], [10, 10], [0, 10], [0, 0]]]);
-    t.throws(() => clustersDbscan(poly, 1), /Input must contain Points/);
+    t.throws(() => clustersDbscan(poly, 1), /points must consist of a FeatureCollection of only Points/);
     t.throws(() => clustersDbscan(points), /maxDistance is required/);
-    t.throws(() => clustersDbscan(points, -4), /Invalid maxDistance/);
-    t.throws(() => clustersDbscan(points, 'foo'), /Invalid maxDistance/);
+    t.throws(() => clustersDbscan(points, -4), /maxDistance is invalid/);
+    t.throws(() => clustersDbscan(points, 'foo'), /maxDistance is invalid/);
     t.throws(() => clustersDbscan(points, 1, {units: 'nanometers'}), /units is invalid/);
-    t.throws(() => clustersDbscan(points, 1, {units: null, minPoints: 0}), /Invalid minPoints/);
-    t.throws(() => clustersDbscan(points, 1, {units: 'miles', minPoints: 'baz'}), /Invalid minPoints/);
+    t.throws(() => clustersDbscan(points, 1, {units: null, minPoints: 0}), /minPoints is invalid/);
+    t.throws(() => clustersDbscan(points, 1, {units: 'miles', minPoints: 'baz'}), /minPoints is invalid/);
     t.end();
 });
 
@@ -124,3 +124,20 @@ function styleResult(clustered) {
     });
     return featureCollection(features);
 }
+
+test('clusters-dbscan -- allow input mutation', t => {
+    const oldPoints = featureCollection([
+        point([0, 0], {foo: 'bar'}),
+        point([2, 4], {foo: 'bar'}),
+        point([3, 6], {foo: 'bar'})
+    ]);
+    // No mutation
+    const newPoints = clustersDbscan(points, 2, {minPoints: 1});
+    t.equal(newPoints.features[1].properties.cluster, 1, 'cluster is 1')
+    t.equal(oldPoints.features[1].properties.cluster, undefined, 'cluster is undefined')
+
+    // Allow mutation
+    clustersDbscan(oldPoints, 2, {minPoints: 1, mutate: true});
+    t.equal(oldPoints.features[1].properties.cluster, 1, 'cluster is 1')
+    t.end()
+})

--- a/packages/turf-clusters-dbscan/types.ts
+++ b/packages/turf-clusters-dbscan/types.ts
@@ -26,3 +26,8 @@ const units = 'miles';
 clustersDbscan(points, maxDistance);
 clustersDbscan(points, maxDistance, {units});
 clustersDbscan(points, maxDistance, {units, minPoints});
+
+// Custom Properties
+clustered.features[0].properties.cluster
+clustered.features[0].properties.dbscan
+clustered.features[0].properties.foo

--- a/packages/turf-clusters-kmeans/index.d.ts
+++ b/packages/turf-clusters-kmeans/index.d.ts
@@ -1,16 +1,8 @@
-import { Point, Feature, FeatureCollection } from '@turf/helpers';
+import { Point, Feature, FeatureCollection, Properties } from '@turf/helpers';
 
-export interface KmeansProps {
+export interface KmeansProps extends Properties {
     cluster?: number;
     centroid?: [number, number];
-    [key: string]: any;
-}
-export interface KmeansPoint extends Feature<Point> {
-    properties: KmeansProps
-}
-export interface KmeansPoints {
-    type: 'FeatureCollection'
-    features: KmeansPoint[];
 }
 
 /**
@@ -22,4 +14,4 @@ export default function (
         numberOfClusters?: number,
         mutate?: boolean
     }
-): KmeansPoints;
+): FeatureCollection<Point, KmeansProps>;

--- a/packages/turf-clusters-kmeans/index.js
+++ b/packages/turf-clusters-kmeans/index.js
@@ -29,7 +29,6 @@ function clustersKmeans(points, options) {
     options = options || {};
     if (typeof options !== 'object') throw new Error('options is invalid');
     var numberOfClusters = options.numberOfClusters;
-    var mutate = options.mutate;
 
     // Input validation
     collectionOf(points, 'Point', 'Input must contain Points');
@@ -43,7 +42,7 @@ function clustersKmeans(points, options) {
     if (numberOfClusters > count) numberOfClusters = count;
 
     // Clone points to prevent any mutations (enabled by default)
-    if (mutate === false || mutate === undefined) points = clone(points, true);
+    if (options.mutate !== true) points = clone(points, true);
 
     // collect points coordinates
     var data = coordAll(points);

--- a/packages/turf-clusters-kmeans/test.js
+++ b/packages/turf-clusters-kmeans/test.js
@@ -46,13 +46,6 @@ const points = featureCollection([
     point([3, 6], {foo: 'bar'})
 ]);
 
-test('clusters-kmeans -- prevent input mutation', t => {
-    const before = JSON.parse(JSON.stringify(points));
-    clustersKmeans(points);
-    t.deepEqual(before, points);
-    t.end();
-});
-
 test('clusters-kmeans -- throws', t => {
     const poly = polygon([[[0, 0], [10, 10], [0, 10], [0, 0]]]);
     t.throws(() => clustersKmeans(poly, {numberOfClusters: 1}), /Input must contain Points/);
@@ -99,3 +92,20 @@ function styleResult(clustered) {
     });
     return featureCollection(features);
 }
+
+test('clusters-kmeans -- allow input mutation', t => {
+    const oldPoints = featureCollection([
+        point([0, 0], {foo: 'bar'}),
+        point([2, 4], {foo: 'bar'}),
+        point([3, 6], {foo: 'bar'})
+    ]);
+    // No mutation
+    const newPoints = clustersKmeans(points, {numberOfClusters: 3});
+    t.equal(newPoints.features[1].properties.cluster, 1, 'cluster is 1');
+    t.equal(oldPoints.features[1].properties.cluster, undefined, 'cluster is undefined');
+
+    // Allow mutation
+    clustersKmeans(oldPoints, {numberOfClusters: 2, mutate: true});
+    t.equal(oldPoints.features[1].properties.cluster, 1, 'cluster is 1');
+    t.end()
+})

--- a/packages/turf-clusters-kmeans/types.ts
+++ b/packages/turf-clusters-kmeans/types.ts
@@ -20,3 +20,8 @@ centroid = [-110, 85]
 clustersKmeans(points)
 clustersKmeans(points, {numberOfClusters})
 clustersKmeans(points, {numberOfClusters, mutate: true})
+
+// Custom Properties
+clustered.features[0].properties.centroid
+clustered.features[0].properties.cluster
+clustered.features[0].properties.foo

--- a/packages/turf-clusters/index.d.ts
+++ b/packages/turf-clusters/index.d.ts
@@ -1,27 +1,27 @@
-import { FeatureCollection, GeometryObject, Feature } from '@turf/helpers'
+import { FeatureCollection, GeometryObject, Feature, Properties } from '@turf/helpers'
 /**
  * http://turfjs.org/docs/#getcluster
  */
-export function getCluster<T extends GeometryObject>(
-    geojson: FeatureCollection<T>,
+export function getCluster<T extends GeometryObject, P = Properties>(
+    geojson: FeatureCollection<T, P>,
     filter: any
-): FeatureCollection<T>;
+): FeatureCollection<T, P>;
 
 /**
  * http://turfjs.org/docs/#clustereach
  */
-export function clusterEach<T extends GeometryObject>(
-    geojson: FeatureCollection<T>,
+export function clusterEach<T extends GeometryObject, P = Properties>(
+    geojson: FeatureCollection<T, P>,
     property: number | string,
-    callback: (cluster?: FeatureCollection<T>, clusterValue?: any, currentIndex?: number) => void
+    callback: (cluster?: FeatureCollection<T, P>, clusterValue?: any, currentIndex?: number) => void
 ): void;
 
 /**
  * http://turfjs.org/docs/#clusterreduce
  */
-export function clusterReduce<T extends GeometryObject>(
-    geojson: FeatureCollection<T>,
+export function clusterReduce<T extends GeometryObject, P = Properties>(
+    geojson: FeatureCollection<T, P>,
     property: number | string,
-    callback: (previousValue?: any, cluster?: FeatureCollection<T>, clusterValue?: any, currentIndex?: number) => void,
+    callback: (previousValue?: any, cluster?: FeatureCollection<T, P>, clusterValue?: any, currentIndex?: number) => void,
     initialValue?: any
 ): void;

--- a/packages/turf-clusters/types.ts
+++ b/packages/turf-clusters/types.ts
@@ -66,3 +66,25 @@ const totalReduce = clusterReduce(geojson, 'cluster', function (previousValue) {
 const valuesReduce = clusterReduce(geojson, 'cluster', function (previousValue, cluster, clusterValue) {
     return previousValue.concat(clusterValue);
 }, []);
+
+/**
+ * Custom Properties
+ */
+const customPoints = featureCollection([
+    point([0, 0], {cluster: 0}),
+    point([2, 4], {cluster: 1}),
+    point([3, 6], {cluster: 1})
+]);
+
+getCluster(customPoints, {cluster: 1}).features[0].properties.cluster
+// getCluster(customPoints, {cluster: 1}).features[0].properties.foo // [ts] Property 'foo' does not exist on type '{ cluster: number; }'.
+
+clusterEach(customPoints, 'cluster', cluster => {
+    cluster.features[0].properties.cluster
+    // cluster.features[0].properties.foo // [ts] Property 'foo' does not exist on type '{ cluster: number; }'.
+})
+
+clusterReduce(customPoints, 'cluster', (previousValue, cluster) => {
+    cluster.features[0].properties.cluster
+    // cluster.features[0].properties.foo // [ts] Property 'foo' does not exist on type '{ cluster: number; }'.
+})


### PR DESCRIPTION
## Add mutate options to clusters & update Typescript definitions

Ref: https://github.com/Turfjs/turf/issues/1183

- [x] Added `options.mutate` to `@turf/clusters-dbscan`
- [x] Add tests for input mutations
- [x] Updated Typescript definitions to translate Properties to Points
- [x] Add Typescript test to custom Properties