### PR TITLE
Update from @std/esm to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "documentation": "*",
     "eslint": "*",
     "eslint-config-mourner": "*",
+    "esm": "^3.2.25",
     "fs-extra": "*",
     "lerna": "2.8.0",
     "load-json-file": "*",

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -43,7 +43,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "*",
     "benchmark": "*",
     "load-json-file": "*",
@@ -59,9 +58,5 @@
     "@turf/projection": "6.x",
     "d3-geo": "1.7.1",
     "turf-jsts": "*"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -54,9 +53,5 @@
     "@turf/union": "^5.1.5",
     "geojson-rbush": "3.x",
     "get-closest": "*"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -37,7 +37,6 @@
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
     "@mapbox/geojsonhint": "*",
-    "@std/esm": "*",
     "@turf/bbox-polygon": "6.x",
     "@turf/circle": "6.x",
     "@turf/destination": "6.x",
@@ -54,9 +53,5 @@
     "@turf/invariant": "6.x",
     "@turf/rhumb-destination": "6.x",
     "@turf/transform-rotate": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -46,9 +45,5 @@
     "@turf/bbox": "6.x",
     "@turf/bbox-polygon": "6.x",
     "@turf/helpers": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "geojson-fixtures": "*",
     "load-json-file": "*",
@@ -46,9 +45,5 @@
   "dependencies": {
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -50,9 +49,5 @@
   "dependencies": {
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -46,9 +45,5 @@
     "@turf/clone": "6.x",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -42,7 +42,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -53,9 +52,5 @@
   "dependencies": {
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "chromatism": "*",
@@ -58,9 +57,5 @@
     "@turf/point-grid": "6.x",
     "@turf/square-grid": "^5.1.5",
     "@turf/triangle-grid": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -42,7 +42,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/envelope": "^5.1.5",
     "@turf/point-grid": "6.x",
     "@turf/random": "6.x",
@@ -65,9 +64,5 @@
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x",
     "object-assign": "*"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -14,8 +14,8 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "0.21.x",
     "@turf/envelope": "^5.1.5",
     "@turf/point-grid": "6.x",
     "@turf/random": "6.x",
@@ -59,9 +58,5 @@
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x",
     "object-assign": "*"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -42,7 +42,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -55,9 +54,5 @@
     "@turf/length": "6.x",
     "@turf/line-slice-along": "^5.1.5",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@turf/line-offset",
   "version": "5.1.5",
@@ -15,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -42,7 +41,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -54,9 +52,5 @@
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/along": "*",
     "benchmark": "*",
     "load-json-file": "*",
@@ -46,9 +45,5 @@
     "@turf/destination": "6.x",
     "@turf/distance": "6.x",
     "@turf/helpers": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -50,9 +49,5 @@
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "@turf/nearest-point-on-line": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -57,9 +56,5 @@
     "@turf/square": "^5.1.5",
     "@turf/truncate": "6.x",
     "geojson-rbush": "3.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "mkdirp": "*",
@@ -48,9 +47,5 @@
     "@turf/meta": "6.x",
     "@turf/union": "^5.1.5",
     "rbush": "^2.0.1"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*"
@@ -46,9 +45,5 @@
     "@turf/destination": "6.x",
     "@turf/distance": "6.x",
     "@turf/helpers": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*"
@@ -44,9 +43,5 @@
   "dependencies": {
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/meta": "6.x",
     "@turf/truncate": "6.x",
     "benchmark": "*",
@@ -50,9 +49,5 @@
     "@turf/explode": "^5.1.5",
     "@turf/helpers": "6.x",
     "@turf/nearest-point": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*"
@@ -45,9 +44,5 @@
     "@turf/boolean-point-in-polygon": "6.x",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
@@ -48,9 +47,5 @@
   "dependencies": {
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@turf/polygon-tangents",
   "version": "5.1.5",

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -41,7 +41,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -55,9 +54,5 @@
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "@turf/nearest-point": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -53,9 +52,5 @@
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@turf/bbox-polygon": "*",
     "@turf/truncate": "*",
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "write-json-file": "*",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -41,7 +41,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -54,9 +53,5 @@
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -35,16 +35,11 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*"
   },
   "dependencies": {
     "@turf/helpers": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -47,9 +46,5 @@
     "@turf/invariant": "6.x",
     "@turf/line-arc": "^5.1.5",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -57,9 +56,5 @@
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x",
     "@turf/transform-scale": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -42,7 +42,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -55,9 +54,5 @@
     "@turf/clone": "6.x",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*"
@@ -43,9 +42,5 @@
   "dependencies": {
     "@turf/distance": "6.x",
     "@turf/helpers": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/random": "6.x",
     "@turf/truncate": "6.x",
     "benchmark": "*",
@@ -54,9 +53,5 @@
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x",
     "@turf/points-within-polygon": "^5.1.5"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "load-json-file": "*",
     "rollup": "*",
@@ -50,9 +49,5 @@
     "@turf/clone": "6.x",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -43,7 +43,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "rollup": "*",
     "tape": "*"
@@ -51,9 +50,5 @@
   "dependencies": {
     "@turf/helpers": "6.x",
     "earcut": "^2.0.0"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -56,9 +55,5 @@
     "@turf/rhumb-bearing": "6.x",
     "@turf/rhumb-destination": "6.x",
     "@turf/rhumb-distance": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -43,7 +43,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/bbox-polygon": "6.x",
     "@turf/hex-grid": "^5.1.5",
     "@turf/truncate": "6.x",
@@ -64,9 +63,5 @@
     "@turf/rhumb-bearing": "6.x",
     "@turf/rhumb-destination": "6.x",
     "@turf/rhumb-distance": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -41,7 +41,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/truncate": "6.x",
     "benchmark": "*",
     "load-json-file": "*",
@@ -55,9 +54,5 @@
     "@turf/invariant": "6.x",
     "@turf/meta": "6.x",
     "@turf/rhumb-destination": "6.x"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "@turf/kinks": "^5.1.5",
     "benchmark": "*",
     "load-json-file": "*",
@@ -51,9 +50,5 @@
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x",
     "rbush": "^2.0.1"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -13,9 +13,9 @@
   ],
   "scripts": {
     "pretest": "rollup -c ../../rollup.config.js",
-    "test": "node -r @std/esm test.js",
-    "posttest": "node -r @std/esm ../../scripts/validate-es5-dependencies.js",
-    "bench": "node -r @std/esm bench.js",
+    "test": "node -r esm test.js",
+    "posttest": "node -r esm ../../scripts/validate-es5-dependencies.js",
+    "bench": "node -r esm bench.js",
     "docs": "node ../../scripts/generate-readmes"
   },
   "repository": {
@@ -42,7 +42,6 @@
   },
   "homepage": "https://github.com/Turfjs/turf",
   "devDependencies": {
-    "@std/esm": "*",
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
@@ -54,9 +53,5 @@
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
     "d3-voronoi": "1.1.2"
-  },
-  "@std/esm": {
-    "esm": "js",
-    "cjs": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,13 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
+"@turf/kinks@5.1.x", "@turf/kinks@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-5.1.5.tgz#8abb6961d9bb0107213baddf2c2c2640d0256980"
+  integrity sha1-irtpYdm7AQchO63fLCwmQNAlaYA=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
 "@turf/line-arc@5.1.x", "@turf/line-arc@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/line-arc/-/line-arc-5.1.5.tgz#0078a7447835a12ae414a211f9a64d1186150e15"
@@ -3812,9 +3819,10 @@ markdown-table@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
 
-martinez-polygon-clipping@*:
+martinez-polygon-clipping@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz#a3971ddf1da147104b5d0fbbf68f728bb62885c1"
+  integrity sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==
   dependencies:
     splaytree "^0.1.4"
     tinyqueue "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,6 @@
     vfile "2.0.0"
     vfile-reporter "3.0.0"
 
-"@std/esm@*", "@std/esm@0.21.x":
-  version "0.21.7"
-  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.21.7.tgz#492d7931aed03e91a133deac4d9062fbfce5fd6b"
-
 "@turf/area@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/area/-/area-5.1.5.tgz#efd899bfd260cdbd1541b2a3c155f8a5d2eefa1d"
@@ -2323,6 +2319,11 @@ eslint@*:
     strip-json-comments "~2.0.1"
     table "^4.0.1"
     text-table "~0.2.0"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^3.5.2:
   version "3.5.3"


### PR DESCRIPTION
The first in a series of maintenance-related PRs.

- `@std/esm` has been deprecated in favor of `esm`, this fixes building on newer node versions
- Moved the `esm` dependency from every package.json into the root package.json
- Small extra commits for a yarn.lock inconsistency and whitespace change