### PR TITLE
Publish Fixes

### DIFF
--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -46,6 +46,7 @@ module.exports = {
           "bugs",
           "homepage",
           "repository",
+          "publishConfig",
           "keywords",
           "main",
           "module",
@@ -70,7 +71,10 @@ module.exports = {
           entries: {
             main: "dist/js/index.js",
             module: "dist/es/index.js",
-            sideEffects: false
+            sideEffects: false,
+            publishConfig: {
+              access: "public"
+            }
           }
         },
         includePackages: [MAIN_PACKAGE, ...TS_PACKAGES, ...JS_PACKAGES]

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,10 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
+  "command": {
+    "publish": {
+      "registry": "https://registry.npmjs.org"
+    }
+  },
   "npmClient": "yarn",
   "version": "6.2.0-alpha.0"
 }

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "along",
     "line",

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "angle"

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "area",

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "extent",

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "bearing"

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geometry",

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "clockwise",

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "polygon",

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "contains",

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "equal",

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "disjoint",

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "intersects",

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "parallel",

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "geojson",
     "polygon",

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "booleanPointOnLine"

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "valid",

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "buffer",
     "offset",

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "center",
     "mean",

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "center-median"

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis"

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "centroid",
     "geojson",

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "circle",

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "clone"

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "aggregate",
     "turf",

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis"

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "distance",

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis"

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "directional-mean"

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "dissolve",

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "distance-weight"

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "distance",

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "ellipse"

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "arc",

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "geo",
     "point",

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "grid",

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "idw",

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "invariant",

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "kinks",

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "linestring",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gif"

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "line",
     "linestring",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "line",

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "along",

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "linestring",

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "mask",

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "functional",
     "programming",

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "midpoint",

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "moran-index"

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "nearest-neighbor"

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/js/index.js",
   "module": "dist/es/index.js",
   "types": "dist/js/index.d.ts",

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "grid",

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "centroid",

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "point-to-line-distance",

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "geojson",
     "within",

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "projection",

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "quadrat-analysis"

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis"

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "grid",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "bearing",

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "distance",

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "distance",

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "geojson",
     "stats",

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gif"

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "shortest-path",

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "grid",

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gis",

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "standard-deviational-ellipse",

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "geojson",
     "turf",

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "turfjs",

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "tin",

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "transform",

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "transform",

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "transform",

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "triangle",

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geojson",

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "gif"

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "kinks",

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "turf",
     "geometry",

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Turfjs/turf.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "gis",
     "geo",


### PR DESCRIPTION
- Add publishConfig.access="public" to all packages, so they can be published to NPM without an account that can have private packages.
- Enforce repository at lerna publish time