### PR TITLE
Move to GitHub Actions from Travis for CI

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -1,0 +1,25 @@
+name: Turf.js Actions
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -20,6 +20,5 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
+      - run: yarn --frozen-lockfile
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-cache: yarn
-node_js:
-  - 12

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ======
 
 [![Version Badge][npm-img]][npm-url]
-[![Travis CI](https://travis-ci.org/Turfjs/turf.svg?branch=master)](https://travis-ci.org/Turfjs/turf)
 [![Gitter chat][gitter-img]][gitter-url]
 [![Backers on Open Collective][oc-backer-badge]](#backers) 
 [![Sponsors on Open Collective][oc-sponsor-badge]](#sponsors) [![Coverage Status](https://coveralls.io/repos/github/Turfjs/turf/badge.svg)](https://coveralls.io/github/Turfjs/turf)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.
 
 
Small change but hopefully this should end our CI woes for the forseeable future. For this to work I think it needs to be force merged to get past the current Travis checks, then we can set up branch protections for the GitHub actions workflow