### PR TITLE
Throw exit code when there is a diff after yarn install during CI buillds

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -36,4 +36,5 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - run: yarn --frozen-lockfile
+      - run: git diff --exit-code
       - run: yarn test


### PR DESCRIPTION
This aims to resolve #2104 - the approach here is to throw an error code if the lock file changes after install

Fixes #2104 