### PR TITLE
Update link to Wikipedia page on isolines

### DIFF
--- a/packages/turf-isolines/index.js
+++ b/packages/turf-isolines/index.js
@@ -8,7 +8,7 @@ import gridToMatrix from './lib/grid-to-matrix';
 
 /**
  * Takes a grid {@link FeatureCollection} of {@link Point} features with z-values and an array of
- * value breaks and generates [isolines](http://en.wikipedia.org/wiki/Isoline).
+ * value breaks and generates [isolines](https://en.wikipedia.org/wiki/Contour_line).
  *
  * @name isolines
  * @param {FeatureCollection<Point>} pointGrid input points


### PR DESCRIPTION
This pull request simply updates the Wikipedia link in the comments.

I release this as a public domain contribution, so is compatible with any license wished.