### PR TITLE
Add .js to relative import statements in es output at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:escheck-js": "es-check es5 packages/*/dist/js/index.js packages/turf/turf.min.js",
     "lint:escheck-es": "es-check --module es5 packages/*/dist/es/index.js",
     "postlint": "documentation lint packages/turf-*/index.js",
-    "prepare": "lerna bootstrap && lerna run build",
+    "prepare": "lerna bootstrap && lerna run build && node ./scripts/add-import-extensions.js",
     "pretest": "npm run lint",
     "test": "lerna run test",
     "posttest": "lerna run --scope @turf/turf last-checks",

--- a/scripts/add-import-extensions.js
+++ b/scripts/add-import-extensions.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * This script adds '.js' extensions to our dist/es output for relative path imports.
+ *
+ * This is a workaround that gives us fully specified ES import statements in our output
+ * while allowing our internal-facing code to be a little looser. Specifically in Typescript
+ * modules, we would normally use .js as an extension for our other typescript code, but
+ * that actually causes issues with ts-node's importing of the .ts files.
+ */
+
+const glob = require("glob");
+const fs = require("fs");
+
+const RELATIVE_IMPORT_REGEX = /^import (.*) from "(\.\/.*)";$/gm;
+
+glob("packages/**/dist/es/**/*.js", (err, files) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  } else {
+    for (const file of files) {
+      fs.readFile(file, (err, data) => {
+        if (err) {
+          console.error(`Error reading ${file}`, err);
+        }
+
+        const contents = data.toString();
+
+        // replace any imports
+        let count = 0;
+        const output = contents.replace(
+          RELATIVE_IMPORT_REGEX,
+          (_match, imports, specifier) => {
+            count++;
+            return `import ${imports} from "${specifier}.js";`;
+          }
+        );
+
+        if (count > 0) {
+          console.log(`Updated ${count} import(s) for ${file}`);
+          fs.writeFile(file, output, (err) => {
+            if (err) {
+              console.error(`Failed to write ${file}`, err);
+              process.exit(1);
+            }
+          });
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
In https://github.com/Turfjs/turf/pull/1942#issuecomment-759070517 it was pointed out that Turf does not quite work in Webpack 5 without a [workaround](https://github.com/webpack/webpack/issues/11467#issuecomment-691873586).

This change adds a build-time transform onto the dist/es output files that adds the .js extensions to all of the outputs.

I would have preferred to specify the .js extension directly in the imports in the source, but that was not working well with the way we use ts-node to run test and bench. I'm a little worried that this is a little fragile because it is a regular expression, but I'm hoping that this ages gracefully and prevents us from needing an entire codemod framework to do the same thing.