### PR TITLE
Standardize some devDependencies with monorepolint

### DIFF
--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -161,6 +161,37 @@ module.exports = {
         },
         includePackages: TYPES_PACKAGES
       }
+    ],
+
+    ":alphabetical-dependencies": {
+      includeWorkspaceRoot: true
+    },
+
+    ":require-dependency": [
+      {
+        options: {
+          devDependencies: {
+            "npm-run-all": "*"
+          }
+        },
+        includePackages: [...TS_PACKAGES, ...JS_PACKAGES]
+      },
+      {
+        options: {
+          devDependencies: {
+            typescript: "*"
+          }
+        },
+        includePackages: TS_PACKAGES
+      },
+      {
+        options: {
+          devDependencies: {
+            rollup: "*"
+          }
+        },
+        includePackages: JS_PACKAGES
+      }
     ]
   }
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint-staged": "^10.0.8",
     "load-json-file": "*",
     "meow": "*",
-    "monorepolint": "^0.5.0-alpha.17",
+    "monorepolint": "^0.5.0-alpha.20",
     "npm-run-all": "^4.1.5",
     "progress": "*",
     "rollup": "*",

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -43,6 +43,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -47,6 +47,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -42,6 +42,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -49,6 +49,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -40,6 +40,7 @@
     "@turf/destination": "^6.2.0-alpha.1",
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -43,6 +43,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -48,6 +48,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -47,6 +47,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -49,6 +49,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -48,6 +48,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -47,6 +47,7 @@
     "benchmark": "*",
     "boolean-shapely": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -51,6 +51,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -47,6 +47,7 @@
     "benchmark": "*",
     "boolean-shapely": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -50,6 +50,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -45,6 +45,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -44,6 +44,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -51,6 +51,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -49,6 +49,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -51,6 +51,7 @@
     "boolean-shapely": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -51,6 +51,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -52,6 +52,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -47,6 +47,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -42,6 +42,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -48,6 +48,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -45,6 +45,7 @@
     "geojson-fixtures": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -47,6 +47,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -46,6 +46,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -44,6 +44,7 @@
     "@turf/meta": "^6.2.0-alpha.1",
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -55,6 +55,7 @@
     "chromatism": "*",
     "concaveman": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -56,6 +56,7 @@
     "concaveman": "*",
     "load-json-file": "*",
     "matrix-to-grid": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -54,6 +54,7 @@
     "@types/topojson": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -42,6 +42,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -46,6 +46,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -40,6 +40,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -43,6 +43,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -43,6 +43,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -42,6 +42,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -48,6 +48,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -42,6 +42,7 @@
     "benchmark": "*",
     "geojson-fixtures": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -49,6 +49,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -55,6 +55,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -46,6 +46,7 @@
     "benchmark": "*",
     "chromatism": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -43,6 +43,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -54,6 +54,7 @@
     "chroma-js": "*",
     "load-json-file": "*",
     "matrix-to-grid": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -53,6 +53,7 @@
     "benchmark": "*",
     "load-json-file": "*",
     "matrix-to-grid": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -42,6 +42,7 @@
     "@turf/meta": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "typescript": "*",
     "write-json-file": "*"

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -48,6 +48,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -41,6 +41,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "typescript": "*",
     "write-json-file": "*"

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -50,6 +50,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -48,6 +48,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -48,6 +48,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -47,6 +47,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -41,6 +41,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -41,6 +41,7 @@
     "@turf/along": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -45,6 +45,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -47,6 +47,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -42,6 +42,7 @@
     "benchmark": "*",
     "load-json-file": "*",
     "mkdirp": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@turf/random": "^6.2.0-alpha.1",
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -43,6 +43,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -44,6 +44,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -40,6 +40,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -50,6 +50,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -49,6 +49,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -44,6 +44,7 @@
     "@turf/meta": "^6.2.0-alpha.1",
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -46,6 +46,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -45,6 +45,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -43,6 +43,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -56,6 +56,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "proj4": "*",
     "tape": "*",
     "tslint": "*",

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -44,6 +44,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -40,6 +40,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "glob": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -47,8 +47,10 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "typescript": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -48,6 +48,7 @@
     "@turf/destination": "^6.2.0-alpha.1",
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -53,6 +53,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -51,6 +51,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -41,6 +41,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -46,6 +46,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -49,6 +49,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -44,6 +44,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -47,6 +47,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "benchmark": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*"
   },

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*"

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -47,6 +47,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -53,6 +53,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -49,6 +49,7 @@
     "@turf/truncate": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -47,6 +47,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -46,6 +46,7 @@
     "@types/tape": "*",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -43,6 +43,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "tape": "*",
     "tslint": "*",
     "typescript": "*",

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -44,6 +44,7 @@
     "@turf/kinks": "^6.2.0-alpha.1",
     "benchmark": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -49,6 +49,7 @@
     "benchmark": "*",
     "glob": "*",
     "load-json-file": "*",
