### PR TITLE
Pass `steps` into turf-jsts, in @turf/buffer, defaults to 8

### DIFF
--- a/packages/turf-buffer/README.md
+++ b/packages/turf-buffer/README.md
@@ -18,7 +18,7 @@ the input, or even be empty.
 -   `radius` **[number][4]** distance to draw the buffer (negative values are allowed)
 -   `options` **[Object][5]** Optional parameters (optional, default `{}`)
     -   `options.units` **[string][6]** any of the options supported by turf units (optional, default `"kilometers"`)
-    -   `options.steps` **[number][4]** number of steps (optional, default `64`)
+    -   `options.steps` **[number][4]** number of steps (optional, default `8`)
 
 **Examples**
 

--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -112,7 +112,7 @@ function bufferFeature(geojson, radius, units, steps) {
     var reader = new GeoJSONReader();
     var geom = reader.read(projected);
     var distance = radiansToLength(lengthToRadians(radius, units), 'meters');
-    var buffered = BufferOp.bufferOp(geom, distance);
+    var buffered = BufferOp.bufferOp(geom, distance, steps);
     var writer = new GeoJSONWriter();
     buffered = writer.write(buffered);
 

--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -20,7 +20,7 @@ import { feature, featureCollection, radiansToLength, lengthToRadians, earthRadi
  * @param {number} radius distance to draw the buffer (negative values are allowed)
  * @param {Object} [options={}] Optional parameters
  * @param {string} [options.units="kilometers"] any of the options supported by turf units
- * @param {number} [options.steps=64] number of steps
+ * @param {number} [options.steps=8] number of steps
  * @returns {FeatureCollection|Feature<Polygon|MultiPolygon>|undefined} buffered features
  * @example
  * var point = turf.point([-90.548630, 14.616599]);
@@ -33,7 +33,7 @@ function buffer(geojson, radius, options) {
     // Optional params
     options = options || {};
     var units = options.units;
-    var steps = options.steps || 64;
+    var steps = options.steps || 8;
 
     // validation
     if (!geojson) throw new Error('geojson is required');
@@ -45,7 +45,7 @@ function buffer(geojson, radius, options) {
     if (steps <= 0) throw new Error('steps must be greater than 0');
 
     // default params
-    steps = steps || 64;
+    steps = steps || 8;
     units = units || 'kilometers';
 
     var results = [];
@@ -77,7 +77,7 @@ function buffer(geojson, radius, options) {
  * @param {Feature<any>} geojson input to be buffered
  * @param {number} radius distance to draw the buffer
  * @param {string} [units='kilometers'] any of the options supported by turf units
- * @param {number} [steps=64] number of steps
+ * @param {number} [steps=8] number of steps
  * @returns {Feature<Polygon|MultiPolygon>} buffered feature
  */
 function bufferFeature(geojson, radius, units, steps) {


### PR DESCRIPTION
This fixes #1112 where the `steps` option is not passed into `turf-jsts`.

I've also changed the default value for `steps` in `README` to **8**, since `turf-jsts` defaults to 8, here: https://github.com/DenisCarriere/turf-jsts/blob/8bd0e262e4cf229935d481eef9cff7af01aaf625/src/org/locationtech/jts/operation/buffer/BufferParameters.js#L92