### PR TITLE
Drop *.ts files in Typescript packages

### DIFF
--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts",
     "lib"
   ],

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts",
     "lib"
   ],

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -6,11 +6,11 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {
     "prepare": "tsc",
+    "pretest": "tsc",
     "test": "node test.js",
     "bench": "node bench.js",
     "docs": "node ../../scripts/generate-readmes"

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts",
     "lib"
   ],

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {
@@ -35,10 +34,12 @@
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
     "benchmark": "*",
-    "rollup": "*",
     "write-json-file": "*",
     "load-json-file": "*",
-    "tape": "*"
+    "tape": "*",
+    "typescript": "*",
+    "tslint": "*",
+    "@types/tape": "*"
   },
   "dependencies": {
     "@turf/helpers": "6.x",

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -2,11 +2,10 @@
   "name": "@turf/distance-weight",
   "version": "6.0.0",
   "description": "turf distance-weight module",
-  "main": "index",  
+  "main": "index",
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {
@@ -33,12 +32,14 @@
     "url": "https://github.com/Turfjs/turf/issues"
   },
   "homepage": "https://github.com/Turfjs/turf",
-  "devDependencies": {    
+  "devDependencies": {
     "benchmark": "*",
-    "rollup": "*",
     "write-json-file": "*",
     "load-json-file": "*",
-    "tape": "*"
+    "tape": "*",
+    "typescript": "*",
+    "tslint": "*",
+    "@types/tape": "*"
   },
   "dependencies": {
     "@turf/helpers": "6.x",

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@turf/helpers",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "turf helpers module",
   "main": "index",
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts",
     "lib"
   ],

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -41,6 +41,8 @@
   "devDependencies": {
     "benchmark": "*",
     "tape": "*",
-    "typescript": "*"
+    "typescript": "*",
+    "tslint": "*",
+    "@types/tape": "*"
   }
 }

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {
@@ -35,10 +34,12 @@
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
     "benchmark": "*",
-    "rollup": "*",
     "write-json-file": "*",
     "load-json-file": "*",
-    "tape": "*"
+    "tape": "*",
+    "typescript": "*",
+    "tslint": "*",
+    "@types/tape": "*"
   },
   "dependencies": {
     "@turf/helpers": "6.x",

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -2,18 +2,17 @@
   "name": "@turf/nearest-neighbor-analysis",
   "version": "6.0.0",
   "description": "turf nearest-neighbor-analysis module",
-  "main": "index",  
+  "main": "index",
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {
     "prepare": "tsc",
     "pretest": "tsc",
     "test": "node test.js",
-    "bench": "node -r @std/esm bench.js",
+    "bench": "node bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -34,13 +33,14 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "*",
     "benchmark": "*",
-    "rollup": "*",
     "write-json-file": "*",
     "load-json-file": "*",
-    "tape": "*"
+    "tape": "*",
+    "typescript": "*",
+    "tslint": "*",
+    "@types/tape": "*"
   },
   "dependencies": {
     "@turf/area": "6.x",
@@ -51,9 +51,5 @@
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x",
     "@turf/nearest-point": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -2,11 +2,10 @@
   "name": "@turf/nearest-point",
   "version": "6.0.0",
   "description": "turf nearest-point module",
-  "main": "index",  
+  "main": "index",
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {
@@ -35,15 +34,16 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
-    "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "typescript": "*",
+    "tslint": "*",
+    "@types/tape": "*"
   },
   "dependencies": {
     "@turf/clone": "6.x",
     "@turf/distance": "6.x",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  }  
+  }
 }

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.ts",
     "index.d.ts"
   ],
   "scripts": {

--- a/scripts/update-typescript-configurations
+++ b/scripts/update-typescript-configurations
@@ -45,7 +45,8 @@ glob.sync(path.join(__dirname, '..', 'packages', 'turf-*', 'index.ts')).forEach(
     fs.writeFileSync(path.join(dir, '.gitignore'), 'index.js');
 
     // Add Typescript configs
-    fs.writeFileSync(path.join(dir, 'tsconfig.json'), `{
+    if (false) {
+        fs.writeFileSync(path.join(dir, 'tsconfig.json'), `{
     "compilerOptions": {
         /* Basic Options */
         "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
@@ -60,7 +61,7 @@ glob.sync(path.join(__dirname, '..', 'packages', 'turf-*', 'index.ts')).forEach(
     }
 }`);
 
-    fs.writeFileSync(path.join(dir, 'tslint.json'), `{
+        fs.writeFileSync(path.join(dir, 'tslint.json'), `{
     "defaultSeverity": "error",
     "extends": [
         "tslint:recommended"
@@ -69,6 +70,7 @@ glob.sync(path.join(__dirname, '..', 'packages', 'turf-*', 'index.ts')).forEach(
     "rules": {},
     "rulesDirectory": []
 }`);
+    }
 });
 
 function entries(obj) {
@@ -80,7 +82,7 @@ function entries(obj) {
  * @returns {Array<string>} Files
  */
 function updateFiles(files) {
-    const newFiles = ['index.js', 'index.ts', 'index.d.ts'];
+    const newFiles = ['index.js', 'index.d.ts'];
     if (files.includes('lib')) newFiles.push('lib');
     return newFiles;
 }


### PR DESCRIPTION
## Drop `*.ts` files in Typescript packages

> TS files in published libraries are often a sign of a badly packaged library.

Removed `*.ts` from files in `package.json`

Ref: https://github.com/Turfjs/turf/issues/1329#issuecomment-378354857
CC: @shonderdos

Already published `@turf/helpers` `v6.1.2` with these changes