+    "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
     "write-json-file": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,44 +803,44 @@
     vfile "2.0.0"
     vfile-reporter "3.0.0"
 
-"@monorepolint/cli@^0.5.0-alpha.17+e7ad10b":
-  version "0.5.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@monorepolint/cli/-/cli-0.5.0-alpha.17.tgz#3ff92299cb8aa81f2c38d6f349daf70f511b79da"
-  integrity sha512-sAbW6Y5h1pfS4ODi3TgP0EN9oSNPHmu6JBUA509XLw7wbTPaPlcW7MI9HA8wvKIJS9pgJgKmQX/WK5D+0UGa/Q==
+"@monorepolint/cli@^0.5.0-alpha.20+fb5a530":
+  version "0.5.0-alpha.20"
+  resolved "https://registry.npmjs.org/@monorepolint/cli/-/cli-0.5.0-alpha.20.tgz#9494843de95bd7767041aa7d2add3f9d0a85b410"
+  integrity sha512-1kuyw+KXqMghN4n2JkTjqwnXbftPkOfmsMid6bN2+dDTN7CIKr9goXqbX8/7/SWkst5tK8AOyPku3ODcsWUjVA==
   dependencies:
-    "@monorepolint/core" "^0.5.0-alpha.17+e7ad10b"
-    "@monorepolint/utils" "^0.5.0-alpha.17+e7ad10b"
+    "@monorepolint/core" "^0.5.0-alpha.20+fb5a530"
+    "@monorepolint/utils" "^0.5.0-alpha.20+fb5a530"
     chalk "^2.4.1"
     yargs "^14.0.0"
 
-"@monorepolint/core@^0.5.0-alpha.17+e7ad10b":
-  version "0.5.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@monorepolint/core/-/core-0.5.0-alpha.17.tgz#db8bed7f59049d5176546430bb3e7d7871004446"
-  integrity sha512-s88ZE8QooeUWPkouQp9XqJRstH9fqXIWsCcp9tCf6wRV821QgTsslBPH695Ai7Qwv6VhX71H1qfLmG+MEARovw==
+"@monorepolint/core@^0.5.0-alpha.20+fb5a530":
+  version "0.5.0-alpha.20"
+  resolved "https://registry.npmjs.org/@monorepolint/core/-/core-0.5.0-alpha.20.tgz#10fa595936ab244a8f540718f936165768d71496"
+  integrity sha512-l7orLrxIJCqwDDohxt2Iv2y5Ib/YSRStPiMUiRNFsE92paL+fO+P1P0wZx7uPPzZ+u75Z1Qqwq/3v483T2zTsQ==
   dependencies:
-    "@monorepolint/utils" "^0.5.0-alpha.17+e7ad10b"
+    "@monorepolint/utils" "^0.5.0-alpha.20+fb5a530"
     camelcase "^5.2.0"
     chalk "^2.4.1"
     minimatch "^3.0.4"
     runtypes "^4.0.0"
     tslib "^1.9.0"
 
-"@monorepolint/rules@^0.5.0-alpha.17+e7ad10b":
-  version "0.5.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@monorepolint/rules/-/rules-0.5.0-alpha.17.tgz#1e91adfb70192a9b641d612ebc739e0126e39ddd"
-  integrity sha512-Vq9dmamZAqbXR1O14u4iGHbK3XMeumCyMg222rW3yta6+eSCgv5X42IgGjJxZyi7OAyUHQq8oRInp5F/ynqB9g==
+"@monorepolint/rules@^0.5.0-alpha.20+fb5a530":
+  version "0.5.0-alpha.20"
+  resolved "https://registry.npmjs.org/@monorepolint/rules/-/rules-0.5.0-alpha.20.tgz#c53d7c6b549c04feef13ab7a2fcea5dda00f259a"
+  integrity sha512-wCNuLGvm+8tf9aCkIkBBc7ik8LH7shImLoIeq1PtOStN9sc4zrVBxz6jdsyH0/l4CFn+dktrl2SXxM4kPH7H+Q==
   dependencies:
