### PR TITLE
[turf/center]: Fix Added types

### DIFF
--- a/packages/turf-center/index.d.ts
+++ b/packages/turf-center/index.d.ts
@@ -1,0 +1,31 @@
+import { BBox, Id, AllGeoJSON, Feature, Point, Properties } from '@turf/helpers';
+/**
+ * Takes a {@link Feature} or {@link FeatureCollection} and returns the absolute center point of all features.
+ *
+ * @name center
+ * @param {GeoJSON} geojson GeoJSON to be centered
+ * @param {Object} [options={}] Optional parameters
+ * @param {Object} [options.properties={}] Translate GeoJSON Properties to Point
+ * @param {Object} [options.bbox={}] Translate GeoJSON BBox to Point
+ * @param {Object} [options.id={}] Translate GeoJSON Id to Point
+ * @returns {Feature<Point>} a Point feature at the absolute center point of all input features
+ * @example
+ * var features = turf.points([
+ *   [-97.522259, 35.4691],
+ *   [-97.502754, 35.463455],
+ *   [-97.508269, 35.463245]
+ * ]);
+ *
+ * var center = turf.center(features);
+ *
+ * //addToMap
+ * var addToMap = [features, center]
+ * center.properties['marker-size'] = 'large';
+ * center.properties['marker-color'] = '#000';
+ */
+declare function center<P = Properties>(geojson: AllGeoJSON, options?: {
+    properties?: P;
+    bbox?: BBox;
+    id?: Id;
+}): Feature<Point, P>;
+export default center;

--- a/packages/turf-center/tsconfig.json
+++ b/packages/turf-center/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        /* Basic Options */
+        "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+        "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+        "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+
+        /* Strict Type-Checking Options */
+        "strict": true,                           /* Enable all strict type-checking options. */
+
+        /* Module Resolution Options */
+        "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

---

Although `turf-center` package has in the `package.json` a types entry. The package itself has no shipped the typing file (`index.d.ts`).

This PR adds a `tsconfig.json` configuration (the same used on `turf-helpers` and many other submodules), in order to create the `index.d.ts` typing file. It also commits the `index.d.ts` file as other modules do (please tell me if this isn't necessary)
