### PR TITLE
point-grid - Use center latitude to compute horizontal distance

### DIFF
--- a/packages/turf-point-grid/index.ts
+++ b/packages/turf-point-grid/index.ts
@@ -52,20 +52,20 @@ function pointGrid<P = Properties>(bbox: BBox, cellSide: number, options: {
     var north = bbox[3];
 
     var xCenter = 0;
-	var yCenter = 0;
+    var yCenter = 0;
 	
-	if(east > west)
-	{
-		xCenter = west + (east - west) / 2;
-	}
-	else if(east < west)
-	{
-		xCenter = east - (west + east) / 2;
-	}
-	
-	yCenter = north - (north - south) / 2;
+    if(east > west)
+    {
+        xCenter = west + (east - west) / 2;
+    }
+    else if(east < west)
+    {
+        xCenter = east - (west + east) / 2;
+    }
+    
+    yCenter = north - (north - south) / 2;
 
-	var xFraction = cellSide / ((distance([xCenter, yCenter], [east, yCenter], options)) * 2);
+    var xFraction = cellSide / ((distance([xCenter, yCenter], [east, yCenter], options)) * 2);
     var cellWidth = xFraction * (east - west);
     var yFraction = cellSide / (distance([west, south], [west, north], options));
     var cellHeight = yFraction * (north - south);

--- a/packages/turf-point-grid/index.ts
+++ b/packages/turf-point-grid/index.ts
@@ -51,7 +51,21 @@ function pointGrid<P = Properties>(bbox: BBox, cellSide: number, options: {
     var east = bbox[2];
     var north = bbox[3];
 
-    var xFraction = cellSide / (distance([west, south], [east, south], options));
+    var xCenter = 0;
+	var yCenter = 0;
+	
+	if(east > west)
+	{
+		xCenter = west + (east - west) / 2;
+	}
+	else if(east < west)
+	{
+		xCenter = east - (west + east) / 2;
+	}
+	
+	yCenter = north - (north - south) / 2;
+
+	var xFraction = cellSide / ((distance([xCenter, yCenter], [east, yCenter], options)) * 2);
     var cellWidth = xFraction * (east - west);
     var yFraction = cellSide / (distance([west, south], [west, north], options));
     var cellHeight = yFraction * (north - south);


### PR DESCRIPTION
Correction of xFraction variable calculation.

I propose to calculate the distance in latitude from the edge of the box to the center and multiply by 2, because with a large box (more than half the length of the latitude), the distance is not calculated correctly (the shortest distance from edge to edge will envelope the Earth from the other side and will not be the length of the box).

I also propose to calculate the distance in latitude, located in the center of the height of the box, because Now it is calculated on the lower edge (south), which gives a very small number of points for large boxes (at a height from the equator to the pole), because at the northern and southern latitudes their length decreases with distance from the equator. Also, with the same small boxes (one in the northern hemisphere, the other in the southern), the difference in result will be visible. In this regard, I think it will be fair to consider the latitude located in the center of the box.

And you also need to revise the tests for this module.

Thank.

PS: I attach the results and testing code to the tests of the module turf-point-grid. For comparison.
[turf-point-grid-test.zip](https://github.com/Turfjs/turf/files/4521022/turf-point-grid-test.zip)

Resolves #1886 