### PR TITLE
Improve @turf/boolean-overlap performance on MultiPoints

### DIFF
--- a/packages/turf-boolean-overlap/index.ts
+++ b/packages/turf-boolean-overlap/index.ts
@@ -1,9 +1,9 @@
-import { coordAll, segmentEach } from '@turf/meta';
+import { segmentEach } from '@turf/meta';
 import { getGeom } from '@turf/invariant';
 import lineOverlap from '@turf/line-overlap';
 import lineIntersect from '@turf/line-intersect';
 import GeojsonEquality from 'geojson-equality';
-import { Feature, LineString, MultiLineString, Polygon, MultiPolygon, Geometry } from '@turf/helpers';
+import { Feature, Geometry, MultiPoint } from '@turf/helpers';
 
 /**
  * Compares two geometries of the same dimension and returns true if their intersection set results in a geometry
@@ -48,14 +48,16 @@ export default function booleanOverlap(
 
     switch (type1) {
     case 'MultiPoint':
-        const coords1 = coordAll(feature1);
-        const coords2 = coordAll(feature2);
-        coords1.forEach((coord1) => {
-            coords2.forEach((coord2) => {
-                if (coord1[0] === coord2[0] && coord1[1] === coord2[1]) overlap++;
-            });
-        });
-        break;
+        for (var i=0; i<(geom1 as MultiPoint).coordinates.length; i++) {
+            for (var j=0; j<(geom2 as MultiPoint).coordinates.length; j++) {
+                var coord1 = geom1.coordinates[i];
+                var coord2 = geom2.coordinates[j];
+                if (coord1[0] === coord2[0] && coord1[1] === coord2[1]) {
+                    return true;
+                }
+            }
+        }
+        return false;
 
     case 'LineString':
     case 'MultiLineString':


### PR DESCRIPTION
Changes:

- Don't make a copy of the multipoint coordinates
- Exit early when we know there is an overlap, instead of continuing on
- Removed some unused imports as a bonus

I wanted to try something similar on the lines and polygons, but segmentEach() doesn't have a way to exit early so I skipped it for now.

Here's the relevant bench.js output, I removed the ones for lines and polygons:

Before:
```
equal-multipoints: 0.271ms
multipoints: 0.231ms
multipoints: 0.025ms
single-multipoints: 0.021ms
equal-multipoints x 65,977 ops/sec ±1.40% (87 runs sampled)
multipoints x 1,664,734 ops/sec ±2.02% (83 runs sampled)
multipoints x 1,572,537 ops/sec ±1.52% (86 runs sampled)
single-multipoints x 1,860,378 ops/sec ±1.86% (89 runs sampled)
```

After:
```
equal-multipoints: 0.186ms
multipoints: 0.035ms
multipoints: 0.017ms
single-multipoints: 0.014ms
equal-multipoints x 69,743 ops/sec ±1.49% (88 runs sampled)
multipoints x 4,899,999 ops/sec ±1.88% (79 runs sampled)
multipoints x 5,212,289 ops/sec ±1.44% (79 runs sampled)
single-multipoints x 6,440,465 ops/sec ±1.53% (87 runs sampled)
```