### PR TITLE
fix: Refactor away defineProperties to help with treeshaking

### DIFF
--- a/src/polygonize/lib/polygonize.js
+++ b/src/polygonize/lib/polygonize.js
@@ -259,7 +259,6 @@ var EdgeRing = function EdgeRing() {
     this.envelope = undefined; //< Caches Envelope representation
 };
 
-var prototypeAccessors = { length: { configurable: true } };
 
 /**
  * Add an edge to the ring, inserting it in the last position.
@@ -283,16 +282,6 @@ EdgeRing.prototype.push = function push (edge) {
  */
 EdgeRing.prototype.get = function get (i) {
     return this.edges[i];
-};
-
-/**
- * Getter of length property.
- *
- * @memberof EdgeRing
- * @returns {number} - Length of the edge ring.
- */
-prototypeAccessors.length.get = function () {
-    return this.edges.length;
 };
 
 /**
@@ -361,8 +350,8 @@ EdgeRing.prototype.isHole = function isHole () {
                 { high = i; }
             return high;
         }, 0),
-        iPrev = (hiIndex === 0 ? this.length : hiIndex) - 1,
-        iNext = (hiIndex + 1) % this.length,
+        iPrev = (hiIndex === 0 ? this.edges.length : hiIndex) - 1,
+        iNext = (hiIndex + 1) % this.edges.length,
         disc = orientationIndex(this.edges[iPrev].from.coordinates, this.edges[hiIndex].from.coordinates, this.edges[iNext].from.coordinates);
 
     if (disc === 0)
@@ -452,69 +441,6 @@ EdgeRing.findEdgeRingContaining = function findEdgeRingContaining (testEdgeRing,
 EdgeRing.prototype.inside = function inside (pt) {
     return booleanPointInPolygon(pt, this.toPolygon());
 };
-
-defineProperties(EdgeRing.prototype, prototypeAccessors);
-
-function defineProperties(obj, properties) {
-  function convertToDescriptor(desc) {
-    function hasProperty(obj, prop) {
-      return Object.prototype.hasOwnProperty.call(obj, prop);
-    }
-
-    function isCallable(v) {
-      // NB: modify as necessary if other values than functions are callable.
-      return typeof v === 'function';
-    }
-
-    if (typeof desc !== 'object' || desc === null)
-      throw new TypeError('bad desc');
-
-    var d = {};
-
-    if (hasProperty(desc, 'enumerable'))
-      d.enumerable = !!desc.enumerable;
-    if (hasProperty(desc, 'configurable'))
-      d.configurable = !!desc.configurable;
-    if (hasProperty(desc, 'value'))
-      d.value = desc.value;
-    if (hasProperty(desc, 'writable'))
-      d.writable = !!desc.writable;
-    if (hasProperty(desc, 'get')) {
-      var g = desc.get;
-
-      if (!isCallable(g) && typeof g !== 'undefined')
-        throw new TypeError('bad get');
-      d.get = g;
-    }
-    if (hasProperty(desc, 'set')) {
-      var s = desc.set;
-      if (!isCallable(s) && typeof s !== 'undefined')
-        throw new TypeError('bad set');
-      d.set = s;
-    }
-
-    if (('get' in d || 'set' in d) && ('value' in d || 'writable' in d))
-      throw new TypeError('identity-confused descriptor');
-
-    return d;
-  }
-
-  if (typeof obj !== 'object' || obj === null)
-    throw new TypeError('bad obj');
-
-  properties = Object(properties);
-
-  var keys = Object.keys(properties);
-  var descs = [];
-
-  for (var i = 0; i < keys.length; i++)
-    descs.push([keys[i], convertToDescriptor(properties[keys[i]])]);
-
-  for (var i = 0; i < descs.length; i++)
-    Object.defineProperty(obj, descs[i][0], descs[i][1]);
-
-  return obj;
-}
 
 /**
  * Validates the geoJson.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

This removes defineProperties, which was only used for one property, also removes that property and simply gets `.edges.length`.