-    "@monorepolint/core" "^0.5.0-alpha.17+e7ad10b"
-    "@monorepolint/utils" "^0.5.0-alpha.17+e7ad10b"
+    "@monorepolint/core" "^0.5.0-alpha.20+fb5a530"
+    "@monorepolint/utils" "^0.5.0-alpha.20+fb5a530"
     globby "^10.0.2"
     jest-diff "^24.9.0"
     minimatch "^3.0.4"
     runtypes "^4.0.0"
 
-"@monorepolint/utils@^0.5.0-alpha.17+e7ad10b":
-  version "0.5.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@monorepolint/utils/-/utils-0.5.0-alpha.17.tgz#63b1cf3f7358346d2981a23649fd19e931fc15e4"
-  integrity sha512-y9q2V+Zjcm3ZFk6AifWpdMBjsjfIn5vjKTxfBm8ZYVr5d4waB6wmVxwoSjsj7DmwYfbkO9fFh9O4qoUCr+MPmQ==
+"@monorepolint/utils@^0.5.0-alpha.20+fb5a530":
+  version "0.5.0-alpha.20"
+  resolved "https://registry.npmjs.org/@monorepolint/utils/-/utils-0.5.0-alpha.20.tgz#7277cca0d2d1c7bfe3949939c04882a56100d6d1"
+  integrity sha512-0i2TZm810ORjaFFucftnUwUb4PHSlnjbEKQOuSBlQVl3CltD/01pRULQwPyzTe+6bWqtZQGo85e7rYJJnZdWZw==
   dependencies:
     glob "^7.1.3"
 
@@ -978,15 +978,35 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@turf/bbox@*":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
+  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/helpers@5.x", "@turf/helpers@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
+
+"@turf/helpers@6.x":
+  version "6.1.4"
+  resolved "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
+  integrity sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==
 
 "@turf/invariant@^5.1.5":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
   dependencies:
     "@turf/helpers" "^5.1.5"
+
+"@turf/meta@6.x":
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz#eb92951126d24a613ac1b7b99d733fcc20fd30cf"
+  integrity sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/rhumb-destination@5.x":
   version "5.1.5"
@@ -6061,15 +6081,15 @@ module-deps-sortable@4.0.6:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-monorepolint@^0.5.0-alpha.17:
-  version "0.5.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/monorepolint/-/monorepolint-0.5.0-alpha.17.tgz#5a455beca2263c8313c3390056c8c2ab9495e395"
-  integrity sha512-yWKwCKKgRmMK9nAcR5SJ7d5K/UvPDEf8DscTKc28sWGXaKbo99FjpUGJm5z+4f0w32gnheGLNJbfjUxF3kTGMA==
+monorepolint@^0.5.0-alpha.20:
+  version "0.5.0-alpha.20"
+  resolved "https://registry.npmjs.org/monorepolint/-/monorepolint-0.5.0-alpha.20.tgz#afa40f05467ab9a4050ca1d4fe34d57a4c44c308"
+  integrity sha512-c3vc2K4YVDgRQgDLuOgQPhtG6uc4S8moleEp7bO8Voa/atKlnEKO4A3U1IQ2tThuOPTV0yRCCDkLvBuxqbvZsA==
   dependencies:
-    "@monorepolint/cli" "^0.5.0-alpha.17+e7ad10b"
-    "@monorepolint/core" "^0.5.0-alpha.17+e7ad10b"
-    "@monorepolint/rules" "^0.5.0-alpha.17+e7ad10b"
-    "@monorepolint/utils" "^0.5.0-alpha.17+e7ad10b"
+    "@monorepolint/cli" "^0.5.0-alpha.20+fb5a530"
+    "@monorepolint/core" "^0.5.0-alpha.20+fb5a530"
+    "@monorepolint/rules" "^0.5.0-alpha.20+fb5a530"
+    "@monorepolint/utils" "^0.5.0-alpha.20+fb5a530"
 
 monotone-convex-hull-2d@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Ensure npm-run-all, typescript, and rollup devDependencies are set. 
Ensure dependencies remain alphabetized.

Fixes #1854