### PR TITLE
union (v7): Change 'fc' to rest argument 'features'

### DIFF
--- a/src/union/index.js
+++ b/src/union/index.js
@@ -6,7 +6,7 @@ import { geomEach } from '../meta';
  * Takes two or more {@link Polygon|polygons} and returns a combined polygon. If the input polygons are not contiguous, this function returns a {@link MultiPolygon} feature.
  *
  * @name union
- * @param {Feature<Polygon|MultiPolygon>} fc a FeatureCollection containting polygons or multipolygons to union
+ * @param {...Feature<Polygon|MultiPolygon>} features FeatureCollections containing polygons or multipolygons to union
  * @returns {Feature<(Polygon|MultiPolygon)>} a combined {@link Polygon} or {@link MultiPolygon} feature
  * @example
  * var poly1 = turf.polygon([[
@@ -29,12 +29,16 @@ import { geomEach } from '../meta';
  * //addToMap
  * var addToMap = [poly1, poly2, union];
  */
-function union(fc) {
+function union(...features) {
     const args = [];
-    geomEach(fc, function (geom) {
-        if (geom.type === 'MultiPolygon') args.push(geom.coordinates);
-        if (geom.type === 'Polygon') args.push([geom.coordinates]);
-    });
+
+    for (const fc of features) {
+        geomEach(fc, function (geom) {
+            if (geom.type === 'MultiPolygon') args.push(geom.coordinates);
+            if (geom.type === 'Polygon') args.push([geom.coordinates]);
+        });
+    }
+
     const unioned = polygonClipping.union(...args);
     if (unioned.length === 0) return null;
     else return multiPolygon(unioned);


### PR DESCRIPTION
When upgrading from turf v6 to v7 (since union uses the more stable union/difference library), we ran into this issue and it was not immediately clear what the issue was.

I think it makes sense to support both styles, especially since `difference` is hard coded to `a` and `b`.

What the PR makes possible / tries to accomplish:

```js
import { union } from 'turf';

union(feature1, feature2, fc);
```