### PR TITLE
Add TypeScript declaration to @turf/clean-coords

### DIFF
--- a/packages/turf-clean-coords/index.d.ts
+++ b/packages/turf-clean-coords/index.d.ts
@@ -1,0 +1,26 @@
+import { Geometry, Feature } from "@turf/helpers";
+
+/**
+ * Removes redundant coordinates from any GeoJSON Geometry.
+ *
+ * @name cleanCoords
+ * @param {Geometry|Feature} geojson Feature or Geometry
+ * @param {Object} [options={}] Optional parameters
+ * @param {boolean} [options.mutate=false] allows GeoJSON input to be mutated
+ * @returns {Geometry|Feature} the cleaned input Feature/Geometry
+ * @example
+ * var line = turf.lineString([[0, 0], [0, 2], [0, 5], [0, 8], [0, 8], [0, 10]]);
+ * var multiPoint = turf.multiPoint([[0, 0], [0, 0], [2, 2]]);
+ *
+ * turf.cleanCoords(line).geometry.coordinates;
+ * //= [[0, 0], [0, 10]]
+ *
+ * turf.cleanCoords(multiPoint).geometry.coordinates;
+ * //= [[0, 0], [2, 2]]
+ */
+export default function cleanCoords<T extends Geometry | Feature>(
+    geojson: T,
+    options?: {
+        mutate?: boolean
+    }
+): T;


### PR DESCRIPTION
Hi,

While working with `@turf/clean-coords`, I noticed that the package doesn't have a TypeScript declaration. This PR proposes a definition for the function `cleanCoords`.

The changes are pretty straightforward; I used a generic that must extend `Geometry` or `Feature`. 

Let me know when you require any changes. 

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

Submitting a new TurfJS Module.

- [ ] Overview description of proposed module.
- [ ] Include JSDocs with a basic example.
- [ ] Execute `./scripts/generate-readmes` to create `README.md`.
- [ ] Add yourself to **contributors** in `package.json` using "Full Name <@GitHub Username>".