### PR TITLE
Fix TypeScript strict mode typing errors for turf-polygonize and turf-clusters-dbscan

### DIFF
--- a/packages/turf-clusters-dbscan/index.ts
+++ b/packages/turf-clusters-dbscan/index.ts
@@ -11,10 +11,10 @@ import {
 import clustering from "density-clustering";
 
 export type Dbscan = "core" | "edge" | "noise";
-export interface DbscanProps extends Properties {
+export type DbscanProps = Properties & {
   dbscan?: Dbscan;
   cluster?: number;
-}
+};
 
 /**
  * Takes a set of {@link Point|points} and partition them into clusters according to {@link DBSCAN's|https://en.wikipedia.org/wiki/DBSCAN} data clustering algorithm.
@@ -62,7 +62,7 @@ function clustersDbscan(
 
   // create clustered ids
   var dbscan = new clustering.DBSCAN();
-  var clusteredIds = dbscan.run(
+  var clusteredIds: number[][] = dbscan.run(
     coordAll(points),
     convertLength(maxDistance, options.units),
     options.minPoints,
@@ -74,7 +74,7 @@ function clustersDbscan(
   clusteredIds.forEach(function (clusterIds) {
     clusterId++;
     // assign cluster ids to input points
-    clusterIds.forEach(function (idx) {
+    clusterIds.forEach(function (idx: number) {
       var clusterPoint = points.features[idx];
       if (!clusterPoint.properties) clusterPoint.properties = {};
       clusterPoint.properties.cluster = clusterId;
@@ -84,14 +84,14 @@ function clustersDbscan(
 
   // handle noise points, if any
   // edges points are tagged by DBSCAN as both 'noise' and 'cluster' as they can "reach" less than 'minPoints' number of points
-  dbscan.noise.forEach(function (noiseId) {
+  dbscan.noise.forEach(function (noiseId: number) {
     var noisePoint = points.features[noiseId];
     if (!noisePoint.properties) noisePoint.properties = {};
     if (noisePoint.properties.cluster) noisePoint.properties.dbscan = "edge";
     else noisePoint.properties.dbscan = "noise";
   });
 
-  return points;
+  return points as FeatureCollection<Point, DbscanProps>;
 }
 
 export default clustersDbscan;

--- a/packages/turf-polygonize/index.ts
+++ b/packages/turf-polygonize/index.ts
@@ -39,8 +39,8 @@ export default function polygonize<T extends LineString | MultiLineString>(
   graph.deleteCutEdges();
 
   // 3. Get all holes and shells
-  const holes = [],
-    shells = [];
+  const holes: EdgeRing[] = [];
+  const shells: EdgeRing[] = [];
 
   graph
     .getEdgeRings()

--- a/packages/turf-polygonize/lib/Edge.ts
+++ b/packages/turf-polygonize/lib/Edge.ts
@@ -7,12 +7,12 @@ import EdgeRing from "./EdgeRing";
  * This class is inspired by GEOS's geos::operation::polygonize::PolygonizeDirectedEdge
  */
 export default class Edge {
-  public label: number;
-  public symetric: Edge;
+  public label: number | undefined;
+  public symetric: Edge | undefined;
   public from: Node;
   public to: Node;
-  public next: Edge;
-  public ring: EdgeRing;
+  public next: Edge | undefined;
+  public ring: EdgeRing | undefined;
 
   /**
    * Creates or get the symetric Edge.
@@ -32,7 +32,7 @@ export default class Edge {
    * @param {Node} from - start node of the Edge
    * @param {Node} to - end node of the edge
    */
-  constructor(from, to) {
+  constructor(from: Node, to: Node) {
     this.from = from; //< start
     this.to = to; //< End
 
@@ -61,7 +61,7 @@ export default class Edge {
    * @param {Edge} edge - Another Edge
    * @returns {boolean} - True if Edges are equal, False otherwise
    */
-  isEqual(edge) {
+  isEqual(edge: Edge) {
     return this.from.id === edge.from.id && this.to.id === edge.to.id;
   }
 
@@ -88,7 +88,7 @@ export default class Edge {
    *          0 if the Edges are colinear,
    *          1 otherwise
    */
-  compareTo(edge) {
+  compareTo(edge: Edge) {
     return orientationIndex(
       edge.from.coordinates,
       edge.to.coordinates,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

 
Fixes TypeScript errors in the `turf-polygonize` and `turf-clusters-dbscan` packages. This should resolve the issue people were seeing with turf-dbscan on install when they have TypeScript strict mode on in their project (https://github.com/Turfjs/turf/issues/2017) 
