### PR TITLE
Expand other languages section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ TypeScript is supported internally within each module, no installs required.
 
 ### Other languages
 
-Ports of Turf.js are underway [in Swift](https://github.com/mapbox/turf-swift/) (for iOS and macOS) and [in Java](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md) (for Android and Java SE).
+Ports of Turf.js are available in:
+
+* [Java](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md) (Android, Java SE)
+* [Swift](https://github.com/mapbox/turf-swift/) (iOS, macOS, tvOS, watchOS, Linux)
 
 - - -
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ TypeScript is supported internally within each module, no installs required.
 
 Ports of Turf.js are available in:
 
-* [Java](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md) (Android, Java SE)
-* [Swift](https://github.com/mapbox/turf-swift/) (iOS, macOS, tvOS, watchOS, Linux)
+- [Java](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md) (Android, Java SE)
+- [Swift](https://github.com/mapbox/turf-swift/) (iOS, macOS, tvOS, watchOS, Linux)
+> Turf for Swift is **experimental** and its public API is subject to change. Please use with care.
 
 - - -
 


### PR DESCRIPTION
Updated the readme to reflect the fact that the Swift port supports five platforms as of [v0.1.0](https://github.com/mapbox/turf-swift/releases/tag/v0.1.0).