### PR TITLE
Revert @turf/turf dist file location change

### DIFF
--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -50,6 +50,7 @@ module.exports = {
           "keywords",
           "main",
           "module",
+          "browser",
           "types",
           "sideEffects",
           "files",
@@ -69,6 +70,19 @@ module.exports = {
       {
         options: {
           entries: {
+            // @turf/turf is commonly consumed through CDNs, moving this output file is a breaking change for anyone
+            // who has a hardcoded reference to this specific file, instead of letting the CDN pick the path.
+            // Example of a URL that will break: https://unpkg.com/@turf/turf/dist/turf.min.js
+            // Example of a URL that will keep working: https://unpkg.com/@turf/turf
+            browser: "turf.min.js",
+            files: ["dist", "index.d.ts", "turf.min.js"]
+          }
+        },
+        includePackages: [MAIN_PACKAGE]
+      },
+      {
+        options: {
+          entries: {
             main: "dist/js/index.js",
             module: "dist/es/index.js",
             sideEffects: false,
@@ -77,7 +91,7 @@ module.exports = {
             }
           }
         },
-        includePackages: [MAIN_PACKAGE, ...TS_PACKAGES, ...JS_PACKAGES]
+        includePackages: [...TS_PACKAGES, ...JS_PACKAGES]
       },
       {
         options: {
@@ -95,7 +109,7 @@ module.exports = {
             files: ["dist", "index.d.ts"]
           }
         },
-        includePackages: [MAIN_PACKAGE, ...JS_PACKAGES]
+        includePackages: JS_PACKAGES
       }
     ],
 

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -44,11 +44,13 @@
   ],
   "main": "dist/js/index.js",
   "module": "dist/es/index.js",
+  "browser": "turf.min.js",
   "types": "index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",
-    "index.d.ts"
+    "index.d.ts",
+    "turf.min.js"
   ],
   "scripts": {
     "last-checks": "npm-run-all last-checks:testjs last-checks:example",
@@ -174,6 +176,5 @@
     "@turf/union": "^6.2.0-alpha.1",
     "@turf/unkink-polygon": "^6.2.0-alpha.1",
     "@turf/voronoi": "^6.2.0-alpha.1"
-  },
-  "browser": "dist/turf.min.js"
+  }
 }


### PR DESCRIPTION
Moving the dist file for @turf/turf is pretty problematic for CDN users. (#1875)
This moves it back to its prior location and enforces it with monorepolint.

