### PR TITLE
Changed README links regarding Turf Java port

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ TypeScript is supported internally within each module, no installs required.
 
 Ports of Turf.js are available in:
 
-- [Java](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md) (Android, Java SE)
+- [Java](https://github.com/mapbox/mapbox-java/tree/master/services-turf/src/main/java/com/mapbox/turf) (Android, Java SE)
+  - > [The current to-do list for porting to Java](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md)
 - [Swift](https://github.com/mapbox/turf-swift/) (iOS, macOS, tvOS, watchOS, Linux)
 > Turf for Swift is **experimental** and its public API is subject to change. Please use with care.
 


### PR DESCRIPTION
Changed the link to the Java Turf library. I also moved the link to the porting to-do list.