### PR TITLE
Add prompt for version in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 Please provide the following when reporting an issue:
 
+- [ ] The version of Turf you are using, and any other relevant versions.
 - [ ] GeoJSON data as a [gist file](https://gist.github.com/) or [geojson.io](http://geojson.io/) (filename extension must be `.geojson`).
 - [ ] Snippet of source code or for complex examples use [jsfiddle](https://jsfiddle.net/).
-- [ ] The version of Turf you are using, and any other relevant versions.
 
 <!-- Love turf? Please consider supporting our collective:
 👉  https://opencollective.com/turf/donate -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,7 @@ Please provide the following when reporting an issue:
 
 - [ ] GeoJSON data as a [gist file](https://gist.github.com/) or [geojson.io](http://geojson.io/) (filename extension must be `.geojson`).
 - [ ] Snippet of source code or for complex examples use [jsfiddle](https://jsfiddle.net/).
+- [ ] The version of Turf you are using, and any other relevant versions.
 
 <!-- Love turf? Please consider supporting our collective:
 👉  https://opencollective.com/turf/donate -->


### PR DESCRIPTION
We've been getting a bunch of issues reported and the first question I ask is always "what version of turf are you using".
Hopefully by adding this to the issue template, we will get proper versions more often and save time with back-and-forth.