### PR TITLE
turf-boolean-crosses: Fix boolean-crosses for MultiPoint+Polygon cases

### DIFF
--- a/packages/turf-boolean-crosses/index.ts
+++ b/packages/turf-boolean-crosses/index.ts
@@ -115,10 +115,10 @@ function doLineStringAndPolygonCross(lineString, polygon: Polygon) {
 function doesMultiPointCrossPoly(multiPoint, polygon) {
     var foundIntPoint = false;
     var foundExtPoint = false;
-    var pointLength = multiPoint.coordinates[0].length;
+    var pointLength = multiPoint.coordinates.length;
     var i = 0;
-    while (i < pointLength && foundIntPoint && foundExtPoint) {
-        if (booleanPointInPolygon(point(multiPoint.coordinates[0][i]), polygon)) {
+    while (i < pointLength && (!foundIntPoint || !foundExtPoint)) {
+        if (booleanPointInPolygon(point(multiPoint.coordinates[i]), polygon)) {
             foundIntPoint = true;
         } else {
             foundExtPoint = true;
@@ -126,7 +126,7 @@ function doesMultiPointCrossPoly(multiPoint, polygon) {
         i++;
     }
 
-    return foundExtPoint && foundExtPoint;
+    return foundIntPoint && foundExtPoint;
 }
 
 /**

--- a/packages/turf-boolean-crosses/test/false/MultiPoint/Polygon/MultipointOnlyInsidePolygon.geojson
+++ b/packages/turf-boolean-crosses/test/false/MultiPoint/Polygon/MultipointOnlyInsidePolygon.geojson
@@ -1,0 +1,27 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [[0, 0], [1, 1]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-2, -2],
+          [2, -2],
+          [2, 2],
+          [-2, 2],
+          [-2, -2]
+        ]]
+      }
+    }
+  ]
+}

--- a/packages/turf-boolean-crosses/test/false/MultiPoint/Polygon/MultipointOnlyOutsidePolygon.geojson
+++ b/packages/turf-boolean-crosses/test/false/MultiPoint/Polygon/MultipointOnlyOutsidePolygon.geojson
@@ -1,0 +1,27 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [[10, 10], [11, 11]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-2, -2],
+          [2, -2],
+          [2, 2],
+          [-2, 2],
+          [-2, -2]
+        ]]
+      }
+    }
+  ]
+}

--- a/packages/turf-boolean-crosses/test/true/MultiPoint/Polygon/MultiPointInsideAndOutsidePolygon.geojson
+++ b/packages/turf-boolean-crosses/test/true/MultiPoint/Polygon/MultiPointInsideAndOutsidePolygon.geojson
@@ -1,0 +1,27 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [[0, 0], [0, 3]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-2, -2],
+          [2, -2],
+          [2, 2],
+          [-2, 2],
+          [-2, -2]
+        ]]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Go over every point in the MultiPoint
- Fix the loop's boolean logic (as it would previously never enter the loop)
- Fix the return value (address both `foundIntPoint` and `foundExtPoint`)
- Test the whole ordeal

There might be more related methods with similar fixes waiting to be
found, I've yet to do a review of the entire file.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.