### PR TITLE
Allow stopping meta.segmentEach() callback iteration

### DIFF
--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -722,12 +722,18 @@ export function segmentEach(geojson, callback) {
         if (type === 'Point' || type === 'MultiPoint') return;
 
         // Generate 2-vertex line segments
-        coordReduce(feature, function (previousCoords, currentCoord, coordIndex, featureIndexCoord, mutliPartIndexCoord, geometryIndex) {
+        var previousCoords;
+        if (coordEach(feature, function (currentCoord, coordIndex, featureIndexCoord, mutliPartIndexCoord, geometryIndex) {
+            // Simulating a meta.coordReduce() since `reduce` operations cannot be stopped by returning `false`
+            if (previousCoords === undefined) {
+                previousCoords = currentCoord;
+                return;
+            }
             var currentSegment = lineString([previousCoords, currentCoord], feature.properties);
-            callback(currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex);
+            if (callback(currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex) === false) return false;
             segmentIndex++;
-            return currentCoord;
-        });
+            previousCoords = currentCoord;
+        }) === false) return false;
     });
 }
 

--- a/packages/turf-meta/test.js
+++ b/packages/turf-meta/test.js
@@ -906,20 +906,23 @@ test('meta -- breaking of iterations', t => {
 
     // Each Iterators
     // meta.segmentEach has been purposely excluded from this list
-    for (const func of [meta.coordEach, meta.featureEach, meta.flattenEach, meta.geomEach, meta.lineEach, meta.propEach]) {
+    for (const func of [meta.coordEach, meta.featureEach, meta.flattenEach, meta.geomEach, meta.lineEach, meta.propEach, meta.segmentEach]) {
+        // Meta Each function should only a value of 1 after returning `false`
+
+        // FeatureCollection
         let count = 0;
-        let multiCount = 0;
         func(lines, () => {
             count += 1;
             return false;
         });
+        t.equal(count, 1, func.name);
+
+        // Multi Geometry
+        let multiCount = 0;
         func(multiLine, () => {
             multiCount += 1;
             return false;
         });
-
-        // Meta Each function should only a value of 1 after returning `false`
-        t.equal(count, 1, func.name);
         t.equal(multiCount, 1, func.name);
     }
     t.end();


### PR DESCRIPTION
## Allow stopping meta.segmentEach() callback iteration

Ref: https://github.com/Turfjs/turf/pull/1185

Add support for `segmentEach` to break callback loop.