### PR TITLE
greaterCircle fix for readme example

### DIFF
--- a/packages/turf-great-circle/README.md
+++ b/packages/turf-great-circle/README.md
@@ -6,7 +6,7 @@
 
 Calculate great circles routes as [LineString][1]
 
-**Parameters**
+### Parameters
 
 -   `start` **[Coord][2]** source point feature
 -   `end` **[Coord][2]** destination point feature
@@ -16,13 +16,13 @@ Calculate great circles routes as [LineString][1]
     -   `options.offset` **[number][4]** offset controls the likelyhood that lines will
         be split which cross the dateline. The higher the number the more likely. (optional, default `10`)
 
-**Examples**
+### Examples
 
 ```javascript
 var start = turf.point([-122, 48]);
 var end = turf.point([-77, 39]);
 
-var greatCircle = turf.greatCircle(start, end, {'name': 'Seattle to DC'});
+var greatCircle = turf.greatCircle(start, end, {properties: {name: 'Seattle to DC'}});
 
 //addToMap
 var addToMap = [start, end, greatCircle]

--- a/packages/turf-great-circle/index.js
+++ b/packages/turf-great-circle/index.js
@@ -17,7 +17,7 @@ import { GreatCircle } from './lib/arc';
  * var start = turf.point([-122, 48]);
  * var end = turf.point([-77, 39]);
  *
- * var greatCircle = turf.greatCircle(start, end, {'name': 'Seattle to DC'});
+ * var greatCircle = turf.greatCircle(start, end, {properties: {name: 'Seattle to DC'}});
  *
  * //addToMap
  * var addToMap = [start, end, greatCircle]


### PR DESCRIPTION
The example in the greaterCircle readme was not correctly declaring the `options.properties` object

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [X] Run `npm test` at the sub modules where changes have occurred.
- [X] Run `npm run lint` to ensure code style at the turf module level.
