### PR TITLE
FeatureCollection type field was missing in TypeScript definition

### DIFF
--- a/packages/turf-helpers/lib/geojson.d.ts
+++ b/packages/turf-helpers/lib/geojson.d.ts
@@ -234,5 +234,6 @@ export interface Feature<G = Geometry | GeometryCollection, P = Properties> exte
  * It is possible for this array to be empty.
  */
 export interface FeatureCollection<G = Geometry | GeometryCollection, P = Properties> extends GeoJSONObject {
+    type: "FeatureCollection";
     features: Array<Feature<G, P>>;
 }


### PR DESCRIPTION
For all other GeoJSON types there was a field asserting the value of `type`, but there was nothing for FeatureCollection, so I've added it there as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.
