### PR TITLE
Buffer TypeScript definition for negative radius

### DIFF
--- a/packages/turf-buffer/index.d.ts
+++ b/packages/turf-buffer/index.d.ts
@@ -21,9 +21,11 @@ interface Options {
 /**
  * http://turfjs.org/docs/#buffer
  */
-declare function buffer<Geom extends Point | LineString | Polygon>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<Polygon>;
+declare function buffer<Geom extends Point | LineString>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<Polygon>;
+declare function buffer<Polygon>(feature: Feature<Polygon>|Polygon, radius?: number, options?: Options): Feature<Polygon | MultiPolygon>;
 declare function buffer<Geom extends MultiPoint | MultiLineString | MultiPolygon>(feature: Feature<Geom>|Geom, radius?: number, options?: Options): Feature<MultiPolygon>;
-declare function buffer<Geom extends Point | LineString | Polygon>(feature: FeatureCollection<Geom>, radius?: number, options?: Options): FeatureCollection<Polygon>;
+declare function buffer<Geom extends Point | LineString>(feature: FeatureCollection<Geom>, radius?: number, options?: Options): FeatureCollection<Polygon>;
+declare function buffer<Polygon>(feature: FeatureCollection<Polygon>, radius?: number, options?: Options): FeatureCollection<Polygon | MultiPolygon>;
 declare function buffer<Geom extends MultiPoint | MultiLineString | MultiPolygon>(feature: FeatureCollection<Geom>, radius?: number, options?: Options): FeatureCollection<MultiPolygon>;
 declare function buffer(feature: FeatureCollection<any> | Feature<GeometryCollection> | GeometryCollection, radius?: number, options?: Options): FeatureCollection<Polygon | MultiPolygon>;
 declare function buffer(feature: Feature<any> | GeometryObject, radius?: number, options?: Options): Feature<Polygon | MultiPolygon>;


### PR DESCRIPTION
When a negative `radius` is used with `buffer` for a polygon, it is possible the result will be a multi-polygon when the original polygon is shaped like several "blobs" connected with narrow "tubes" - the tubes disappear entirely if they are thinner than radius*2 and the blobs shrink into separated polygons in a multi-polygon.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

Submitting a new TurfJS Module.

- [ ] Overview description of proposed module.
- [ ] Include JSDocs with a basic example.
- [ ] Execute `./scripts/generate-readmes` to create `README.md`.
- [ ] Add yourself to **contributors** in `package.json` using "Full Name <@GitHub Username>".
