### PR TITLE
WIP: turf-cluster-kmeans deduplicate initial centroids

### DIFF
--- a/packages/turf-clusters-kmeans/test.js
+++ b/packages/turf-clusters-kmeans/test.js
@@ -60,6 +60,18 @@ test('clusters-kmeans -- translate properties', t => {
     t.end();
 });
 
+const duplicatePoints = featureCollection([
+    point([0, 0], { foo: 'bar' }),
+    point([0, 0], { foo: 'bar' }),
+    point([2, 4], { foo: 'bar' }),
+    point([3, 6], { foo: 'bar' })
+])
+
+test('clusters-kmeans -- ignores duplicate initial centroids', t => {
+    t.equal(clustersKmeans(points, { numberOfClusters: 2 }).features.length, 2);
+    t.end();
+});
+
 // style result
 function styleResult(clustered) {
     const count = clusterReduce(clustered, 'cluster', i => i + 1, 0);


### PR DESCRIPTION
This is a WIP. I was unable to get the development environment working correctly (master doesn't appear to pass pre-lint). Thus the empty checkboxes below:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [ ] Run `npm test` at the sub modules where changes have occurred.
- [ ] Run `npm run lint` to ensure code style at the turf module level.

Currently if you run kmeans clustering on a series of points with duplicates in the first NUMBER_OF_CLUSTERS coordinates it will fail to produce the right number of clusters; the algorithm ignores half of the duplicates.

There are a two ways I can think of to fix this:

 1. Shift each point by a tiny amount in an arbitrary direction. (.5% of the bbox around the points?) This will reduce the changes of collision dramatically, but I am guessing would be suboptimal for performance).
 1. Keep picking new points until the initial points are unique.

I implemented option 2 which provided a more natural way to determine the actual number of clusters, so I was able to remove some numberOfClusters code and replace it with simply 'Number of clusters found'.

It is possible that there is a better solution to this (from within the algorithm itself). I didn't dig any deeper.