### PR TITLE
update clean coords for boolean equals to avoid TS error

### DIFF
--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -49,7 +49,7 @@
     "@types/tape": "*"
   },
   "dependencies": {
-    "@turf/clean-coords": "6.0.0",
+    "@turf/clean-coords": "6.0.1",
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "geojson-equality": "0.1.6"

--- a/packages/turf-line-arc/index.js
+++ b/packages/turf-line-arc/index.js
@@ -1,10 +1,7 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var circle_1 = __importDefault(require("@turf/circle"));
-var destination_1 = __importDefault(require("@turf/destination"));
+var circle_1 = require("@turf/circle");
+var destination_1 = require("@turf/destination");
 var helpers_1 = require("@turf/helpers");
 /**
  * Creates a circular arc, of a circle of the given radius and center point, between bearing1 and bearing2;

--- a/packages/turf-line-arc/index.js
+++ b/packages/turf-line-arc/index.js
@@ -1,7 +1,10 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-var circle_1 = require("@turf/circle");
-var destination_1 = require("@turf/destination");
+var circle_1 = __importDefault(require("@turf/circle"));
+var destination_1 = __importDefault(require("@turf/destination"));
 var helpers_1 = require("@turf/helpers");
 /**
  * Creates a circular arc, of a circle of the given radius and center point, between bearing1 and bearing2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,13 +86,6 @@
     "@turf/destination" "^5.1.5"
     "@turf/helpers" "^5.1.5"
 
-"@turf/clean-coords@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-6.0.0.tgz#edac2b00dcbfd61c42dd035bfd5f21075c887565"
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-
 "@turf/clean-coords@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-5.1.5.tgz#12800a98a78c9a452a72ec428493c43acf2ada1f"
@@ -156,6 +149,13 @@
 "@turf/invariant@^5.1.5":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
+"@turf/kinks@5.1.x", "@turf/kinks@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-5.1.5.tgz#8abb6961d9bb0107213baddf2c2c2640d0256980"
+  integrity sha1-irtpYdm7AQchO63fLCwmQNAlaYA=
   dependencies:
     "@turf/helpers" "^5.1.5"
 
@@ -3812,9 +3812,10 @@ markdown-table@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
 
-martinez-polygon-clipping@*:
+martinez-polygon-clipping@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz#a3971ddf1da147104b5d0fbbf68f728bb62885c1"
+  integrity sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==
   dependencies:
     splaytree "^0.1.4"
     tinyqueue "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,13 @@
     "@turf/destination" "^5.1.5"
     "@turf/helpers" "^5.1.5"
 
+"@turf/clean-coords@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-6.0.0.tgz#edac2b00dcbfd61c42dd035bfd5f21075c887565"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
 "@turf/clean-coords@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-5.1.5.tgz#12800a98a78c9a452a72ec428493c43acf2ada1f"
@@ -149,13 +156,6 @@
 "@turf/invariant@^5.1.5":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/kinks@5.1.x", "@turf/kinks@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-5.1.5.tgz#8abb6961d9bb0107213baddf2c2c2640d0256980"
-  integrity sha1-irtpYdm7AQchO63fLCwmQNAlaYA=
   dependencies:
     "@turf/helpers" "^5.1.5"
 
@@ -3812,10 +3812,9 @@ markdown-table@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
 
-martinez-polygon-clipping@^0.4.3:
+martinez-polygon-clipping@*:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz#a3971ddf1da147104b5d0fbbf68f728bb62885c1"
-  integrity sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==
   dependencies:
     splaytree "^0.1.4"
     tinyqueue "^1.2.0"


### PR DESCRIPTION
booleanEqual relies on cleanCoords 6.0.0 however this version has a typescript file included in the package build which breaks typescript projects. This has been fixed in cleanCoords 6.0.1.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.
