### PR TITLE
Issue-1469: Fixes incorrect implementation for line crosses line

### DIFF
--- a/src/boolean-crosses/test/true/LineString/LineString/ObliqueCrossing.geojson
+++ b/src/boolean-crosses/test/true/LineString/LineString/ObliqueCrossing.geojson
@@ -1,0 +1,21 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[0, 0], [2, 2]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[2, 0], [0, 2]]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This fixes Issue-1469, where booleanCrosses did not correctly identify two lines which cross. This was due to some overly aggressive checking for endpoint-on-line, which I re-implemented.
