### PR TITLE
Increase 5x performance of invariant.getCoord()

### DIFF
--- a/packages/turf-invariant/README.md
+++ b/packages/turf-invariant/README.md
@@ -8,7 +8,7 @@ Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
 
 **Parameters**
 
--   `obj` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [Geometry](https://tools.ietf.org/html/rfc7946#section-3.1)&lt;[Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)> | [Feature](https://tools.ietf.org/html/rfc7946#section-3.2)&lt;[Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)>)** Object
+-   `coord` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [Geometry](https://tools.ietf.org/html/rfc7946#section-3.1)&lt;[Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)> | [Feature](https://tools.ietf.org/html/rfc7946#section-3.2)&lt;[Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)>)** GeoJSON Point or an Array of numbers
 
 **Examples**
 
@@ -27,7 +27,7 @@ Unwrap coordinates from a Feature, Geometry Object or an Array of numbers
 
 **Parameters**
 
--   `obj` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [Geometry](https://tools.ietf.org/html/rfc7946#section-3.1) \| [Feature](https://tools.ietf.org/html/rfc7946#section-3.2))** Object
+-   `obj` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;any> | [Geometry](https://tools.ietf.org/html/rfc7946#section-3.1) \| [Feature](https://tools.ietf.org/html/rfc7946#section-3.2))** Object
 
 **Examples**
 

--- a/packages/turf-invariant/bench.js
+++ b/packages/turf-invariant/bench.js
@@ -1,6 +1,6 @@
 import Benchmark from 'benchmark';
-import helpers from '@turf/helpers';
-import invariant from './';
+import * as helpers from '@turf/helpers';
+import * as invariant from './';
 
 const point = helpers.point([-75, 40]);
 const linestring = helpers.lineString([[-75, 40], [-70, 50]]);
@@ -9,8 +9,17 @@ const featureCollection = helpers.featureCollection([point, point]);
 
 const suite = new Benchmark.Suite('turf-invariant');
 
+/**
+ * Benchmark Results
+ *
+ * getCoord (BEFORE) x 14,586,933 ops/sec ±0.92% (88 runs sampled)
+ * getCoord x 49,812,538 ops/sec ±1.00% (87 runs sampled)
+ * getCoords.linestring x 1,407,538 ops/sec ±0.90% (90 runs sampled)
+ * getCoords.polygon x 1,270,899 ops/sec ±2.46% (84 runs sampled)
+ * collectionOf x 25,912,969 ops/sec ±1.52% (88 runs sampled)
+ */
 suite
-    .add('getCoord.point', () => { invariant.getCoord(point); })
+    .add('getCoord', () => { invariant.getCoord(point); })
     .add('getCoords.linestring', () => { invariant.getCoords(linestring); })
     .add('getCoords.polygon', () => { invariant.getCoords(polygon); })
     .add('collectionOf', () => { invariant.collectionOf(featureCollection, 'Point', 'bench'); })

--- a/packages/turf-invariant/index.d.ts
+++ b/packages/turf-invariant/index.d.ts
@@ -6,14 +6,16 @@ import {
     GeometryTypes,
     CollectionTypes,
     Types,
+    Point,
     AllGeoJSON,
-    Geometries
+    Geometries,
+    Position
 } from '@turf/helpers'
 
 /**
  * http://turfjs.org/docs/#getcoords
  */
-export function getCoord(obj: Feature<any> | GeometryObject | any[]): number[];
+export function getCoord<P extends Position>(coord: Feature<Point> | Point | P): P;
 
 /**
  * http://turfjs.org/docs/#getcoords

--- a/packages/turf-invariant/index.js
+++ b/packages/turf-invariant/index.js
@@ -4,7 +4,7 @@ import { isNumber } from '@turf/helpers';
  * Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
  *
  * @name getCoord
- * @param {Array<number>|Geometry<Point>|Feature<Point>} obj Object
+ * @param {Array<number>|Geometry<Point>|Feature<Point>} coord GeoJSON Point or an Array of numbers
  * @returns {Array<number>} coordinates
  * @example
  * var pt = turf.point([10, 10]);
@@ -12,24 +12,20 @@ import { isNumber } from '@turf/helpers';
  * var coord = turf.getCoord(pt);
  * //= [10, 10]
  */
-export function getCoord(obj) {
-    if (!obj) throw new Error('obj is required');
+export function getCoord(coord) {
+    if (!coord) throw new Error('coord is required');
+    if (coord.type === 'Feature' && coord.geometry !== null && coord.geometry.type === 'Point') return coord.geometry.coordinates;
+    if (coord.type === 'Point') return coord.coordinates;
+    if (coord.length >= 2 && coord[0].length === undefined && coord[1].length === undefined) return coord;
 
-    var coordinates = getCoords(obj);
-
-    // getCoord() must contain at least two numbers (Point)
-    if (coordinates.length > 1 && isNumber(coordinates[0]) && isNumber(coordinates[1])) {
-        return coordinates;
-    } else {
-        throw new Error('Coordinate is not a valid Point');
-    }
+    throw new Error('coord must be GeoJSON Point or an Array of numbers');
 }
 
 /**
  * Unwrap coordinates from a Feature, Geometry Object or an Array of numbers
  *
  * @name getCoords
- * @param {Array<number>|Geometry|Feature} obj Object
+ * @param {Array<any>|Geometry|Feature} obj Object
  * @returns {Array<number>} coordinates
  * @example
  * var poly = turf.polygon([[[119.32, -8.7], [119.55, -8.69], [119.51, -8.54], [119.32, -8.7]]]);

--- a/packages/turf-invariant/test.js
+++ b/packages/turf-invariant/test.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import { point, lineString, polygon, featureCollection, geometryCollection } from '@turf/helpers';
-import * as invariant from './index';
+import * as invariant from '.';
 
 test('invariant -- containsNumber', t => {
     t.equals(invariant.containsNumber([1, 1]), true);
@@ -144,11 +144,12 @@ test('invariant -- getCoord', t => {
         coordinates: [[1, 2], [3, 4]]
     }));
 
-    t.throws(() => invariant.getCoord(false));
-    t.throws(() => invariant.getCoord(null));
-    t.throws(() => invariant.getCoord(lineString([[1, 2], [3, 4]])));
-    t.throws(() => invariant.getCoord(['A', 'B', 'C']));
-    t.throws(() => invariant.getCoord([1, 'foo', 'bar']));
+    t.throws(() => invariant.getCoord(false), 'false should throw Error');
+    t.throws(() => invariant.getCoord(null), 'null should throw Error');
+    t.throws(() => invariant.getCoord(lineString([[1, 2], [3, 4]])), 'LineString is not a Point');
+    t.throws(() => invariant.getCoord([10]), 'Single number Array should throw Error');
+    t.throws(() => invariant.getCoord(['A', 'B']), 'Array of String should throw Error');
+    t.throws(() => invariant.getCoord([1, 'foo']), 'Mixed Array should throw Error');
 
     t.deepEqual(invariant.getCoord({
         type: 'Point',
@@ -219,7 +220,7 @@ test('null geometries', t => {
     };
     t.throws(() => invariant.getGeom(null), /geojson is required/, 'getGeom => geojson is required');
     t.throws(() => invariant.getCoords(nullFeature), /No valid coordinates/, 'getCoords => No valid coordinates');
-    t.throws(() => invariant.getCoord(nullFeature), /No valid coordinates/, 'getCoord => No valid coordinates');
+    t.throws(() => invariant.getCoord(nullFeature), /coord must be GeoJSON Point or an Array of numbers/, 'getCoord => coord must be GeoJSON Point or an Array of numbers');
 
     t.equal(invariant.getGeom(nullFeature), null, 'getGeom => null');
     t.end();

--- a/packages/turf-invariant/types.ts
+++ b/packages/turf-invariant/types.ts
@@ -1,10 +1,6 @@
 import * as invariant from './'
+import * as helpers from '@turf/helpers'
 import {
-    point,
-    lineString,
-    polygon,
-    geometryCollection,
-    featureCollection,
     Geometry,
     Types,
     GeometryCollection,
@@ -13,31 +9,21 @@ import {
     Polygon,
     GeometryTypes
 } from '@turf/helpers'
-import {
-    getCoord,
-    getCoords,
-    geojsonType,
-    featureOf,
-    collectionOf,
-    containsNumber,
-    getGeom,
-    getType
-} from './'
 
 /**
  * Fixtures
  */
-const pt = point([0, 0])
-const line = lineString([[0, 0], [1, 1]])
-const poly = polygon([[[0, 0], [1, 1], [2, 2], [0, 0]]])
-const gc = geometryCollection([pt.geometry, line.geometry, poly.geometry])
-const fc = featureCollection([pt, line, poly])
+const pt = helpers.point([0, 0])
+const line = helpers.lineString([[0, 0], [1, 1]])
+const poly = helpers.polygon([[[0, 0], [1, 1], [2, 2], [0, 0]]])
+const gc = helpers.geometryCollection([pt.geometry, line.geometry, poly.geometry])
+const fc = helpers.featureCollection([pt, line, poly])
 
 /**
  * invariant.getGeom
  */
 // invariant.getGeom(fc) // Argument of type 'FeatureCollection<any>' is not assignable to parameter of type
-getGeom(gc)
+invariant.getGeom(gc)
 const gcGeom: GeometryCollection  = invariant.getGeom(gc)
 const pointGeom: Point = invariant.getGeom(pt)
 const lineGeom: LineString = invariant.getGeom(line)
@@ -48,8 +34,17 @@ invariant.getGeom(pt.geometry)
  * invariant.getType
  */
 const type: GeometryTypes = invariant.getType(pt)
-if (getType(gc) === 'GeometryCollection') console;
-if (getType(line) === 'LineString') console;
-if (getType(poly) === 'Polygon') console;
-if (getType(pt.geometry) === 'Point') console;
-if (getType(fc) === 'FeatureCollection') console;
+invariant.getType(gc) === 'GeometryCollection'
+invariant.getType(line) === 'LineString'
+invariant.getType(poly) === 'Polygon'
+invariant.getType(pt.geometry) === 'Point'
+invariant.getType(fc) === 'FeatureCollection'
+
+/**
+ * getCoord
+ */
+invariant.getCoord(pt)
+invariant.getCoord(pt.geometry)
+invariant.getCoord(pt.geometry.coordinates)
+let coordZ: [number, number, number] = [10, 30, 2000]
+coordZ = invariant.getCoord(coordZ)

--- a/packages/turf-transform-rotate/test.js
+++ b/packages/turf-transform-rotate/test.js
@@ -41,7 +41,7 @@ test('rotate -- throws', t => {
 
     t.throws(() => rotate(null, 100), /geojson is required/, 'missing geojson');
     t.throws(() => rotate(line, null), /angle is required/, 'missing angle');
-    t.throws(() => rotate(line, 56, {pivot: 'notApoint'}), /coordinates must only contain numbers/, 'invalid pivot');
+    t.throws(() => rotate(line, 56, {pivot: 'notApoint'}), /coord must be GeoJSON Point or an Array of numbers/, 'coord must be GeoJSON Point or an Array of numbers');
     t.end();
 });
 


### PR DESCRIPTION
## Increase 5x performance of `invariant.getCoord()`

Ref: https://github.com/Turfjs/turf/issues/914#issuecomment-351806286

Tests remained unchanged, however performance is 5x faster than previous implementation.

Assumes when giving a `Feature<Point>` it already contains valid coordinates.

## Benchmark Results

```
getCoord (BEFORE) x 14,586,933 ops/sec ±0.92% (88 runs sampled)
getCoord x 49,812,538 ops/sec ±1.00% (87 runs sampled)
```