### PR TITLE
@turf/rewind: typescript definition has "reverse" property called "reversed" (with an extra d)

### DIFF
--- a/packages/turf-rewind/index.d.ts
+++ b/packages/turf-rewind/index.d.ts
@@ -6,7 +6,7 @@ import { AllGeoJSON } from '@turf/helpers';
 export default function rewind<T extends AllGeoJSON>(
     geojson: T,
     options?: {
-        reversed?: boolean,
+        reverse?: boolean,
         mutate?: boolean
     }
 ): T;


### PR DESCRIPTION
Typescript has incorrect options property name (an extra "d" on the end of reverse)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [N/A] Run `npm test` at the sub modules where changes have occurred.
- [N/A] Run `npm run lint` to ensure code style at the turf module level.

Submitting a new TurfJS Module.

- [ ] Overview description of proposed module.
- [ ] Include JSDocs with a basic example.
- [ ] Execute `./scripts/generate-readmes` to create `README.md`.
- [ ] Add yourself to **contributors** in `package.json` using "Full Name <@GitHub Username>".
