### PR TITLE
Fix closed linestring issue in clean-coords

### DIFF
--- a/packages/turf-clean-coords/index.ts
+++ b/packages/turf-clean-coords/index.ts
@@ -115,7 +115,8 @@ function cleanLine(line) {
     newPoints.push(points[points.length - 1]);
 
     newPointsLength = newPoints.length;
-    if (equals(points[0], points[points.length - 1]) && newPointsLength < 4) throw new Error('invalid polygon');
+    var type = getType(line)
+    if (type && type.indexOf('Polygon') > -1 && equals(points[0], points[points.length - 1]) && newPointsLength < 4) throw new Error('invalid polygon');
     if (isPointOnLineSegment(newPoints[newPointsLength - 3], newPoints[newPointsLength - 1], newPoints[newPointsLength - 2])) newPoints.splice(newPoints.length - 2, 1);
 
     return newPoints;

--- a/packages/turf-clean-coords/test/in/closed_linestring.geojson
+++ b/packages/turf-clean-coords/test/in/closed_linestring.geojson
@@ -1,0 +1,21 @@
+{
+	"type": "Feature",
+	"properties": {},
+	"geometry": {
+		"type": "LineString",
+		"coordinates": [
+			[
+				0,
+				0
+			],
+			[
+				1,
+				1
+			],
+			[
+				0,
+				0
+			]
+		]
+	}
+}

--- a/packages/turf-clean-coords/test/out/closed_linestring.geojson
+++ b/packages/turf-clean-coords/test/out/closed_linestring.geojson
@@ -1,0 +1,21 @@
+{
+	"type": "Feature",
+	"properties": {},
+	"geometry": {
+		"type": "LineString",
+		"coordinates": [
+			[
+				0,
+				0
+			],
+			[
+				1,
+				1
+			],
+			[
+				0,
+				0
+			]
+		]
+	}
+}


### PR DESCRIPTION
This PR fixes the invalid polygon issue that happens in `clean-coords` with closed linestrings.

This issue is reported in https://github.com/Turfjs/turf/issues/1563.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

Submitting a new TurfJS Module.

- [ ] Overview description of proposed module.
- [ ] Include JSDocs with a basic example.
- [ ] Execute `./scripts/generate-readmes` to create `README.md`.
- [ ] Add yourself to **contributors** in `package.json` using "Full Name <@GitHub Username>".
