### PR TITLE
turf-nearest-point-on-line: add type definitions

### DIFF
--- a/packages/turf-nearest-point-on-line/index.d.ts
+++ b/packages/turf-nearest-point-on-line/index.d.ts
@@ -1,0 +1,57 @@
+import bearing from "@turf/bearing";
+import distance from "@turf/distance";
+import destination from "@turf/destination";
+import lineIntersects from "@turf/line-intersect";
+import { flattenEach } from "@turf/meta";
+import {
+  Feature,
+  Point,
+  LineString,
+  MultiLineString,
+  Coord,
+  Units
+} from "@turf/helpers";
+import { getCoords } from "@turf/invariant";
+
+export interface NearestPointOnLine extends Feature<Point> {
+  properties: {
+    index?: number;
+    dist?: number;
+    location?: number;
+    [key: string]: any;
+  };
+}
+
+/**
+ * Takes a {@link Point} and a {@link LineString} and calculates the closest Point on the (Multi)LineString.
+ *
+ * @name nearestPointOnLine
+ * @param {Geometry|Feature<LineString|MultiLineString>} lines lines to snap to
+ * @param {Geometry|Feature<Point>|number[]} pt point to snap from
+ * @param {Object} [options={}] Optional parameters
+ * @param {string} [options.units='kilometers'] can be degrees, radians, miles, or kilometers
+ * @returns {Feature<Point>} closest point on the `line` to `point`. The properties object will contain three values: `index`: closest point was found on nth line part, `dist`: distance between pt and the closest point, `location`: distance along the line between start and the closest point.
+ * @example
+ * var line = turf.lineString([
+ *     [-77.031669, 38.878605],
+ *     [-77.029609, 38.881946],
+ *     [-77.020339, 38.884084],
+ *     [-77.025661, 38.885821],
+ *     [-77.021884, 38.889563],
+ *     [-77.019824, 38.892368]
+ * ]);
+ * var pt = turf.point([-77.037076, 38.884017]);
+ *
+ * var snapped = turf.nearestPointOnLine(line, pt, {units: 'miles'});
+ *
+ * //addToMap
+ * var addToMap = [line, pt, snapped];
+ * snapped.properties['marker-color'] = '#00f';
+ */
+function nearestPointOnLine<G extends LineString | MultiLineString>(
+  lines: Feature<G> | G,
+  pt: Coord,
+  options?: { units?: Units }
+): NearestPointOnLine;
+
+export default nearestPointOnLine;


### PR DESCRIPTION
Simply taken from the existing index.ts file. This resolves the problem of importing @turf/nearest-point-on-line into a TS project.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.