### PR TITLE
Turf Area should take input as [lat, lng] instead of current [lng, lat]

### DIFF
--- a/packages/turf-area/index.ts
+++ b/packages/turf-area/index.ts
@@ -105,7 +105,7 @@ function ringArea(coords: number[][]) {
             p1 = coords[lowerIndex];
             p2 = coords[middleIndex];
             p3 = coords[upperIndex];
-            total += (rad(p3[0]) - rad(p1[0])) * Math.sin(rad(p2[1]));
+            total += (rad(p3[1]) - rad(p1[1])) * Math.sin(rad(p2[0]));
         }
 
         total = total * RADIUS * RADIUS / 2;


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [ ] Run `npm test` at the sub modules where changes have occurred.
- [ ] Run `npm run lint` to ensure code style at the turf module level.


Hi guys,

The area calculated was coming out to be incorrect. 
I went through the research [note]( https://trs.jpl.nasa.gov/bitstream/handle/2014/41271/07-0286.pdf?sequence=1&isAllowed=y ) and then figured that we have to give input in `Turf-Area ` as [Longitude, Latitude][] which is against the normal convention of [Latitude, Longitude][].





