### PR TITLE
Clarify MarchingSquares.js license

### DIFF
--- a/packages/turf-isobands/lib/marchingsquares-isobands.js
+++ b/packages/turf-isobands/lib/marchingsquares-isobands.js
@@ -3,8 +3,38 @@
  * Copyright (c) 2015, 2015 Ronny Lorenz <ronny@tbi.univie.ac.at>
  * v. 1.2.0
  * https://github.com/RaumZeit/MarchingSquares.js
+ *
+ * MarchingSquaresJS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MarchingSquaresJS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * As additional permission under GNU Affero General Public License version 3
+ * section 7, third-party projects (personal or commercial) may distribute,
+ * include, or link against UNMODIFIED VERSIONS of MarchingSquaresJS without the
+ * requirement that said third-party project for that reason alone becomes
+ * subject to any requirement of the GNU Affero General Public License version 3.
+ * Any modifications to MarchingSquaresJS, however, must be shared with the public
+ * and made available.
+ *
+ * In summary this:
+ * - allows you to use MarchingSquaresJS at no cost
+ * - allows you to use MarchingSquaresJS for both personal and commercial purposes
+ * - allows you to distribute UNMODIFIED VERSIONS of MarchingSquaresJS under any
+ *   license as long as this license notice is included
+ * - enables you to keep the source code of your program that uses MarchingSquaresJS
+ *   disclosed
+ * - forces you to share any modifications you have made to MarchingSquaresJS,
+ *   e.g. bug-fixes
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with MarchingSquaresJS.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 var defaultSettings = {
   successCallback: null,
   verbose: false,

--- a/packages/turf-isobands/lib/marchingsquares-isobands.js
+++ b/packages/turf-isobands/lib/marchingsquares-isobands.js
@@ -28,7 +28,7 @@
  * - allows you to distribute UNMODIFIED VERSIONS of MarchingSquaresJS under any
  *   license as long as this license notice is included
  * - enables you to keep the source code of your program that uses MarchingSquaresJS
- *   disclosed
+ *   undisclosed
  * - forces you to share any modifications you have made to MarchingSquaresJS,
  *   e.g. bug-fixes
  *

--- a/packages/turf-isolines/lib/marchingsquares-isocontours.js
+++ b/packages/turf-isolines/lib/marchingsquares-isocontours.js
@@ -28,7 +28,7 @@
  * - allows you to distribute UNMODIFIED VERSIONS of MarchingSquaresJS under any
  *   license as long as this license notice is included
  * - enables you to keep the source code of your program that uses MarchingSquaresJS
- *   disclosed
+ *   undisclosed
  * - forces you to share any modifications you have made to MarchingSquaresJS,
  *   e.g. bug-fixes
  *

--- a/packages/turf-isolines/lib/marchingsquares-isocontours.js
+++ b/packages/turf-isolines/lib/marchingsquares-isocontours.js
@@ -3,6 +3,37 @@
  * Copyright (c) 2015, 2015 Ronny Lorenz <ronny@tbi.univie.ac.at>
  * v. 1.2.0
  * https://github.com/RaumZeit/MarchingSquares.js
+ *
+ * MarchingSquaresJS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MarchingSquaresJS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * As additional permission under GNU Affero General Public License version 3
+ * section 7, third-party projects (personal or commercial) may distribute,
+ * include, or link against UNMODIFIED VERSIONS of MarchingSquaresJS without the
+ * requirement that said third-party project for that reason alone becomes
+ * subject to any requirement of the GNU Affero General Public License version 3.
+ * Any modifications to MarchingSquaresJS, however, must be shared with the public
+ * and made available.
+ *
+ * In summary this:
+ * - allows you to use MarchingSquaresJS at no cost
+ * - allows you to use MarchingSquaresJS for both personal and commercial purposes
+ * - allows you to distribute UNMODIFIED VERSIONS of MarchingSquaresJS under any
+ *   license as long as this license notice is included
+ * - enables you to keep the source code of your program that uses MarchingSquaresJS
+ *   disclosed
+ * - forces you to share any modifications you have made to MarchingSquaresJS,
+ *   e.g. bug-fixes
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with MarchingSquaresJS.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,15 +1008,6 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@rollup/plugin-buble@^0.21.3":
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-buble/-/plugin-buble-0.21.3.tgz#1649a915b1d051a4f430d40e7734a7f67a69b33e"
-  integrity sha1-FkmpFbHQUaT0MNQOdzSn9nppsz4=
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    "@types/buble" "^0.19.2"
-    buble "^0.20.0"
-
 "@rollup/plugin-commonjs@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-17.0.0.tgz#2ae2228354cf0fbba6cf9f06f30b2c66a974324c"
@@ -1042,7 +1033,7 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=
@@ -1094,13 +1085,6 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
     "@turf/invariant" "^5.1.5"
-
-"@types/buble@^0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@types/buble/-/buble-0.19.2.tgz#a4289d20b175b3c206aaad80caabdabe3ecdfdd1"
-  integrity sha1-pCidILF1s8IGqq2Ayqvavj7N/dE=
-  dependencies:
-    magic-string "^0.25.0"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -1320,12 +1304,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-acorn-dynamic-import@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
-  integrity sha1-SCIQFAWCo2uDw+NC4c/ryqkkCUg=
-
-acorn-jsx@^5.2.0, acorn-jsx@^5.3.1:
+acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
@@ -2480,19 +2459,6 @@ btoa-lite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
-
-buble@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/buble/-/buble-0.20.0.tgz#a143979a8d968b7f76b57f38f2e7ce7cfe938d1f"
-  integrity sha1-oUOXmo2Wi392tX848ufOfP6TjR8=
-  dependencies:
-    acorn "^6.4.1"
-    acorn-dynamic-import "^4.0.0"
-    acorn-jsx "^5.2.0"
-    chalk "^2.4.2"
-    magic-string "^0.25.7"
-    minimist "^1.2.5"
-    regexpu-core "4.5.4"
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -5964,7 +5930,7 @@ macos-release@^2.2.0:
   resolved "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
   integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
-magic-string@^0.25.0, magic-string@^0.25.7:
+magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha1-P0l9b9NMZpxnmNy4IfLvMfVEUFE=
@@ -7652,21 +7618,9 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-regenerate-unicode-properties@^8.0.2:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
-  integrity sha1-5d5xEdZV57pgwFfb6f83yH5lzew=
-  dependencies:
-    regenerate "^1.4.0"
-
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
-
-regenerate@^1.4.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
-  integrity sha1-uTRtiCfo9aMve6KWN9OYtpAUhIo=
 
 regenerator-runtime@^0.10.0:
   version "0.10.5"
@@ -7708,18 +7662,6 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
-regexpu-core@4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
-  integrity sha1-CA2dAiiaqH/hZnpPUTa8mKauuq4=
-  dependencies:
-    regenerate "^1.4.0"
-    regenerate-unicode-properties "^8.0.2"
-    regjsgen "^0.5.0"
-    regjsparser "^0.6.0"
-    unicode-match-property-ecmascript "^1.0.4"
-    unicode-match-property-value-ecmascript "^1.1.0"
-
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -7732,21 +7674,9 @@ regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
 
-regjsgen@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.2.tgz#92ff295fb1deecbf6ecdab2543d207e91aa33733"
-  integrity sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM=
-
 regjsparser@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
-  dependencies:
-    jsesc "~0.5.0"
-
-regjsparser@^0.6.0:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.4.tgz#a769f8684308401a66e9b529d2436ff4d0666272"
-  integrity sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=
   dependencies:
     jsesc "~0.5.0"
 
@@ -9237,29 +9167,6 @@ unherit@^1.0.4:
   dependencies:
     inherits "^2.0.1"
     xtend "^4.0.1"
-
-unicode-canonical-property-names-ecmascript@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
-  integrity sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=
-
-unicode-match-property-ecmascript@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
-  integrity sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=
-  dependencies:
-    unicode-canonical-property-names-ecmascript "^1.0.4"
-    unicode-property-aliases-ecmascript "^1.0.4"
-
-unicode-match-property-value-ecmascript@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz#0d91f600eeeb3096aa962b1d6fc88876e64ea531"
-  integrity sha1-DZH2AO7rMJaqlisdb8iIduZOpTE=
-
-unicode-property-aliases-ecmascript@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
-  integrity sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ=
 
 unified@^6.0.0:
   version "6.1.6"


### PR DESCRIPTION
There was a bit of confusion about the license on the MarchingSquares code. In order to make it clearer that this particular code is compatible with Turf's chosen MIT license, I went ahead and copied the entire license block from the source repo and put it inline to make things clearer for the next person that comes along.

Related original discussion: https://github.com/RaumZeit/MarchingSquares.js/issues/3

@stebogit @RaumZeit @rowanwins FYSA

There's also an unrelated small yarn.lock update that somehow wasn't caught by the build system.