### PR TITLE
added hectares to convertArea

### DIFF
--- a/packages/turf-helpers/README.md
+++ b/packages/turf-helpers/README.md
@@ -453,7 +453,7 @@ Returns **[number][6]** the converted length
 ## convertArea
 
 Converts a area to the requested unit.
-Valid units: kilometers, kilometres, meters, metres, centimetres, millimeters, acres, miles, yards, feet, inches
+Valid units: kilometers, kilometres, meters, metres, centimetres, millimeters, acres, miles, yards, feet, inches, hectares
 
 **Parameters**
 

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -19,7 +19,7 @@ export type Coord = Feature<Point> | Point | Position;
 // TurfJS String Types
 export type Units = "meters" | "millimeters" | "centimeters" |
                     "kilometers" | "acres" | "miles" | "nauticalmiles" |
-                    "inches" | "yards" | "feet" | "radians" | "degrees";
+                    "inches" | "yards" | "feet" | "radians" | "degrees" | "hectares";
 export type Grid = "point" | "square" | "hex" | "triangle";
 export type Corners = "sw" | "se" | "nw" | "ne" | "center" | "centroid";
 
@@ -97,6 +97,7 @@ export let areaFactors: any = {
     centimeters: 10000,
     centimetres: 10000,
     feet: 10.763910417,
+    hectares: 0.0001,
     inches: 1550.003100006,
     kilometers: 0.000001,
     kilometres: 0.000001,
@@ -628,7 +629,7 @@ export function convertLength(
 
 /**
  * Converts a area to the requested unit.
- * Valid units: kilometers, kilometres, meters, metres, centimetres, millimeters, acres, miles, yards, feet, inches
+ * Valid units: kilometers, kilometres, meters, metres, centimetres, millimeters, acres, miles, yards, feet, inches, hectares
  * @param {number} area to be converted
  * @param {Units} [originalUnit="meters"] of the distance
  * @param {Units} [finalUnit="kilometers"] returned unit

--- a/packages/turf-helpers/test.js
+++ b/packages/turf-helpers/test.js
@@ -354,6 +354,7 @@ test('convertArea', t => {
     t.equal(convertArea(100, undefined, 'yards'), 119.59900459999999);
     t.equal(convertArea(100, 'metres', 'feet'), 1076.3910417);
     t.equal(convertArea(100000, 'feet', undefined), 0.009290303999749462);
+    t.equal(convertArea(1, 'meters', 'hectares'), 0.0001);
     // t.throws(() => convertLength(1, 'foo'), 'invalid original units');
     // t.throws(() => convertLength(1, 'meters', 'foo'), 'invalid final units');
 


### PR DESCRIPTION
Hello.  This pull request adds hectares as a unit to convertArea inside of turf-helpers.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [X] Run `npm test` at the sub modules where changes have occurred.
- [X] Run `npm run lint` to ensure code style at the turf module level.

This is my first submission to Turf.  I apologize in advance for anything I might have missed.  Happy to provide more details.  Thank you for your consideration.

References:
- https://en.wikipedia.org/wiki/Hectare
- googling convert 1 meter to hectares which displays
<img width="584" alt="Screen Shot 2020-09-16 at 5 46 07 PM" src="https://user-images.githubusercontent.com/4313463/93395776-83262080-f844-11ea-8454-c0d2c1abf443.png">
