### PR TITLE
Proof of Concept - Remove turf-jsts replace with custom JSTS build in turf-buffer

### DIFF
--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -1,5 +1,5 @@
 import center from "@turf/center";
-import { BufferOp, GeoJSONReader, GeoJSONWriter } from "turf-jsts";
+import { bufferOp } from "./lib/bufferOp";
 import { geomEach, featureEach } from "@turf/meta";
 import { geoAzimuthalEquidistant } from "d3-geo";
 import {
@@ -104,12 +104,8 @@ function bufferFeature(geojson, radius, units, steps) {
   };
 
   // JSTS buffer operation
-  var reader = new GeoJSONReader();
-  var geom = reader.read(projected);
   var distance = radiansToLength(lengthToRadians(radius, units), "meters");
-  var buffered = BufferOp.bufferOp(geom, distance, steps);
-  var writer = new GeoJSONWriter();
-  buffered = writer.write(buffered);
+  var buffered = bufferOp(projected, distance, steps);
 
   // Detect if empty geometries
   if (coordsIsNaN(buffered.coordinates)) return undefined;

--- a/packages/turf-buffer/lib/bufferOp.js
+++ b/packages/turf-buffer/lib/bufferOp.js
@@ -1,0 +1,11 @@
+/**
+ * Polyfill for IE support
+ */
+import "./utils/polyfills";
+
+/**
+ * Turf JSTS dependant modules
+ *
+ * BufferOp => @turf/buffer
+ */
+export { bufferOp } from "./org/locationtech/jts/operation/buffer";

--- a/packages/turf-buffer/lib/java/lang/IllegalArgumentException.js
+++ b/packages/turf-buffer/lib/java/lang/IllegalArgumentException.js
@@ -1,0 +1,8 @@
+export default class IllegalArgumentException extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "IllegalArgumentException";
+    this.message = message;
+    this.stack = new Error().stack;
+  }
+}

--- a/packages/turf-buffer/lib/java/lang/RuntimeException.js
+++ b/packages/turf-buffer/lib/java/lang/RuntimeException.js
@@ -1,0 +1,8 @@
+export default class RuntimeException extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RuntimeException";
+    this.message = message;
+    this.stack = new Error().stack;
+  }
+}

--- a/packages/turf-buffer/lib/java/util/TreeMap.js
+++ b/packages/turf-buffer/lib/java/util/TreeMap.js
@@ -1,0 +1,270 @@
+const BLACK = 0;
+const RED = 1;
+function colorOf(p) {
+  return p === null ? BLACK : p.color;
+}
+function parentOf(p) {
+  return p === null ? null : p.parent;
+}
+function setColor(p, c) {
+  if (p !== null) p.color = c;
+}
+function leftOf(p) {
+  return p === null ? null : p.left;
+}
+function rightOf(p) {
+  return p === null ? null : p.right;
+}
+
+/**
+ * @see http://download.oracle.com/javase/6/docs/api/java/util/TreeMap.html
+ *
+ * @extends {SortedMap}
+ * @constructor
+ * @private
+ */
+export default function TreeMap(
+  comparator = (a, b) => {
+    return a.compareTo(b);
+  }
+) {
+  this._root_ = null;
+  this._size_ = 0;
+  this._compare = comparator;
+}
+
+/**
+ * @override
+ */
+TreeMap.prototype.get = function (key) {
+  let p = this._root_;
+  while (p !== null) {
+    const cmp = this._compare(key, p.key);
+    if (cmp < 0) p = p.left;
+    else if (cmp > 0) p = p.right;
+    else return p.value;
+  }
+  return null;
+};
+
+/**
+ * @override
+ */
+TreeMap.prototype.put = function (key, value) {
+  if (this._root_ === null) {
+    this._root_ = {
+      key: key,
+      value: value,
+      left: null,
+      right: null,
+      parent: null,
+      color: BLACK,
+      getValue() {
+        return this.value;
+      },
+      getKey() {
+        return this.key;
+      },
+    };
+    this._size_ = 1;
+    return null;
+  }
+  let t = this._root_;
+  let parent;
+  let cmp;
+  do {
+    parent = t;
+    cmp = this._compare(key, t.key);
+    if (cmp < 0) {
+      t = t.left;
+    } else if (cmp > 0) {
+      t = t.right;
+    } else {
+      const oldValue = t.value;
+      t.value = value;
+      return oldValue;
+    }
+  } while (t !== null);
+  const e = {
+    key: key,
+    left: null,
+    right: null,
+    value: value,
+    parent: parent,
+    color: BLACK,
+    getValue() {
+      return this.value;
+    },
+    getKey() {
+      return this.key;
+    },
+  };
+  if (cmp < 0) {
+    parent.left = e;
+  } else {
+    parent.right = e;
+  }
+  this.fixAfterInsertion(e);
+  this._size_++;
+  return null;
+};
+
+/**
+ * @param {Object} x
+ */
+TreeMap.prototype.fixAfterInsertion = function (x) {
+  x.color = RED;
+  while (x != null && x !== this._root_ && x.parent.color === RED) {
+    if (parentOf(x) === leftOf(parentOf(parentOf(x)))) {
+      const y = rightOf(parentOf(parentOf(x)));
+      if (colorOf(y) === RED) {
+        setColor(parentOf(x), BLACK);
+        setColor(y, BLACK);
+        setColor(parentOf(parentOf(x)), RED);
+        x = parentOf(parentOf(x));
+      } else {
+        if (x === rightOf(parentOf(x))) {
+          x = parentOf(x);
+          this.rotateLeft(x);
+        }
+        setColor(parentOf(x), BLACK);
+        setColor(parentOf(parentOf(x)), RED);
+        this.rotateRight(parentOf(parentOf(x)));
+      }
+    } else {
+      const y = leftOf(parentOf(parentOf(x)));
+      if (colorOf(y) === RED) {
+        setColor(parentOf(x), BLACK);
+        setColor(y, BLACK);
+        setColor(parentOf(parentOf(x)), RED);
+        x = parentOf(parentOf(x));
+      } else {
+        if (x === leftOf(parentOf(x))) {
+          x = parentOf(x);
+          this.rotateRight(x);
+        }
+        setColor(parentOf(x), BLACK);
+        setColor(parentOf(parentOf(x)), RED);
+        this.rotateLeft(parentOf(parentOf(x)));
+      }
+    }
+  }
+  this._root_.color = BLACK;
+};
+
+/**
+ * @override
+ */
+TreeMap.prototype.values = function () {
+  const arrayList = [];
+  let p = this.getFirstEntry();
+  if (p !== null) {
+    arrayList.push(p.value);
+    while ((p = TreeMap.successor(p)) !== null) {
+      arrayList.push(p.value);
+    }
+  }
+  return arrayList;
+};
+
+/**
+ * @override
+ */
+TreeMap.prototype.entrySet = function () {
+  const hashSet = [];
+  let p = this.getFirstEntry();
+  if (p !== null) {
+    hashSet.push(p);
+    while ((p = TreeMap.successor(p)) !== null) {
+      hashSet.push(p);
+    }
+  }
+  return hashSet;
+};
+
+/**
+ * @param {Object} p
+ */
+TreeMap.prototype.rotateLeft = function (p) {
+  if (p != null) {
+    const r = p.right;
+    p.right = r.left;
+    if (r.left != null) {
+      r.left.parent = p;
+    }
+    r.parent = p.parent;
+    if (p.parent === null) {
+      this._root_ = r;
+    } else if (p.parent.left === p) {
+      p.parent.left = r;
+    } else {
+      p.parent.right = r;
+    }
+    r.left = p;
+    p.parent = r;
+  }
+};
+
+/**
+ * @param {Object} p
+ */
+TreeMap.prototype.rotateRight = function (p) {
+  if (p != null) {
+    const l = p.left;
+    p.left = l.right;
+    if (l.right != null) l.right.parent = p;
+    l.parent = p.parent;
+    if (p.parent === null) {
+      this._root_ = l;
+    } else if (p.parent.right === p) {
+      p.parent.right = l;
+    } else p.parent.left = l;
+    l.right = p;
+    p.parent = l;
+  }
+};
+
+/**
+ * @return {Object}
+ */
+TreeMap.prototype.getFirstEntry = function () {
+  let p = this._root_;
+  if (p != null) {
+    while (p.left != null) {
+      p = p.left;
+    }
+  }
+  return p;
+};
+
+/**
+ * @param {Object} t
+ * @return {Object}
+ * @private
+ */
+TreeMap.successor = function (t) {
+  if (t === null) {
+    return null;
+  } else if (t.right !== null) {
+    let p = t.right;
+    while (p.left !== null) {
+      p = p.left;
+    }
+    return p;
+  } else {
+    let p = t.parent;
+    let ch = t;
+    while (p !== null && ch === p.right) {
+      ch = p;
+      p = p.parent;
+    }
+    return p;
+  }
+};
+
+/**
+ * @override
+ */
+TreeMap.prototype.size = function () {
+  return this._size_;
+};

--- a/packages/turf-buffer/lib/org/locationtech/jts/algorithm/CGAlgorithms.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/algorithm/CGAlgorithms.js
@@ -1,0 +1,144 @@
+import Location from "../geom/Location";
+import IllegalArgumentException from "../../../../java/lang/IllegalArgumentException";
+import CGAlgorithmsDD from "./CGAlgorithmsDD";
+import Envelope from "../geom/Envelope";
+import RayCrossingCounter from "./RayCrossingCounter";
+import { coordinates } from "../../../../utils/coordinates";
+
+export default class CGAlgorithms {
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q
+   */
+  static orientationIndex(p1, p2, q) {
+    return CGAlgorithmsDD.orientationIndex(p1, p2, q);
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} A
+   * @param {GeoJSONCoordinate} B
+   * @param {GeoJSONCoordinate} C
+   * @param {GeoJSONCoordinate} D
+   */
+  static distanceLineLine(A, B, C, D) {
+    const [ax, ay] = A,
+      [bx, by] = B,
+      [cx, cy] = C,
+      [dx, dy] = D;
+
+    if (coordinates.equals(A, B))
+      return CGAlgorithms.distancePointLine(A, C, D);
+    if (coordinates.equals(C, D))
+      return CGAlgorithms.distancePointLine(D, A, B);
+    let noIntersection = false;
+    if (!Envelope.intersects(...arguments)) {
+      noIntersection = true;
+    } else {
+      const denom = (bx - ax) * (dy - cy) - (by - ay) * (dx - cx);
+      if (denom === 0) {
+        noIntersection = true;
+      } else {
+        const rNumb = (ay - cy) * (dx - cx) - (ax - cx) * (dy - cy);
+        const sNum = (ay - cy) * (bx - ax) - (ax - cx) * (by - ay);
+        const s = sNum / denom;
+        const r = rNumb / denom;
+        if (r < 0 || r > 1 || s < 0 || s > 1) {
+          noIntersection = true;
+        }
+      }
+    }
+    if (noIntersection) {
+      return Math.min(
+        CGAlgorithms.distancePointLine(A, C, D),
+        CGAlgorithms.distancePointLine(B, C, D),
+        CGAlgorithms.distancePointLine(C, A, B),
+        CGAlgorithms.distancePointLine(D, A, B)
+      );
+    }
+    return 0.0;
+  }
+  static isPointInRing(p, ring) {
+    return CGAlgorithms.locatePointInRing(p, ring) !== Location.EXTERIOR;
+  }
+  static isCCW(ring) {
+    const nPts = ring.length - 1;
+    if (nPts < 3)
+      throw new IllegalArgumentException(
+        "Ring has fewer than 4 points, so orientation cannot be determined"
+      );
+    let hiPt = [...ring[0]];
+    let hiIndex = 0;
+    for (let i = 1; i <= nPts; i++) {
+      const p = [...ring[i]];
+      if (p[1] > hiPt[1]) {
+        hiPt = [...p];
+        hiIndex = i;
+      }
+    }
+    let iPrev = hiIndex;
+    do {
+      iPrev = iPrev - 1;
+      if (iPrev < 0) iPrev = nPts;
+    } while (coordinates.equals(ring[iPrev], hiPt) && iPrev !== hiIndex);
+    let iNext = hiIndex;
+    do {
+      iNext = (iNext + 1) % nPts;
+    } while (coordinates.equals(ring[iNext], hiPt) && iNext !== hiIndex);
+    const prev = [...ring[iPrev]];
+    const next = [...ring[iNext]];
+    if (
+      coordinates.equals(prev, hiPt) ||
+      coordinates.equals(next, hiPt) ||
+      coordinates.equals(prev, next)
+    )
+      return false;
+    const disc = CGAlgorithms.computeOrientation(prev, hiPt, next);
+    let isCCW = false;
+    if (disc === 0) {
+      isCCW = prev[0] > next[0];
+    } else {
+      isCCW = disc > 0;
+    }
+    return isCCW;
+  }
+  static locatePointInRing(p, ring) {
+    return RayCrossingCounter.locatePointInRing(p, ring);
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q
+   */
+  static computeOrientation(p1, p2, q) {
+    return CGAlgorithms.orientationIndex(p1, p2, q);
+  }
+
+  /**
+   *
+   * @param {GeoJSONCoordinate} p
+   * @param {GeoJSONCoordinate} A
+   * @param {GeoJSONCoordinate} B
+   */
+  static distancePointLine(p, A, B) {
+    const [px, py] = p,
+      [ax, ay] = A,
+      [bx, by] = B;
+
+    if (ax === bx && ay === by) return coordinates.distance(p, A);
+    const len2 = (bx - ax) * (bx - ax) + (by - ay) * (by - ay);
+    const r = ((px - ax) * (bx - ax) + (py - ay) * (by - ay)) / len2;
+    if (r <= 0.0) return coordinates.distance(p, A);
+    if (r >= 1.0) return coordinates.distance(p, B);
+    const s = ((ay - py) * (bx - ax) - (ax - px) * (by - ay)) / len2;
+    return Math.abs(s) * Math.sqrt(len2);
+  }
+  static get CLOCKWISE() {
+    return -1;
+  }
+  static get COUNTERCLOCKWISE() {
+    return 1;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/algorithm/CGAlgorithmsDD.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/algorithm/CGAlgorithmsDD.js
@@ -1,0 +1,65 @@
+import DD from "../math/DD";
+import { x, y } from "../../../../utils/coordinates";
+
+export default class CGAlgorithmsDD {
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q
+   */
+  static orientationIndex(p1, p2, q) {
+    const index = CGAlgorithmsDD.orientationIndexFilter(p1, p2, q);
+    if (index <= 1) return index;
+    const dx1 = new DD(x(p2)).selfAdd(-x(p1));
+    const dy1 = new DD(y(p2)).selfAdd(-y(p1));
+    const dx2 = new DD(x(q)).selfAdd(-x(p2));
+    const dy2 = new DD(y(q)).selfAdd(-y(p2));
+    return dx1.selfMultiply(dy2).selfSubtract(dy1.selfMultiply(dx2)).signum();
+  }
+
+  /**
+   *
+   * @param {GeoJSONCoordinate} pa
+   * @param {GeoJSONCoordinate} pb
+   * @param {GeoJSONCoordinate} pc
+   */
+  static orientationIndexFilter(pa, pb, pc) {
+    let detsum = null;
+    const detleft = (x(pa) - x(pc)) * (y(pb) - y(pc));
+    const detright = (y(pa) - y(pc)) * (x(pb) - x(pc));
+    const det = detleft - detright;
+    if (detleft > 0.0) {
+      if (detright <= 0.0) {
+        return CGAlgorithmsDD.signum(det);
+      } else {
+        detsum = detleft + detright;
+      }
+    } else if (detleft < 0.0) {
+      if (detright >= 0.0) {
+        return CGAlgorithmsDD.signum(det);
+      } else {
+        detsum = -detleft - detright;
+      }
+    } else {
+      return CGAlgorithmsDD.signum(det);
+    }
+    const errbound = CGAlgorithmsDD.DP_SAFE_EPSILON * detsum;
+    if (det >= errbound || -det >= errbound) {
+      return CGAlgorithmsDD.signum(det);
+    }
+    return 2;
+  }
+  /**
+   * Returns signum of x.
+   * @param {number} x
+   */
+  static signum(x) {
+    if (x > 0) return 1;
+    if (x < 0) return -1;
+    return 0;
+  }
+  static get DP_SAFE_EPSILON() {
+    return 1e-15;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/algorithm/LineIntersector.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/algorithm/LineIntersector.js
@@ -1,0 +1,71 @@
+import { coordinates } from "../../../../utils/coordinates";
+export default class LineIntersector {
+  constructor() {
+    this._inputLines = [[], []];
+    this._intPt = [null, null];
+    this._intLineIndex = null;
+    this._isProper = null;
+    this._result = 0;
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} p3
+   * @param {GeoJSONCoordinate} p4
+   */
+  computeIntersection(p1, p2, p3, p4) {
+    this._inputLines = [
+      [[...p1], [...p2]],
+      [[...p3], [...p4]],
+    ];
+    this._result = this.computeIntersect(p1, p2, p3, p4);
+  }
+  getIntersectionNum() {
+    return this._result;
+  }
+  isProper() {
+    return this.hasIntersection() && this._isProper;
+  }
+  isInteriorIntersection() {
+    if (arguments.length === 0) {
+      if (this.isInteriorIntersection(0)) return true;
+      if (this.isInteriorIntersection(1)) return true;
+      return false;
+    } else if (arguments.length === 1) {
+      let inputLineIndex = arguments[0];
+      for (var i = 0; i < this._result; i++) {
+        if (
+          !(
+            coordinates.equals(
+              this._intPt[i],
+              this._inputLines[inputLineIndex][0]
+            ) ||
+            coordinates.equals(
+              this._intPt[i],
+              this._inputLines[inputLineIndex][1]
+            )
+          )
+        ) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+  getIntersection(intIndex) {
+    return this._intPt[intIndex];
+  }
+  hasIntersection() {
+    return this._result !== LineIntersector.NO_INTERSECTION;
+  }
+  static get NO_INTERSECTION() {
+    return 0;
+  }
+  static get POINT_INTERSECTION() {
+    return 1;
+  }
+  static get COLLINEAR_INTERSECTION() {
+    return 2;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/algorithm/RayCrossingCounter.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/algorithm/RayCrossingCounter.js
@@ -1,0 +1,68 @@
+import Location from "../geom/Location";
+import RobustDeterminant from "./RobustDeterminant";
+import { x, y } from "../../../../utils/coordinates";
+
+export default class RayCrossingCounter {
+  constructor(point) {
+    this._crossingCount = 0;
+    this._isPointOnSegment = false;
+    this._point = point;
+  }
+  _countSegment(p1, p2) {
+    if (x(p1) < x(this._point) && x(p2) < x(this._point)) return null;
+    if (x(this._point) === x(p2) && y(this._point) === y(p2)) {
+      this._isPointOnSegment = true;
+      return null;
+    }
+    if (y(p1) === y(this._point) && y(p2) === y(this._point)) {
+      let minx = x(p1);
+      let maxx = x(p2);
+      if (minx > maxx) {
+        minx = x(p2);
+        maxx = x(p1);
+      }
+      if (x(this._point) >= minx && x(this._point) <= maxx) {
+        this._isPointOnSegment = true;
+      }
+      return null;
+    }
+    if (
+      (y(p1) > y(this._point) && y(p2) <= y(this._point)) ||
+      (y(p2) > y(this._point) && y(p1) <= y(this._point))
+    ) {
+      const x1 = x(p1) - x(this._point);
+      const y1 = y(p1) - y(this._point);
+      const x2 = x(p2) - x(this._point);
+      const y2 = y(p2) - y(this._point);
+      let xIntSign = RobustDeterminant.signOfDet2x2(x1, y1, x2, y2);
+      if (xIntSign === 0.0) {
+        this._isPointOnSegment = true;
+        return null;
+      }
+      if (y2 < y1) xIntSign = -xIntSign;
+      if (xIntSign > 0.0) {
+        this._crossingCount++;
+      }
+    }
+  }
+  _getLocation() {
+    if (this._isPointOnSegment) return Location.BOUNDARY;
+    if (this._crossingCount % 2 === 1) {
+      return Location.INTERIOR;
+    }
+    return Location.EXTERIOR;
+  }
+  _isOnSegment() {
+    return this._isPointOnSegment;
+  }
+  static locatePointInRing(point, ring) {
+    const counter = new RayCrossingCounter(point);
+    for (let i = 1; i < ring.length; i++) {
+      const p1 = ring[i];
+      const p2 = ring[i - 1];
+      counter._countSegment(p1, p2);
+      if (counter._isOnSegment()) return counter._getLocation();
+    }
+    return counter._getLocation();
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/algorithm/RobustDeterminant.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/algorithm/RobustDeterminant.js
@@ -1,0 +1,187 @@
+export default class RobustDeterminant {
+  static signOfDet2x2(x1, y1, x2, y2) {
+    let sign = null;
+    let swap = null;
+    let k = null;
+    let count = 0;
+    sign = 1;
+    if (x1 === 0.0 || y2 === 0.0) {
+      if (y1 === 0.0 || x2 === 0.0) {
+        return 0;
+      } else if (y1 > 0) {
+        if (x2 > 0) {
+          return -sign;
+        } else {
+          return sign;
+        }
+      } else {
+        if (x2 > 0) {
+          return sign;
+        } else {
+          return -sign;
+        }
+      }
+    }
+    if (y1 === 0.0 || x2 === 0.0) {
+      if (y2 > 0) {
+        if (x1 > 0) {
+          return sign;
+        } else {
+          return -sign;
+        }
+      } else {
+        if (x1 > 0) {
+          return -sign;
+        } else {
+          return sign;
+        }
+      }
+    }
+    if (y1 > 0.0) {
+      if (y2 > 0.0) {
+        if (y1 <= y2) {
+        } else {
+          sign = -sign;
+          swap = x1;
+          x1 = x2;
+          x2 = swap;
+          swap = y1;
+          y1 = y2;
+          y2 = swap;
+        }
+      } else {
+        if (y1 <= -y2) {
+          sign = -sign;
+          x2 = -x2;
+          y2 = -y2;
+        } else {
+          swap = x1;
+          x1 = -x2;
+          x2 = swap;
+          swap = y1;
+          y1 = -y2;
+          y2 = swap;
+        }
+      }
+    } else {
+      if (y2 > 0.0) {
+        if (-y1 <= y2) {
+          sign = -sign;
+          x1 = -x1;
+          y1 = -y1;
+        } else {
+          swap = -x1;
+          x1 = x2;
+          x2 = swap;
+          swap = -y1;
+          y1 = y2;
+          y2 = swap;
+        }
+      } else {
+        if (y1 >= y2) {
+          x1 = -x1;
+          y1 = -y1;
+          x2 = -x2;
+          y2 = -y2;
+        } else {
+          sign = -sign;
+          swap = -x1;
+          x1 = -x2;
+          x2 = swap;
+          swap = -y1;
+          y1 = -y2;
+          y2 = swap;
+        }
+      }
+    }
+    if (x1 > 0.0) {
+      if (x2 > 0.0) {
+        if (x1 <= x2) {
+        } else {
+          return sign;
+        }
+      } else {
+        return sign;
+      }
+    } else {
+      if (x2 > 0.0) {
+        return -sign;
+      } else {
+        if (x1 >= x2) {
+          sign = -sign;
+          x1 = -x1;
+          x2 = -x2;
+        } else {
+          return -sign;
+        }
+      }
+    }
+    while (true) {
+      count = count + 1;
+      k = Math.floor(x2 / x1);
+      x2 = x2 - k * x1;
+      y2 = y2 - k * y1;
+      if (y2 < 0.0) {
+        return -sign;
+      }
+      if (y2 > y1) {
+        return sign;
+      }
+      if (x1 > x2 + x2) {
+        if (y1 < y2 + y2) {
+          return sign;
+        }
+      } else {
+        if (y1 > y2 + y2) {
+          return -sign;
+        } else {
+          x2 = x1 - x2;
+          y2 = y1 - y2;
+          sign = -sign;
+        }
+      }
+      if (y2 === 0.0) {
+        if (x2 === 0.0) {
+          return 0;
+        } else {
+          return -sign;
+        }
+      }
+      if (x2 === 0.0) {
+        return sign;
+      }
+      k = Math.floor(x1 / x2);
+      x1 = x1 - k * x2;
+      y1 = y1 - k * y2;
+      if (y1 < 0.0) {
+        return sign;
+      }
+      if (y1 > y2) {
+        return -sign;
+      }
+      if (x2 > x1 + x1) {
+        if (y2 < y1 + y1) {
+          return -sign;
+        }
+      } else {
+        if (y2 > y1 + y1) {
+          return sign;
+        } else {
+          x1 = x2 - x1;
+          y1 = y2 - y1;
+          sign = -sign;
+        }
+      }
+      if (y1 === 0.0) {
+        if (x1 === 0.0) {
+          return 0;
+        } else {
+          return sign;
+        }
+      }
+      if (x1 === 0.0) {
+        return -sign;
+      }
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/algorithm/RobustLineIntersector.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/algorithm/RobustLineIntersector.js
@@ -1,0 +1,208 @@
+import CGAlgorithms from "./CGAlgorithms";
+import Envelope from "../geom/Envelope";
+import LineIntersector from "./LineIntersector";
+import { coordinates, x, y } from "../../../../utils/coordinates";
+
+export default class RobustLineIntersector extends LineIntersector {
+  _isInSegmentEnvelopes(intPt) {
+    const env0 = new Envelope(this._inputLines[0][0], this._inputLines[0][1]);
+    const env1 = new Envelope(this._inputLines[1][0], this._inputLines[1][1]);
+    return env0.contains(intPt) && env1.contains(intPt);
+  }
+  computeIntersection() {
+    return LineIntersector.prototype.computeIntersection.apply(this, arguments);
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q1
+   * @param {GeoJSONCoordinate} q2
+   */
+  _safeHCoordinateIntersection(p1, p2, q1, q2) {
+    const intPt = coordinates.intersection(p1, p2, q1, q2);
+    if (intPt) {
+      return intPt;
+    }
+    return RobustLineIntersector.nearestEndpoint(p1, p2, q1, q2);
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q1
+   * @param {GeoJSONCoordinate} q2
+   */
+  intersection(p1, p2, q1, q2) {
+    let intPt = this._intersectionWithNormalization(p1, p2, q1, q2);
+    if (!this._isInSegmentEnvelopes(intPt)) {
+      return RobustLineIntersector.nearestEndpoint(p1, p2, q1, q2);
+    }
+    return intPt;
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q1
+   * @param {GeoJSONCoordinate} q2
+   */
+  _intersectionWithNormalization(p1, p2, q1, q2) {
+    const normPt = [];
+    this._normalizeToEnvCentre(p1, p2, q1, q2, normPt);
+    const intPt = this._safeHCoordinateIntersection(p1, p2, q1, q2);
+    return [x(intPt) + x(normPt), y(intPt) + y(normPt)];
+  }
+  computeCollinearIntersection(p1, p2, q1, q2) {
+    const p1q1p2 = Envelope.intersects(p1, p2, q1);
+    const p1q2p2 = Envelope.intersects(p1, p2, q2);
+    const q1p1q2 = Envelope.intersects(q1, q2, p1);
+    const q1p2q2 = Envelope.intersects(q1, q2, p2);
+    if (p1q1p2 && p1q2p2) {
+      this._intPt[0] = q1;
+      this._intPt[1] = q2;
+      return LineIntersector.COLLINEAR_INTERSECTION;
+    }
+    if (q1p1q2 && q1p2q2) {
+      this._intPt[0] = p1;
+      this._intPt[1] = p2;
+      return LineIntersector.COLLINEAR_INTERSECTION;
+    }
+    if (p1q1p2 && q1p1q2) {
+      this._intPt[0] = q1;
+      this._intPt[1] = p1;
+      return coordinates.equals(q1, p1) && !p1q2p2 && !q1p2q2
+        ? LineIntersector.POINT_INTERSECTION
+        : LineIntersector.COLLINEAR_INTERSECTION;
+    }
+    if (p1q1p2 && q1p2q2) {
+      this._intPt[0] = q1;
+      this._intPt[1] = p2;
+      return coordinates.equals(q1, p2) && !p1q2p2 && !q1p1q2
+        ? LineIntersector.POINT_INTERSECTION
+        : LineIntersector.COLLINEAR_INTERSECTION;
+    }
+    if (p1q2p2 && q1p1q2) {
+      this._intPt[0] = q2;
+      this._intPt[1] = p1;
+      return coordinates.equals(q2, p1) && !p1q1p2 && !q1p2q2
+        ? LineIntersector.POINT_INTERSECTION
+        : LineIntersector.COLLINEAR_INTERSECTION;
+    }
+    if (p1q2p2 && q1p2q2) {
+      this._intPt[0] = q2;
+      this._intPt[1] = p2;
+      return coordinates.equals(q2, p2) && !p1q1p2 && !q1p1q2
+        ? LineIntersector.POINT_INTERSECTION
+        : LineIntersector.COLLINEAR_INTERSECTION;
+    }
+    return LineIntersector.NO_INTERSECTION;
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} n00
+   * @param {GeoJSONCoordinate} n01
+   * @param {GeoJSONCoordinate} n10
+   * @param {GeoJSONCoordinate} n11
+   */
+  _normalizeToEnvCentre(n00, n01, n10, n11, normPt) {
+    const minX0 = x(n00) < x(n01) ? x(n00) : x(n01);
+    const minY0 = y(n00) < y(n01) ? y(n00) : y(n01);
+    const maxX0 = x(n00) > x(n01) ? x(n00) : x(n01);
+    const maxY0 = y(n00) > y(n01) ? y(n00) : y(n01);
+    const minX1 = x(n10) < x(n11) ? x(n10) : x(n11);
+    const minY1 = y(n10) < y(n11) ? y(n10) : y(n11);
+    const maxX1 = x(n10) > x(n11) ? x(n10) : x(n11);
+    const maxY1 = y(n10) > y(n11) ? y(n10) : y(n11);
+    const intMinX = minX0 > minX1 ? minX0 : minX1;
+    const intMaxX = maxX0 < maxX1 ? maxX0 : maxX1;
+    const intMinY = minY0 > minY1 ? minY0 : minY1;
+    const intMaxY = maxY0 < maxY1 ? maxY0 : maxY1;
+    const intMidX = (intMinX + intMaxX) / 2.0;
+    const intMidY = (intMinY + intMaxY) / 2.0;
+    normPt[0] = intMidX;
+    normPt[1] = intMidY;
+    n00[0] -= x(normPt);
+    n00[1] -= y(normPt);
+    n01[0] -= x(normPt);
+    n01[1] -= y(normPt);
+    n10[0] -= x(normPt);
+    n10[1] -= y(normPt);
+    n11[0] -= x(normPt);
+    n11[1] -= y(normPt);
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q1
+   * @param {GeoJSONCoordinate} q2
+   */
+  computeIntersect(p1, p2, q1, q2) {
+    this._isProper = false;
+    if (!Envelope.intersects(p1, p2, q1, q2))
+      return LineIntersector.NO_INTERSECTION;
+    const Pq1 = CGAlgorithms.orientationIndex(p1, p2, q1);
+    const Pq2 = CGAlgorithms.orientationIndex(p1, p2, q2);
+    if ((Pq1 > 0 && Pq2 > 0) || (Pq1 < 0 && Pq2 < 0)) {
+      return LineIntersector.NO_INTERSECTION;
+    }
+    const Qp1 = CGAlgorithms.orientationIndex(q1, q2, p1);
+    const Qp2 = CGAlgorithms.orientationIndex(q1, q2, p2);
+    if ((Qp1 > 0 && Qp2 > 0) || (Qp1 < 0 && Qp2 < 0)) {
+      return LineIntersector.NO_INTERSECTION;
+    }
+    const collinear = Pq1 === 0 && Pq2 === 0 && Qp1 === 0 && Qp2 === 0;
+    if (collinear) {
+      return this.computeCollinearIntersection(p1, p2, q1, q2);
+    }
+    if (Pq1 === 0 || Pq2 === 0 || Qp1 === 0 || Qp2 === 0) {
+      this._isProper = false;
+      if (coordinates.equals(p1, q1) || coordinates.equals(p1, q2)) {
+        this._intPt[0] = p1;
+      } else if (coordinates.equals(p2, q1) || coordinates.equals(p2, q2)) {
+        this._intPt[0] = p2;
+      } else if (Pq1 === 0) {
+        this._intPt[0] = q1;
+      } else if (Pq2 === 0) {
+        this._intPt[0] = q2;
+      } else if (Qp1 === 0) {
+        this._intPt[0] = p1;
+      } else if (Qp2 === 0) {
+        this._intPt[0] = p2;
+      }
+    } else {
+      this._isProper = true;
+      this._intPt[0] = this.intersection(p1, p2, q1, q2);
+    }
+    return LineIntersector.POINT_INTERSECTION;
+  }
+
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q1
+   * @param {GeoJSONCoordinate} q2
+   */
+  static nearestEndpoint(p1, p2, q1, q2) {
+    let nearestPt = p1;
+    let minDist = CGAlgorithms.distancePointLine(p1, q1, q2);
+    let dist = CGAlgorithms.distancePointLine(p2, q1, q2);
+    if (dist < minDist) {
+      minDist = dist;
+      nearestPt = p2;
+    }
+    dist = CGAlgorithms.distancePointLine(q1, p1, p2);
+    if (dist < minDist) {
+      minDist = dist;
+      nearestPt = q1;
+    }
+    dist = CGAlgorithms.distancePointLine(q2, p1, p2);
+    if (dist < minDist) {
+      minDist = dist;
+      nearestPt = q2;
+    }
+    return nearestPt;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geom/Envelope.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geom/Envelope.js
@@ -1,0 +1,315 @@
+import { coordinates, x, y } from "../../../../utils/coordinates";
+
+export default class Envelope {
+  constructor() {
+    this.init(...arguments);
+  }
+  equals(other) {
+    if (!(other instanceof Envelope)) {
+      return false;
+    }
+    var otherEnvelope = other;
+    if (this.isNull()) {
+      return otherEnvelope.isNull();
+    }
+    return (
+      this._maxx === otherEnvelope.getMaxX() &&
+      this._maxy === otherEnvelope.getMaxY() &&
+      this._minx === otherEnvelope.getMinX() &&
+      this._miny === otherEnvelope.getMinY()
+    );
+  }
+  intersection(env) {
+    if (this.isNull() || env.isNull() || !this.intersects(env))
+      return new Envelope();
+    var intMinX = this._minx > env._minx ? this._minx : env._minx;
+    var intMinY = this._miny > env._miny ? this._miny : env._miny;
+    var intMaxX = this._maxx < env._maxx ? this._maxx : env._maxx;
+    var intMaxY = this._maxy < env._maxy ? this._maxy : env._maxy;
+    return new Envelope(intMinX, intMaxX, intMinY, intMaxY);
+  }
+  isNull() {
+    return this._maxx < this._minx;
+  }
+  getMaxX() {
+    return this._maxx;
+  }
+  covers() {
+    if (arguments.length === 1) {
+      if (coordinates.isCoordinate(arguments[0])) {
+        let p = arguments[0];
+        return this.covers(x(p), y(p));
+      } else if (arguments[0] instanceof Envelope) {
+        let other = arguments[0];
+        if (this.isNull() || other.isNull()) {
+          return false;
+        }
+        return (
+          other.getMinX() >= this._minx &&
+          other.getMaxX() <= this._maxx &&
+          other.getMinY() >= this._miny &&
+          other.getMaxY() <= this._maxy
+        );
+      }
+    } else if (arguments.length === 2) {
+      const x = arguments[0];
+      const y = arguments[1];
+      if (this.isNull()) return false;
+      return (
+        x >= this._minx && x <= this._maxx && y >= this._miny && y <= this._maxy
+      );
+    }
+  }
+  intersects() {
+    if (arguments.length === 1) {
+      if (arguments[0] instanceof Envelope) {
+        const other = arguments[0];
+        if (this.isNull() || other.isNull()) {
+          return false;
+        }
+        return !(
+          other._minx > this._maxx ||
+          other._maxx < this._minx ||
+          other._miny > this._maxy ||
+          other._maxy < this._miny
+        );
+      } else if (coordinates.isCoordinate(arguments[0])) {
+        const p = arguments[0];
+        return this.intersects(x(p), y(p));
+      }
+    } else if (arguments.length === 2) {
+      const x = arguments[0];
+      const y = arguments[1];
+      if (this.isNull()) return false;
+      return !(
+        x > this._maxx ||
+        x < this._minx ||
+        y > this._maxy ||
+        y < this._miny
+      );
+    }
+  }
+  getMinY() {
+    return this._miny;
+  }
+  getMinX() {
+    return this._minx;
+  }
+  expandToInclude() {
+    if (arguments.length === 1) {
+      if (coordinates.isCoordinate(arguments[0])) {
+        let p = arguments[0];
+        this.expandToInclude(x(p), y(p));
+      } else if (arguments[0] instanceof Envelope) {
+        let other = arguments[0];
+        if (other.isNull()) {
+          return null;
+        }
+        if (this.isNull()) {
+          this._minx = other.getMinX();
+          this._maxx = other.getMaxX();
+          this._miny = other.getMinY();
+          this._maxy = other.getMaxY();
+        } else {
+          if (other._minx < this._minx) {
+            this._minx = other._minx;
+          }
+          if (other._maxx > this._maxx) {
+            this._maxx = other._maxx;
+          }
+          if (other._miny < this._miny) {
+            this._miny = other._miny;
+          }
+          if (other._maxy > this._maxy) {
+            this._maxy = other._maxy;
+          }
+        }
+      }
+    } else if (arguments.length === 2) {
+      const x = arguments[0];
+      const y = arguments[1];
+      if (this.isNull()) {
+        this._minx = x;
+        this._maxx = x;
+        this._miny = y;
+        this._maxy = y;
+      } else {
+        if (x < this._minx) {
+          this._minx = x;
+        }
+        if (x > this._maxx) {
+          this._maxx = x;
+        }
+        if (y < this._miny) {
+          this._miny = y;
+        }
+        if (y > this._maxy) {
+          this._maxy = y;
+        }
+      }
+    }
+  }
+  getWidth() {
+    if (this.isNull()) {
+      return 0;
+    }
+    return this._maxx - this._minx;
+  }
+  compareTo(o) {
+    var env = o;
+    if (this.isNull()) {
+      if (env.isNull()) return 0;
+      return -1;
+    } else {
+      if (env.isNull()) return 1;
+    }
+    if (this._minx < env._minx) return -1;
+    if (this._minx > env._minx) return 1;
+    if (this._miny < env._miny) return -1;
+    if (this._miny > env._miny) return 1;
+    if (this._maxx < env._maxx) return -1;
+    if (this._maxx > env._maxx) return 1;
+    if (this._maxy < env._maxy) return -1;
+    if (this._maxy > env._maxy) return 1;
+    return 0;
+  }
+  translate(transX, transY) {
+    if (this.isNull()) {
+      return null;
+    }
+    this.init(
+      this.getMinX() + transX,
+      this.getMaxX() + transX,
+      this.getMinY() + transY,
+      this.getMaxY() + transY
+    );
+  }
+  _setToNull() {
+    this._minx = 0;
+    this._maxx = -1;
+    this._miny = 0;
+    this._maxy = -1;
+  }
+  getHeight() {
+    if (this.isNull()) {
+      return 0;
+    }
+    return this._maxy - this._miny;
+  }
+  maxExtent() {
+    if (this.isNull()) return 0.0;
+    const w = this.getWidth();
+    const h = this.getHeight();
+    if (w > h) return w;
+    return h;
+  }
+  contains() {
+    if (arguments.length === 1) {
+      if (arguments[0] instanceof Envelope) {
+        const other = arguments[0];
+        return this.covers(other);
+      } else if (coordinates.isCoordinate(arguments[0])) {
+        const p = arguments[0];
+        return this.covers(p);
+      }
+    } else if (arguments.length === 2) {
+      const x = arguments[0];
+      const y = arguments[1];
+      return this.covers(x, y);
+    }
+  }
+  centre() {
+    if (this.isNull()) return null;
+    return [
+      (this.getMinX() + this.getMaxX()) / 2.0,
+      (this.getMinY() + this.getMaxY()) / 2.0,
+    ];
+  }
+  init() {
+    this._setToNull();
+    if (arguments.length === 1) {
+      if (coordinates.isCoordinate(arguments[0])) {
+        let p = arguments[0];
+        this.init(x(p), x(p), y(p), y(p));
+      } else if (arguments[0] instanceof Envelope) {
+        let env = arguments[0];
+        this._minx = env._minx;
+        this._maxx = env._maxx;
+        this._miny = env._miny;
+        this._maxy = env._maxy;
+      }
+    } else if (arguments.length === 2) {
+      let p1 = arguments[0];
+      let p2 = arguments[1];
+      this.init(x(p1), x(p2), y(p1), y(p2));
+    } else if (arguments.length === 4) {
+      const x1 = arguments[0];
+      const x2 = arguments[1];
+      const y1 = arguments[2];
+      const y2 = arguments[3];
+      if (x1 < x2) {
+        this._minx = x1;
+        this._maxx = x2;
+      } else {
+        this._minx = x2;
+        this._maxx = x1;
+      }
+      if (y1 < y2) {
+        this._miny = y1;
+        this._maxy = y2;
+      } else {
+        this._miny = y2;
+        this._maxy = y1;
+      }
+    }
+  }
+  getMaxY() {
+    return this._maxy;
+  }
+  distance(env) {
+    if (this.intersects(env)) return 0;
+    var dx = 0.0;
+    if (this._maxx < env._minx) dx = env._minx - this._maxx;
+    else if (this._minx > env._maxx) dx = this._minx - env._maxx;
+    var dy = 0.0;
+    if (this._maxy < env._miny) dy = env._miny - this._maxy;
+    else if (this._miny > env._maxy) dy = this._miny - env._maxy;
+    if (dx === 0.0) return dy;
+    if (dy === 0.0) return dx;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p1
+   * @param {GeoJSONCoordinate} p2
+   * @param {GeoJSONCoordinate} q1
+   * @param {GeoJSONCoordinate} q2
+   */
+  static intersects(p1, p2, q1, q2) {
+    if (arguments.length === 3) {
+      if (
+        x(q1) >= (x(p1) < x(p2) ? x(p1) : x(p2)) &&
+        x(q1) <= (x(p1) > x(p2) ? x(p1) : x(p2)) &&
+        y(q1) >= (y(p1) < y(p2) ? y(p1) : y(p2)) &&
+        y(q1) <= (y(p1) > y(p2) ? y(p1) : y(p2))
+      ) {
+        return true;
+      }
+      return false;
+    } else if (arguments.length === 4) {
+      let minq = Math.min(x(q1), x(q2));
+      let maxq = Math.max(x(q1), x(q2));
+      let minp = Math.min(x(p1), x(p2));
+      let maxp = Math.max(x(p1), x(p2));
+      if (minp > maxq) return false;
+      if (maxp < minq) return false;
+      minq = Math.min(y(q1), y(q2));
+      maxq = Math.max(y(q1), y(q2));
+      minp = Math.min(y(p1), y(p2));
+      maxp = Math.max(y(p1), y(p2));
+      if (minp > maxq) return false;
+      if (maxp < minq) return false;
+      return true;
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geom/LineSegment.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geom/LineSegment.js
@@ -1,0 +1,81 @@
+import CGAlgorithms from "../algorithm/CGAlgorithms";
+import { coordinates } from "../../../../utils/coordinates";
+
+export default class LineSegment {
+  constructor(p0, p1) {
+    this.p0 = [];
+    this.p1 = [];
+    if (arguments.length === 2) {
+      this.p0 = [...p0];
+      this.p1 = [...p1];
+    }
+  }
+  minX() {
+    return Math.min(this.p0[0], this.p1[0]);
+  }
+  /**
+   *
+   * @param {LineSegment} seg
+   */
+  orientationIndex(seg) {
+    var orient0 = CGAlgorithms.orientationIndex(this.p0, this.p1, seg.p0);
+    var orient1 = CGAlgorithms.orientationIndex(this.p0, this.p1, seg.p1);
+    if (orient0 >= 0 && orient1 >= 0) return Math.max(orient0, orient1);
+    if (orient0 <= 0 && orient1 <= 0) return Math.max(orient0, orient1);
+    return 0;
+  }
+  equals(other) {
+    if (!(other instanceof LineSegment)) {
+      return false;
+    }
+    return (
+      coordinates.equals(this.p0, other.p0) &&
+      coordinates.equals(this.p1, other.p1)
+    );
+  }
+  angle() {
+    return Math.atan2(this.p1[1] - this.p0[1], this.p1[0] - this.p0[0]);
+  }
+  getCoordinate(i) {
+    if (i === 0) return this.p0;
+    return this.p1;
+  }
+  minY() {
+    return Math.min(this.p0[1], this.p1[1]);
+  }
+  maxX() {
+    return Math.max(this.p0[0], this.p1[0]);
+  }
+  getLength() {
+    return coordinates.distance(this.p0, this.p1);
+  }
+  compareTo(other) {
+    var comp0 = coordinates.compare(this.p0, other.p0);
+    if (comp0 !== 0) return comp0;
+    return coordinates.compare(this.p1, other.p1);
+  }
+  reverse() {
+    var temp = this.p0;
+    this.p0 = this.p1;
+    this.p1 = temp;
+  }
+  maxY() {
+    return Math.max(this.p0[1], this.p1[1]);
+  }
+  setCoordinates(p0, p1) {
+    this.p0 = [...p0];
+    this.p1 = [...p1];
+  }
+  isHorizontal() {
+    return this.p0[1] === this.p1[1];
+  }
+  distance() {
+    if (arguments[0] instanceof LineSegment) {
+      const ls = arguments[0];
+      return CGAlgorithms.distanceLineLine(this.p0, this.p1, ls.p0, ls.p1);
+    } else if (coordinates.isCoordinate(arguments[0])) {
+      const p = arguments[0];
+      return CGAlgorithms.distancePointLine(p, this.p0, this.p1);
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geom/LineString.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geom/LineString.js
@@ -1,0 +1,52 @@
+import IllegalArgumentException from "../../../../java/lang/IllegalArgumentException";
+import Envelope from "./Envelope";
+import { coordinates } from "../../../../utils/coordinates";
+
+export default class LineString {
+  constructor(points = []) {
+    this._envelope = null;
+    if (points.length === 1) {
+      throw new IllegalArgumentException(
+        "Invalid number of points in LineString (found " +
+          points.length +
+          " - must be 0 or >= 2)"
+      );
+    }
+    this._points = points;
+  }
+  computeEnvelopeInternal() {
+    if (this.isEmpty()) {
+      return new Envelope();
+    }
+    const env = new Envelope();
+    this._points.forEach((coordinate) => env.expandToInclude(coordinate));
+    return env;
+  }
+  getCoordinates() {
+    return this._points;
+  }
+  isClosed() {
+    if (this.isEmpty()) {
+      return false;
+    }
+    return coordinates.equals(
+      this.getCoordinateN(0),
+      this.getCoordinateN(this.getNumPoints() - 1)
+    );
+  }
+  getCoordinateN(n) {
+    return this._points[n];
+  }
+  getNumPoints() {
+    return this._points.length;
+  }
+  getEnvelopeInternal() {
+    if (this._envelope === null) {
+      this._envelope = this.computeEnvelopeInternal();
+    }
+    return new Envelope(this._envelope);
+  }
+  isEmpty() {
+    return this._points.length === 0;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geom/LinearRing.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geom/LinearRing.js
@@ -1,0 +1,29 @@
+import LineString from "./LineString";
+import IllegalArgumentException from "../../../../java/lang/IllegalArgumentException";
+
+export default class LinearRing extends LineString {
+  constructor(points) {
+    super(points);
+    this._validateConstruction();
+  }
+  _validateConstruction() {
+    if (!this.isEmpty() && !LineString.prototype.isClosed.call(this)) {
+      throw new IllegalArgumentException(
+        "Points of LinearRing do not form a closed linestring"
+      );
+    }
+    if (
+      this.getCoordinates().length >= 1 &&
+      this.getCoordinates().length < LinearRing.MINIMUM_VALID_SIZE
+    ) {
+      throw new IllegalArgumentException(
+        "Invalid number of points in LinearRing (found " +
+          this.getCoordinates().length +
+          " - must be 0 or >= 4)"
+      );
+    }
+  }
+  static get MINIMUM_VALID_SIZE() {
+    return 4;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geom/Location.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geom/Location.js
@@ -1,0 +1,32 @@
+import IllegalArgumentException from "../../../../java/lang/IllegalArgumentException";
+
+export default class Location {
+  static toLocationSymbol(locationValue) {
+    switch (locationValue) {
+      case Location.EXTERIOR:
+        return "e";
+      case Location.BOUNDARY:
+        return "b";
+      case Location.INTERIOR:
+        return "i";
+      case Location.NONE:
+        return "-";
+      default:
+    }
+    throw new IllegalArgumentException(
+      "Unknown location value: " + locationValue
+    );
+  }
+  static get INTERIOR() {
+    return 0;
+  }
+  static get BOUNDARY() {
+    return 1;
+  }
+  static get EXTERIOR() {
+    return 2;
+  }
+  static get NONE() {
+    return -1;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geom/TopologyException.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geom/TopologyException.js
@@ -1,0 +1,16 @@
+import RuntimeException from "../../../../java/lang/RuntimeException";
+
+export default class TopologyException extends RuntimeException {
+  constructor(msg, pt) {
+    super(TopologyException.msgWithCoord(msg, pt));
+    this.pt = pt ? [...pt] : null;
+    this.name = "TopologyException";
+  }
+  getCoordinate() {
+    return this.pt;
+  }
+  static msgWithCoord(msg, pt) {
+    if (!pt) return msg + " [ " + pt + " ]";
+    return msg;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Depth.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Depth.js
@@ -1,0 +1,90 @@
+import Location from "../geom/Location";
+import Position from "./Position";
+
+export default class Depth {
+  constructor() {
+    this._depth = Array(2)
+      .fill()
+      .map(() => Array(3));
+    for (let i = 0; i < 2; i++) {
+      for (let j = 0; j < 3; j++) {
+        this._depth[i][j] = Depth.NULL_VALUE;
+      }
+    }
+  }
+  getDepth(geomIndex, posIndex) {
+    return this._depth[geomIndex][posIndex];
+  }
+  setDepth(geomIndex, posIndex, depthValue) {
+    this._depth[geomIndex][posIndex] = depthValue;
+  }
+  isNull() {
+    if (arguments.length === 0) {
+      for (let i = 0; i < 2; i++) {
+        for (let j = 0; j < 3; j++) {
+          if (this._depth[i][j] !== Depth.NULL_VALUE) return false;
+        }
+      }
+      return true;
+    } else if (arguments.length === 1) {
+      const geomIndex = arguments[0];
+      return this._depth[geomIndex][1] === Depth.NULL_VALUE;
+    } else if (arguments.length === 2) {
+      const geomIndex = arguments[0];
+      const posIndex = arguments[1];
+      return this._depth[geomIndex][posIndex] === Depth.NULL_VALUE;
+    }
+  }
+  normalize() {
+    for (let i = 0; i < 2; i++) {
+      if (!this.isNull(i)) {
+        let minDepth = this._depth[i][1];
+        if (this._depth[i][2] < minDepth) minDepth = this._depth[i][2];
+        if (minDepth < 0) minDepth = 0;
+        for (let j = 1; j < 3; j++) {
+          let newValue = 0;
+          if (this._depth[i][j] > minDepth) newValue = 1;
+          this._depth[i][j] = newValue;
+        }
+      }
+    }
+  }
+  getDelta(geomIndex) {
+    return (
+      this._depth[geomIndex][Position.RIGHT] -
+      this._depth[geomIndex][Position.LEFT]
+    );
+  }
+  getLocation(geomIndex, posIndex) {
+    if (this._depth[geomIndex][posIndex] <= 0) return Location.EXTERIOR;
+    return Location.INTERIOR;
+  }
+  add() {
+    if (arguments.length === 1) {
+      const lbl = arguments[0];
+      for (let i = 0; i < 2; i++) {
+        for (let j = 1; j < 3; j++) {
+          const loc = lbl.getLocation(i, j);
+          if (loc === Location.EXTERIOR || loc === Location.INTERIOR) {
+            if (this.isNull(i, j)) {
+              this._depth[i][j] = Depth.depthAtLocation(loc);
+            } else this._depth[i][j] += Depth.depthAtLocation(loc);
+          }
+        }
+      }
+    } else if (arguments.length === 3) {
+      const geomIndex = arguments[0];
+      const posIndex = arguments[1];
+      const location = arguments[2];
+      if (location === Location.INTERIOR) this._depth[geomIndex][posIndex]++;
+    }
+  }
+  static depthAtLocation(location) {
+    if (location === Location.EXTERIOR) return 0;
+    if (location === Location.INTERIOR) return 1;
+    return Depth.NULL_VALUE;
+  }
+  static get NULL_VALUE() {
+    return -1;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/DirectedEdge.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/DirectedEdge.js
@@ -1,0 +1,153 @@
+import Location from "../geom/Location";
+import EdgeEnd from "./EdgeEnd";
+import Position from "./Position";
+import TopologyException from "../geom/TopologyException";
+import Label from "./Label";
+
+export default class DirectedEdge extends EdgeEnd {
+  constructor() {
+    const edge = arguments[0];
+    const isForward = arguments[1];
+    super(edge);
+    this._isForward = null;
+    this._isInResult = false;
+    this._isVisited = false;
+    this._sym = null;
+    this._next = null;
+    this._nextMin = null;
+    this._edgeRing = null;
+    this._minEdgeRing = null;
+    this._depth = [0, -999, -999];
+    this._isForward = isForward;
+    if (isForward) {
+      this.init(edge.getCoordinate(0), edge.getCoordinate(1));
+    } else {
+      const n = edge.getNumPoints() - 1;
+      this.init(edge.getCoordinate(n), edge.getCoordinate(n - 1));
+    }
+    this.computeDirectedLabel();
+  }
+  getNextMin() {
+    return this._nextMin;
+  }
+  getDepth(position) {
+    return this._depth[position];
+  }
+  setVisited(isVisited) {
+    this._isVisited = isVisited;
+  }
+  computeDirectedLabel() {
+    this._label = new Label(this._edge.getLabel());
+    if (!this._isForward) this._label.flip();
+  }
+  getNext() {
+    return this._next;
+  }
+  setDepth(position, depthVal) {
+    if (this._depth[position] !== -999) {
+      if (this._depth[position] !== depthVal)
+        throw new TopologyException(
+          "assigned depths do not match",
+          this.getCoordinate()
+        );
+    }
+    this._depth[position] = depthVal;
+  }
+  isInteriorAreaEdge() {
+    let isInteriorAreaEdge = true;
+    for (let i = 0; i < 2; i++) {
+      if (
+        !(
+          this._label.isArea(i) &&
+          this._label.getLocation(i, Position.LEFT) === Location.INTERIOR &&
+          this._label.getLocation(i, Position.RIGHT) === Location.INTERIOR
+        )
+      ) {
+        isInteriorAreaEdge = false;
+      }
+    }
+    return isInteriorAreaEdge;
+  }
+  setNextMin(nextMin) {
+    this._nextMin = nextMin;
+  }
+  setMinEdgeRing(minEdgeRing) {
+    this._minEdgeRing = minEdgeRing;
+  }
+  isLineEdge() {
+    const isLine = this._label.isLine(0) || this._label.isLine(1);
+    const isExteriorIfArea0 =
+      !this._label.isArea(0) ||
+      this._label.allPositionsEqual(0, Location.EXTERIOR);
+    const isExteriorIfArea1 =
+      !this._label.isArea(1) ||
+      this._label.allPositionsEqual(1, Location.EXTERIOR);
+    return isLine && isExteriorIfArea0 && isExteriorIfArea1;
+  }
+  setEdgeRing(edgeRing) {
+    this._edgeRing = edgeRing;
+  }
+  getMinEdgeRing() {
+    return this._minEdgeRing;
+  }
+  getDepthDelta() {
+    let depthDelta = this._edge.getDepthDelta();
+    if (!this._isForward) depthDelta = -depthDelta;
+    return depthDelta;
+  }
+  setInResult(isInResult) {
+    this._isInResult = isInResult;
+  }
+  getSym() {
+    return this._sym;
+  }
+  isForward() {
+    return this._isForward;
+  }
+  getEdge() {
+    return this._edge;
+  }
+  setSym(de) {
+    this._sym = de;
+  }
+  setVisitedEdge(isVisited) {
+    this.setVisited(isVisited);
+    this._sym.setVisited(isVisited);
+  }
+  setEdgeDepths(position, depth) {
+    let depthDelta = this.getEdge().getDepthDelta();
+    if (!this._isForward) depthDelta = -depthDelta;
+    let directionFactor = 1;
+    if (position === Position.LEFT) directionFactor = -1;
+    const oppositePos = Position.opposite(position);
+    const delta = depthDelta * directionFactor;
+    const oppositeDepth = depth + delta;
+    this.setDepth(position, depth);
+    this.setDepth(oppositePos, oppositeDepth);
+  }
+  getEdgeRing() {
+    return this._edgeRing;
+  }
+  isInResult() {
+    return this._isInResult;
+  }
+  setNext(next) {
+    this._next = next;
+  }
+  isVisited() {
+    return this._isVisited;
+  }
+  static depthFactor(currLocation, nextLocation) {
+    if (
+      currLocation === Location.EXTERIOR &&
+      nextLocation === Location.INTERIOR
+    )
+      return 1;
+    else if (
+      currLocation === Location.INTERIOR &&
+      nextLocation === Location.EXTERIOR
+    )
+      return -1;
+    return 0;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/DirectedEdgeStar.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/DirectedEdgeStar.js
@@ -1,0 +1,162 @@
+import Position from "./Position";
+import TopologyException from "../geom/TopologyException";
+import EdgeEndStar from "./EdgeEndStar";
+import Quadrant from "./Quadrant";
+import Assert from "../util/Assert";
+
+export default class DirectedEdgeStar extends EdgeEndStar {
+  constructor() {
+    super();
+    this._resultAreaEdgeList = null;
+    this._label = null;
+    this._SCANNING_FOR_INCOMING = 1;
+    this._LINKING_TO_OUTGOING = 2;
+  }
+  linkResultDirectedEdges() {
+    this.getResultAreaEdges();
+    let firstOut = null;
+    let incoming = null;
+    let state = this._SCANNING_FOR_INCOMING;
+    for (let i = 0; i < this._resultAreaEdgeList.length; i++) {
+      const nextOut = this._resultAreaEdgeList[i];
+      const nextIn = nextOut.getSym();
+      if (!nextOut.getLabel().isArea()) continue;
+      if (firstOut === null && nextOut.isInResult()) firstOut = nextOut;
+      switch (state) {
+        case this._SCANNING_FOR_INCOMING:
+          if (!nextIn.isInResult()) continue;
+          incoming = nextIn;
+          state = this._LINKING_TO_OUTGOING;
+          break;
+        case this._LINKING_TO_OUTGOING:
+          if (!nextOut.isInResult()) continue;
+          incoming.setNext(nextOut);
+          state = this._SCANNING_FOR_INCOMING;
+          break;
+        default:
+      }
+    }
+    if (state === this._LINKING_TO_OUTGOING) {
+      if (firstOut === null)
+        throw new TopologyException(
+          "no outgoing dirEdge found",
+          this.getCoordinate()
+        );
+      Assert.isTrue(
+        firstOut.isInResult(),
+        "unable to link last incoming dirEdge"
+      );
+      incoming.setNext(firstOut);
+    }
+  }
+  insert(ee) {
+    const de = ee;
+    this.insertEdgeEnd(de, de);
+  }
+  getRightmostEdge() {
+    const edges = this.getEdges();
+    const size = edges.length;
+    if (size < 1) return null;
+    const de0 = edges[0];
+    if (size === 1) return de0;
+    const deLast = edges[size - 1];
+    const quad0 = de0.getQuadrant();
+    const quad1 = deLast.getQuadrant();
+    if (Quadrant.isNorthern(quad0) && Quadrant.isNorthern(quad1)) return de0;
+    else if (!Quadrant.isNorthern(quad0) && !Quadrant.isNorthern(quad1))
+      return deLast;
+    else {
+      // const nonHorizontalEdge = null
+      if (de0.getDy() !== 0) return de0;
+      else if (deLast.getDy() !== 0) return deLast;
+    }
+    Assert.shouldNeverReachHere("found two horizontal edges incident on node");
+    return null;
+  }
+  getResultAreaEdges() {
+    if (this._resultAreaEdgeList !== null) return this._resultAreaEdgeList;
+    this._resultAreaEdgeList = this.getEdges().filter(
+      (de) => de.isInResult() || de.getSym().isInResult()
+    );
+    return this._resultAreaEdgeList;
+  }
+  linkAllDirectedEdges() {
+    this.getEdges();
+    let prevOut = null;
+    let firstIn = null;
+    for (let i = this._edgeList.length - 1; i >= 0; i--) {
+      const nextOut = this._edgeList[i];
+      const nextIn = nextOut.getSym();
+      if (firstIn === null) firstIn = nextIn;
+      if (prevOut !== null) nextIn.setNext(prevOut);
+      prevOut = nextOut;
+    }
+    firstIn.setNext(prevOut);
+  }
+  computeDepths() {
+    if (arguments.length === 1) {
+      let de = arguments[0];
+      const edgeIndex = this.findIndex(de);
+      // const label = de.getLabel()
+      const startDepth = de.getDepth(Position.LEFT);
+      const targetLastDepth = de.getDepth(Position.RIGHT);
+      const nextDepth = this.computeDepths(
+        edgeIndex + 1,
+        this._edgeList.length,
+        startDepth
+      );
+      const lastDepth = this.computeDepths(0, edgeIndex, nextDepth);
+      if (lastDepth !== targetLastDepth)
+        throw new TopologyException("depth mismatch at " + de.getCoordinate());
+    } else if (arguments.length === 3) {
+      const startIndex = arguments[0];
+      const endIndex = arguments[1];
+      const startDepth = arguments[2];
+      let currDepth = startDepth;
+      for (let i = startIndex; i < endIndex; i++) {
+        const nextDe = this._edgeList[i];
+        // const label = nextDe.getLabel()
+        nextDe.setEdgeDepths(Position.RIGHT, currDepth);
+        currDepth = nextDe.getDepth(Position.LEFT);
+      }
+      return currDepth;
+    }
+  }
+  linkMinimalDirectedEdges(er) {
+    let firstOut = null;
+    let incoming = null;
+    let state = this._SCANNING_FOR_INCOMING;
+    for (let i = this._resultAreaEdgeList.length - 1; i >= 0; i--) {
+      const nextOut = this._resultAreaEdgeList[i];
+      const nextIn = nextOut.getSym();
+      if (firstOut === null && nextOut.getEdgeRing() === er) firstOut = nextOut;
+      switch (state) {
+        case this._SCANNING_FOR_INCOMING:
+          if (nextIn.getEdgeRing() !== er) continue;
+          incoming = nextIn;
+          state = this._LINKING_TO_OUTGOING;
+          break;
+        case this._LINKING_TO_OUTGOING:
+          if (nextOut.getEdgeRing() !== er) continue;
+          incoming.setNextMin(nextOut);
+          state = this._SCANNING_FOR_INCOMING;
+          break;
+        default:
+      }
+    }
+    if (state === this._LINKING_TO_OUTGOING) {
+      Assert.isTrue(firstOut !== null, "found null for first outgoing dirEdge");
+      Assert.isTrue(
+        firstOut.getEdgeRing() === er,
+        "unable to link last incoming dirEdge"
+      );
+      incoming.setNextMin(firstOut);
+    }
+  }
+  getOutgoingDegree(er) {
+    return this.getEdges().filter((de) => de.getEdgeRing() === er).length;
+  }
+  getLabel() {
+    return this._label;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Edge.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Edge.js
@@ -1,0 +1,99 @@
+import { coordinates } from "../../../../utils/coordinates";
+import Envelope from "../geom/Envelope";
+import Depth from "./Depth";
+import GraphComponent from "./GraphComponent";
+
+export default class Edge extends GraphComponent {
+  constructor(pts, label) {
+    super();
+    this.pts = pts;
+    this._label = label;
+    this._env = null;
+    this._name = null;
+    this._mce = null;
+    this._isIsolated = true;
+    this._depth = new Depth();
+    this._depthDelta = 0;
+  }
+  getDepth() {
+    return this._depth;
+  }
+  isIsolated() {
+    return this._isIsolated;
+  }
+  getCoordinates() {
+    return this.pts;
+  }
+  setIsolated(isIsolated) {
+    this._isIsolated = isIsolated;
+  }
+  setName(name) {
+    this._name = name;
+  }
+  equals(o) {
+    if (!(o instanceof Edge)) return false;
+    const e = o;
+    if (this.pts.length !== e.pts.length) return false;
+    let isEqualForward = true;
+    let isEqualReverse = true;
+    let iRev = this.pts.length;
+    for (let i = 0; i < this.pts.length; i++) {
+      if (!coordinates.equals(this.pts[i], e.pts[i])) {
+        isEqualForward = false;
+      }
+      if (!coordinates.equals(this.pts[i], e.pts[--iRev])) {
+        isEqualReverse = false;
+      }
+      if (!isEqualForward && !isEqualReverse) return false;
+    }
+    return true;
+  }
+  getCoordinate() {
+    if (arguments.length === 0) {
+      if (this.pts.length > 0) return this.pts[0];
+      return null;
+    } else if (arguments.length === 1) {
+      const i = arguments[0];
+      return this.pts[i];
+    }
+  }
+  isCollapsed() {
+    if (!this._label.isArea()) return false;
+    if (this.pts.length !== 3) return false;
+    if (coordinates.equals(this.pts[0], this.pts[2])) return true;
+    return false;
+  }
+  isClosed() {
+    return coordinates.equals(this.pts[0], this.pts[this.pts.length - 1]);
+  }
+  getMaximumSegmentIndex() {
+    return this.pts.length - 1;
+  }
+  getDepthDelta() {
+    return this._depthDelta;
+  }
+  getNumPoints() {
+    return this.pts.length;
+  }
+  getEnvelope() {
+    if (this._env === null) {
+      this._env = new Envelope();
+      for (let i = 0; i < this.pts.length; i++) {
+        this._env.expandToInclude(this.pts[i]);
+      }
+    }
+    return this._env;
+  }
+  isPointwiseEqual(edge) {
+    if (this.pts.length !== edge.pts.length) return false;
+    for (let i = 0; i < this.pts.length; i++) {
+      if (!coordinates.equals(this.pts[i], edge.pts[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  setDepthDelta(depthDelta) {
+    this._depthDelta = depthDelta;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeEnd.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeEnd.js
@@ -1,0 +1,65 @@
+import CGAlgorithms from "../algorithm/CGAlgorithms";
+import Quadrant from "./Quadrant";
+import Assert from "../util/Assert";
+import { x, y } from "../../../../utils/coordinates";
+
+export default class EdgeEnd {
+  constructor(edge) {
+    this._edge = edge;
+    this._label = null;
+    this._node = null;
+    this._p0 = null;
+    this._p1 = null;
+    this._dx = null;
+    this._dy = null;
+    this._quadrant = null;
+  }
+  compareDirection(e) {
+    if (this._dx === e._dx && this._dy === e._dy) return 0;
+    if (this._quadrant > e._quadrant) return 1;
+    if (this._quadrant < e._quadrant) return -1;
+    return CGAlgorithms.computeOrientation(e._p0, e._p1, this._p1);
+  }
+  getDy() {
+    return this._dy;
+  }
+  getCoordinate() {
+    return this._p0;
+  }
+  setNode(node) {
+    this._node = node;
+  }
+  compareTo(obj) {
+    var e = obj;
+    return this.compareDirection(e);
+  }
+  getDirectedCoordinate() {
+    return this._p1;
+  }
+  getDx() {
+    return this._dx;
+  }
+  getLabel() {
+    return this._label;
+  }
+  getEdge() {
+    return this._edge;
+  }
+  getQuadrant() {
+    return this._quadrant;
+  }
+  getNode() {
+    return this._node;
+  }
+  init(p0, p1) {
+    this._p0 = p0;
+    this._p1 = p1;
+    this._dx = x(p1) - x(p0);
+    this._dy = y(p1) - y(p0);
+    this._quadrant = Quadrant.quadrant(this._dx, this._dy);
+    Assert.isTrue(
+      !(this._dx === 0 && this._dy === 0),
+      "EdgeEnd with identical endpoints found"
+    );
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeEndStar.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeEndStar.js
@@ -1,0 +1,30 @@
+import Location from "../geom/Location";
+import TreeMap from "../../../../java/util/TreeMap";
+
+export default class EdgeEndStar {
+  constructor() {
+    this._edgeMap = new TreeMap();
+    this._edgeList = null;
+    this._ptInAreaLocation = [Location.NONE, Location.NONE];
+  }
+  getCoordinate() {
+    edge = this.getEdges()[0];
+    return edge ? edge.getCoordinate() : null;
+  }
+  findIndex(eSearch) {
+    return this.getEdges().indexOf(eSearch);
+  }
+  getEdges() {
+    if (this._edgeList === null) {
+      this._edgeList = this._edgeMap.values();
+    }
+    return this._edgeList;
+  }
+  getDegree() {
+    return this._edgeMap.size();
+  }
+  insertEdgeEnd(e, obj) {
+    this._edgeMap.put(e, obj);
+    this._edgeList = null;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeList.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeList.js
@@ -1,0 +1,22 @@
+import OrientedCoordinateArray from "../noding/OrientedCoordinateArray";
+import TreeMap from "../../../../java/util/TreeMap";
+
+export default class EdgeList {
+  constructor() {
+    this._edges = [];
+    this._ocaMap = new TreeMap();
+  }
+  getEdges() {
+    return this._edges;
+  }
+  findEqualEdge(edge) {
+    const oca = new OrientedCoordinateArray(edge.getCoordinates());
+    const matchEdge = this._ocaMap.get(oca);
+    return matchEdge;
+  }
+  add(edge) {
+    this._edges.push(edge);
+    const oca = new OrientedCoordinateArray(edge.getCoordinates());
+    this._ocaMap.put(oca, edge);
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeRing.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/EdgeRing.js
@@ -1,0 +1,134 @@
+import Location from "../geom/Location";
+import CGAlgorithms from "../algorithm/CGAlgorithms";
+import Position from "./Position";
+import TopologyException from "../geom/TopologyException";
+import Label from "./Label";
+import Assert from "../util/Assert";
+import LinearRing from "../geom/LinearRing";
+
+export default class EdgeRing {
+  constructor(start) {
+    this._startDe = null;
+    this._maxNodeDegree = -1;
+    this._pts = [];
+    this._label = new Label(Location.NONE);
+    this._ring = null;
+    this._isHole = null;
+    this._shell = null;
+    this._holes = [];
+    this.computePoints(start);
+    this.computeRing();
+  }
+  computeRing() {
+    if (this._ring !== null) return null;
+    this._ring = new LinearRing(this._pts);
+    this._isHole = CGAlgorithms.isCCW(this._ring.getCoordinates());
+  }
+  computePoints(start) {
+    this._startDe = start;
+    let de = start;
+    let isFirstEdge = true;
+    do {
+      if (de === null) throw new TopologyException("Found null DirectedEdge");
+      if (de.getEdgeRing() === this)
+        throw new TopologyException(
+          "Directed Edge visited twice during ring-building at " +
+            de.getCoordinate()
+        );
+      const label = de.getLabel();
+      Assert.isTrue(label.isArea());
+      this.mergeLabel(label);
+      this.addPoints(de.getEdge(), de.isForward(), isFirstEdge);
+      isFirstEdge = false;
+      this.setEdgeRing(de, this);
+      de = this.getNext(de);
+    } while (de !== this._startDe);
+  }
+  getLinearRing() {
+    return this._ring;
+  }
+  getCoordinate(i) {
+    return this._pts[i];
+  }
+  computeMaxNodeDegree() {
+    this._maxNodeDegree = 0;
+    let de = this._startDe;
+    do {
+      const node = de.getNode();
+      const degree = node.getEdges().getOutgoingDegree(this);
+      if (degree > this._maxNodeDegree) this._maxNodeDegree = degree;
+      de = this.getNext(de);
+    } while (de !== this._startDe);
+    this._maxNodeDegree *= 2;
+  }
+  addPoints(edge, isForward, isFirstEdge) {
+    const edgePts = edge.getCoordinates();
+    if (isForward) {
+      let startIndex = 1;
+      if (isFirstEdge) startIndex = 0;
+      for (let i = startIndex; i < edgePts.length; i++) {
+        this._pts.push(edgePts[i]);
+      }
+    } else {
+      let startIndex = edgePts.length - 2;
+      if (isFirstEdge) startIndex = edgePts.length - 1;
+      for (let i = startIndex; i >= 0; i--) {
+        this._pts.push(edgePts[i]);
+      }
+    }
+  }
+  isHole() {
+    return this._isHole;
+  }
+  setInResult() {
+    let de = this._startDe;
+    do {
+      de.getEdge().setInResult(true);
+      de = de.getNext();
+    } while (de !== this._startDe);
+  }
+  addHole(ring) {
+    this._holes.push(ring);
+  }
+  isShell() {
+    return this._shell === null;
+  }
+  getLabel() {
+    return this._label;
+  }
+  getMaxNodeDegree() {
+    if (this._maxNodeDegree < 0) this.computeMaxNodeDegree();
+    return this._maxNodeDegree;
+  }
+  getShell() {
+    return this._shell;
+  }
+  mergeLabel() {
+    if (arguments.length === 1) {
+      const deLabel = arguments[0];
+      this.mergeLabel(deLabel, 0);
+      this.mergeLabel(deLabel, 1);
+    } else if (arguments.length === 2) {
+      const deLabel = arguments[0];
+      const geomIndex = arguments[1];
+      const loc = deLabel.getLocation(geomIndex, Position.RIGHT);
+      if (loc === Location.NONE) return null;
+      if (this._label.getLocation(geomIndex) === Location.NONE) {
+        this._label.setLocation(geomIndex, loc);
+        return null;
+      }
+    }
+  }
+  setShell(shell) {
+    this._shell = shell;
+    if (shell !== null) shell.addHole(this);
+  }
+  toPolygon() {
+    return {
+      type: "Polygon",
+      coordinates: [this, ...this._holes].map((p) =>
+        p.getLinearRing().getCoordinates()
+      ),
+    };
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/GraphComponent.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/GraphComponent.js
@@ -1,0 +1,34 @@
+export default class GraphComponent {
+  constructor() {
+    this._label = null;
+    this._isInResult = false;
+    this._isCovered = false;
+    this._isCoveredSet = false;
+    this._isVisited = false;
+  }
+  setVisited(isVisited) {
+    this._isVisited = isVisited;
+  }
+  setInResult(isInResult) {
+    this._isInResult = isInResult;
+  }
+  isCovered() {
+    return this._isCovered;
+  }
+  isCoveredSet() {
+    return this._isCoveredSet;
+  }
+  getLabel() {
+    return this._label;
+  }
+  setCovered(isCovered) {
+    this._isCovered = isCovered;
+    this._isCoveredSet = true;
+  }
+  isInResult() {
+    return this._isInResult;
+  }
+  isVisited() {
+    return this._isVisited;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Label.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Label.js
@@ -1,0 +1,142 @@
+import Location from "../geom/Location";
+import Position from "./Position";
+import TopologyLocation from "./TopologyLocation";
+
+export default class Label {
+  constructor() {
+    this.elt = new Array(2).fill(null);
+    if (arguments.length === 1) {
+      if (Number.isInteger(arguments[0])) {
+        const onLoc = arguments[0];
+        this.elt[0] = new TopologyLocation(onLoc);
+        this.elt[1] = new TopologyLocation(onLoc);
+      } else if (arguments[0] instanceof Label) {
+        const lbl = arguments[0];
+        this.elt[0] = new TopologyLocation(lbl.elt[0]);
+        this.elt[1] = new TopologyLocation(lbl.elt[1]);
+      }
+    } else if (arguments.length === 2) {
+      const geomIndex = arguments[0];
+      const onLoc = arguments[1];
+      this.elt[0] = new TopologyLocation(Location.NONE);
+      this.elt[1] = new TopologyLocation(Location.NONE);
+      this.elt[geomIndex].setLocation(onLoc);
+    } else if (arguments.length === 3) {
+      const onLoc = arguments[0];
+      const leftLoc = arguments[1];
+      const rightLoc = arguments[2];
+      this.elt[0] = new TopologyLocation(onLoc, leftLoc, rightLoc);
+      this.elt[1] = new TopologyLocation(onLoc, leftLoc, rightLoc);
+    } else if (arguments.length === 4) {
+      const geomIndex = arguments[0];
+      const onLoc = arguments[1];
+      const leftLoc = arguments[2];
+      const rightLoc = arguments[3];
+      this.elt[0] = new TopologyLocation(
+        Location.NONE,
+        Location.NONE,
+        Location.NONE
+      );
+      this.elt[1] = new TopologyLocation(
+        Location.NONE,
+        Location.NONE,
+        Location.NONE
+      );
+      this.elt[geomIndex].setLocations(onLoc, leftLoc, rightLoc);
+    }
+  }
+  getGeometryCount() {
+    let count = 0;
+    if (!this.elt[0].isNull()) count++;
+    if (!this.elt[1].isNull()) count++;
+    return count;
+  }
+  setAllLocations(geomIndex, location) {
+    this.elt[geomIndex].setAllLocations(location);
+  }
+  isNull(geomIndex) {
+    return this.elt[geomIndex].isNull();
+  }
+  setAllLocationsIfNull() {
+    if (arguments.length === 1) {
+      const location = arguments[0];
+      this.setAllLocationsIfNull(0, location);
+      this.setAllLocationsIfNull(1, location);
+    } else if (arguments.length === 2) {
+      const geomIndex = arguments[0];
+      const location = arguments[1];
+      this.elt[geomIndex].setAllLocationsIfNull(location);
+    }
+  }
+  isLine(geomIndex) {
+    return this.elt[geomIndex].isLine();
+  }
+  merge(lbl) {
+    for (let i = 0; i < 2; i++) {
+      if (this.elt[i] === null && lbl.elt[i] !== null) {
+        this.elt[i] = new TopologyLocation(lbl.elt[i]);
+      } else {
+        this.elt[i].merge(lbl.elt[i]);
+      }
+    }
+  }
+  flip() {
+    this.elt[0].flip();
+    this.elt[1].flip();
+  }
+  getLocation() {
+    if (arguments.length === 1) {
+      const geomIndex = arguments[0];
+      return this.elt[geomIndex].get(Position.ON);
+    } else if (arguments.length === 2) {
+      const geomIndex = arguments[0];
+      const posIndex = arguments[1];
+      return this.elt[geomIndex].get(posIndex);
+    }
+  }
+  isArea() {
+    if (arguments.length === 0) {
+      return this.elt[0].isArea() || this.elt[1].isArea();
+    } else if (arguments.length === 1) {
+      const geomIndex = arguments[0];
+      return this.elt[geomIndex].isArea();
+    }
+  }
+  isAnyNull(geomIndex) {
+    return this.elt[geomIndex].isAnyNull();
+  }
+  setLocation() {
+    if (arguments.length === 2) {
+      const geomIndex = arguments[0];
+      const location = arguments[1];
+      this.elt[geomIndex].setLocation(Position.ON, location);
+    } else if (arguments.length === 3) {
+      const geomIndex = arguments[0];
+      const posIndex = arguments[1];
+      const location = arguments[2];
+      this.elt[geomIndex].setLocation(posIndex, location);
+    }
+  }
+  isEqualOnSide(lbl, side) {
+    return (
+      this.elt[0].isEqualOnSide(lbl.elt[0], side) &&
+      this.elt[1].isEqualOnSide(lbl.elt[1], side)
+    );
+  }
+  allPositionsEqual(geomIndex, loc) {
+    return this.elt[geomIndex].allPositionsEqual(loc);
+  }
+  toLine(geomIndex) {
+    if (this.elt[geomIndex].isArea())
+      this.elt[geomIndex] = new TopologyLocation(
+        this.elt[geomIndex].location[0]
+      );
+  }
+  static toLineLabel(label) {
+    const lineLabel = new Label(Location.NONE);
+    for (let i = 0; i < 2; i++) {
+      lineLabel.setLocation(i, label.getLocation(i));
+    }
+    return lineLabel;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Node.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Node.js
@@ -1,0 +1,16 @@
+import GraphComponent from "./GraphComponent";
+
+export default class Node extends GraphComponent {
+  constructor(coord, edges) {
+    super();
+    this._coord = coord;
+    this._edges = edges;
+  }
+  getEdges() {
+    return this._edges;
+  }
+  add(edge) {
+    this._edges.insert(edge);
+    edge.setNode(this);
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/NodeMap.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/NodeMap.js
@@ -1,0 +1,28 @@
+import { coordinates } from "../../../../utils/coordinates";
+import Node from "./Node";
+import TreeMap from "../../../../java/util/TreeMap";
+import DirectedEdgeStar from "./DirectedEdgeStar";
+
+export default class NodeMap {
+  constructor() {
+    this.nodeMap = new TreeMap(coordinates.compare);
+  }
+  _addNode(coord) {
+    if (coordinates.isCoordinate(coord)) {
+      let node = this.nodeMap.get(coord);
+      if (node === null) {
+        node = new Node(coord, new DirectedEdgeStar());
+        this.nodeMap.put(coord, node);
+      }
+      return node;
+    }
+  }
+  values() {
+    return this.nodeMap.values();
+  }
+  add(edge) {
+    const point = edge.getCoordinate();
+    const node = this._addNode(point);
+    node.add(edge);
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/PlanarGraph.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/PlanarGraph.js
@@ -1,0 +1,33 @@
+import NodeMap from "./NodeMap";
+import DirectedEdge from "./DirectedEdge";
+
+export default class PlanarGraph {
+  constructor() {
+    this._nodes = new NodeMap();
+  }
+  linkResultDirectedEdges() {
+    this._nodes
+      .values()
+      .forEach((node) => node.getEdges().linkResultDirectedEdges());
+  }
+  addEdges(edgesToAdd) {
+    edgesToAdd.forEach((edge) => {
+      const de1 = new DirectedEdge(edge, true);
+      const de2 = new DirectedEdge(edge, false);
+      de1.setSym(de2);
+      de2.setSym(de1);
+      this._add(de1);
+      this._add(de2);
+    });
+  }
+  _add(directEdge) {
+    this._nodes.add(directEdge);
+  }
+  getNodes() {
+    return this._nodes.values();
+  }
+
+  static linkResultDirectedEdges(nodes) {
+    nodes.forEach((node) => node.getEdges().linkResultDirectedEdges());
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Position.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Position.js
@@ -1,0 +1,16 @@
+export default class Position {
+  static opposite(position) {
+    if (position === Position.LEFT) return Position.RIGHT;
+    if (position === Position.RIGHT) return Position.LEFT;
+    return position;
+  }
+  static get ON() {
+    return 0;
+  }
+  static get LEFT() {
+    return 1;
+  }
+  static get RIGHT() {
+    return 2;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Quadrant.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/Quadrant.js
@@ -1,0 +1,54 @@
+import IllegalArgumentException from "../../../../java/lang/IllegalArgumentException";
+import { coordinates, x, y } from "../../../../utils/coordinates";
+
+export default class Quadrant {
+  static isNorthern(quad) {
+    return quad === Quadrant.NE || quad === Quadrant.NW;
+  }
+  static quadrant() {
+    if (typeof arguments[0] === "number" && typeof arguments[1] === "number") {
+      const dx = arguments[0];
+      const dy = arguments[1];
+      if (dx === 0.0 && dy === 0.0)
+        throw new IllegalArgumentException(
+          "Cannot compute the quadrant for point ( " + dx + ", " + dy + " )"
+        );
+      if (dx >= 0.0) {
+        if (dy >= 0.0) return Quadrant.NE;
+        else return Quadrant.SE;
+      } else {
+        if (dy >= 0.0) return Quadrant.NW;
+        else return Quadrant.SW;
+      }
+    } else if (
+      coordinates.isCoordinate(arguments[0]) &&
+      coordinates.isCoordinate(arguments[1])
+    ) {
+      const p0 = arguments[0];
+      const p1 = arguments[1];
+      if (x(p1) === x(p0) && y(p1) === y(p0))
+        throw new IllegalArgumentException(
+          "Cannot compute the quadrant for two identical points " + p0
+        );
+      if (x(p1) >= x(p0)) {
+        if (y(p1) >= y(p0)) return Quadrant.NE;
+        else return Quadrant.SE;
+      } else {
+        if (y(p1) >= y(p0)) return Quadrant.NW;
+        else return Quadrant.SW;
+      }
+    }
+  }
+  static get NE() {
+    return 0;
+  }
+  static get NW() {
+    return 1;
+  }
+  static get SW() {
+    return 2;
+  }
+  static get SE() {
+    return 3;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/TopologyLocation.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/geomgraph/TopologyLocation.js
@@ -1,0 +1,116 @@
+import Location from "../geom/Location";
+import Position from "./Position";
+
+export default class TopologyLocation {
+  constructor() {
+    this.location = null;
+    if (arguments.length === 1) {
+      if (arguments[0] instanceof Array) {
+        const location = arguments[0];
+        this.init(location.length);
+      } else if (Number.isInteger(arguments[0])) {
+        const on = arguments[0];
+        this.init(1);
+        this.location[Position.ON] = on;
+      } else if (arguments[0] instanceof TopologyLocation) {
+        const gl = arguments[0];
+        this.init(gl.location.length);
+        if (gl !== null) {
+          for (let i = 0; i < this.location.length; i++) {
+            this.location[i] = gl.location[i];
+          }
+        }
+      }
+    } else if (arguments.length === 3) {
+      const on = arguments[0];
+      const left = arguments[1];
+      const right = arguments[2];
+      this.init(3);
+      this.location[Position.ON] = on;
+      this.location[Position.LEFT] = left;
+      this.location[Position.RIGHT] = right;
+    }
+  }
+  setAllLocations(locValue) {
+    for (let i = 0; i < this.location.length; i++) {
+      this.location[i] = locValue;
+    }
+  }
+  isNull() {
+    for (let i = 0; i < this.location.length; i++) {
+      if (this.location[i] !== Location.NONE) return false;
+    }
+    return true;
+  }
+  setAllLocationsIfNull(locValue) {
+    for (let i = 0; i < this.location.length; i++) {
+      if (this.location[i] === Location.NONE) this.location[i] = locValue;
+    }
+  }
+  isLine() {
+    return this.location.length === 1;
+  }
+  merge(gl) {
+    if (gl.location.length > this.location.length) {
+      const newLoc = new Array(3).fill(null);
+      newLoc[Position.ON] = this.location[Position.ON];
+      newLoc[Position.LEFT] = Location.NONE;
+      newLoc[Position.RIGHT] = Location.NONE;
+      this.location = newLoc;
+    }
+    for (let i = 0; i < this.location.length; i++) {
+      if (this.location[i] === Location.NONE && i < gl.location.length)
+        this.location[i] = gl.location[i];
+    }
+  }
+  getLocations() {
+    return this.location;
+  }
+  flip() {
+    if (this.location.length <= 1) return null;
+    const temp = this.location[Position.LEFT];
+    this.location[Position.LEFT] = this.location[Position.RIGHT];
+    this.location[Position.RIGHT] = temp;
+  }
+  setLocations(on, left, right) {
+    this.location[Position.ON] = on;
+    this.location[Position.LEFT] = left;
+    this.location[Position.RIGHT] = right;
+  }
+  get(posIndex) {
+    if (posIndex < this.location.length) return this.location[posIndex];
+    return Location.NONE;
+  }
+  isArea() {
+    return this.location.length > 1;
+  }
+  isAnyNull() {
+    for (let i = 0; i < this.location.length; i++) {
+      if (this.location[i] === Location.NONE) return true;
+    }
+    return false;
+  }
+  setLocation() {
+    if (arguments.length === 1) {
+      const locValue = arguments[0];
+      this.setLocation(Position.ON, locValue);
+    } else if (arguments.length === 2) {
+      const locIndex = arguments[0];
+      const locValue = arguments[1];
+      this.location[locIndex] = locValue;
+    }
+  }
+  init(size) {
+    this.location = new Array(size).fill(null);
+    this.setAllLocations(Location.NONE);
+  }
+  isEqualOnSide(le, locIndex) {
+    return this.location[locIndex] === le.location[locIndex];
+  }
+  allPositionsEqual(loc) {
+    for (let i = 0; i < this.location.length; i++) {
+      if (this.location[i] !== loc) return false;
+    }
+    return true;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/chain/MonotoneChain.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/chain/MonotoneChain.js
@@ -1,0 +1,104 @@
+import Envelope from "../../geom/Envelope";
+
+export default class MonotoneChain {
+  constructor(pts, start, end, context) {
+    this._env = null;
+    this._id = null;
+    this._pts = pts;
+    this._start = start;
+    this._end = end;
+    this._context = context;
+  }
+  getLineSegment(index, ls) {
+    ls.p0 = this._pts[index];
+    ls.p1 = this._pts[index + 1];
+  }
+  computeSelect(searchEnv, start0, end0, mcs) {
+    const p0 = this._pts[start0];
+    const p1 = this._pts[end0];
+    mcs.tempEnv1.init(p0, p1);
+    if (end0 - start0 === 1) {
+      mcs.select(this, start0);
+      return null;
+    }
+    if (!searchEnv.intersects(mcs.tempEnv1)) return null;
+    const mid = Math.trunc((start0 + end0) / 2);
+    if (start0 < mid) {
+      this.computeSelect(searchEnv, start0, mid, mcs);
+    }
+    if (mid < end0) {
+      this.computeSelect(searchEnv, mid, end0, mcs);
+    }
+  }
+  getCoordinates() {
+    const coord = new Array(this._end - this._start + 1).fill(null);
+    let index = 0;
+    for (let i = this._start; i <= this._end; i++) {
+      coord[index++] = this._pts[i];
+    }
+    return coord;
+  }
+  computeOverlaps(mc, mco) {
+    this.computeOverlapsInternal(
+      this._start,
+      this._end,
+      mc,
+      mc._start,
+      mc._end,
+      mco
+    );
+  }
+  setId(id) {
+    this._id = id;
+  }
+  select(searchEnv, mcs) {
+    this.computeSelect(searchEnv, this._start, this._end, mcs);
+  }
+  getEnvelope() {
+    if (this._env === null) {
+      const p0 = this._pts[this._start];
+      const p1 = this._pts[this._end];
+      this._env = new Envelope(p0, p1);
+    }
+    return this._env;
+  }
+  getEndIndex() {
+    return this._end;
+  }
+  getStartIndex() {
+    return this._start;
+  }
+  getContext() {
+    return this._context;
+  }
+  getId() {
+    return this._id;
+  }
+  computeOverlapsInternal(start0, end0, mc, start1, end1, mco) {
+    const p00 = this._pts[start0];
+    const p01 = this._pts[end0];
+    const p10 = mc._pts[start1];
+    const p11 = mc._pts[end1];
+    if (end0 - start0 === 1 && end1 - start1 === 1) {
+      mco.overlap(this, start0, mc, start1);
+      return null;
+    }
+    mco.tempEnv1.init(p00, p01);
+    mco.tempEnv2.init(p10, p11);
+    if (!mco.tempEnv1.intersects(mco.tempEnv2)) return null;
+    const mid0 = Math.trunc((start0 + end0) / 2);
+    const mid1 = Math.trunc((start1 + end1) / 2);
+    if (start0 < mid0) {
+      if (start1 < mid1)
+        this.computeOverlapsInternal(start0, mid0, mc, start1, mid1, mco);
+      if (mid1 < end1)
+        this.computeOverlapsInternal(start0, mid0, mc, mid1, end1, mco);
+    }
+    if (mid0 < end0) {
+      if (start1 < mid1)
+        this.computeOverlapsInternal(mid0, end0, mc, start1, mid1, mco);
+      if (mid1 < end1)
+        this.computeOverlapsInternal(mid0, end0, mc, mid1, end1, mco);
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/chain/MonotoneChainBuilder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/chain/MonotoneChainBuilder.js
@@ -1,0 +1,53 @@
+import MonotoneChain from "./MonotoneChain";
+import Quadrant from "../../geomgraph/Quadrant";
+import { coordinates } from "../../../../../utils/coordinates";
+
+export default class MonotoneChainBuilder {
+  static getChainStartIndices(pts) {
+    let start = 0;
+    const startIndexList = [];
+    startIndexList.push(start);
+    do {
+      const last = MonotoneChainBuilder.findChainEnd(pts, start);
+      startIndexList.push(last);
+      start = last;
+    } while (start < pts.length - 1);
+    return startIndexList;
+  }
+  static findChainEnd(pts, start) {
+    let safeStart = start;
+    while (
+      safeStart < pts.length - 1 &&
+      coordinates.equals(pts[safeStart], pts[safeStart + 1])
+    ) {
+      safeStart++;
+    }
+    if (safeStart >= pts.length - 1) {
+      return pts.length - 1;
+    }
+    const chainQuad = Quadrant.quadrant(pts[safeStart], pts[safeStart + 1]);
+    let last = start + 1;
+    while (last < pts.length) {
+      if (!coordinates.equals(pts[last - 1], pts[last])) {
+        const quad = Quadrant.quadrant(pts[last - 1], pts[last]);
+        if (quad !== chainQuad) break;
+      }
+      last++;
+    }
+    return last - 1;
+  }
+  static getChains(pts, context) {
+    const mcList = [];
+    const startIndex = MonotoneChainBuilder.getChainStartIndices(pts);
+    for (let i = 0; i < startIndex.length - 1; i++) {
+      const mc = new MonotoneChain(
+        pts,
+        startIndex[i],
+        startIndex[i + 1],
+        context
+      );
+      mcList.push(mc);
+    }
+    return mcList;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/chain/MonotoneChainOverlapAction.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/chain/MonotoneChainOverlapAction.js
@@ -1,0 +1,25 @@
+import LineSegment from "../../geom/LineSegment";
+import Envelope from "../../geom/Envelope";
+
+export default class MonotoneChainOverlapAction {
+  constructor() {
+    this.tempEnv1 = new Envelope();
+    this.tempEnv2 = new Envelope();
+    this._overlapSeg1 = new LineSegment();
+    this._overlapSeg2 = new LineSegment();
+  }
+  overlap() {
+    if (arguments.length === 2) {
+      // const seg1 = arguments[0]
+      // const seg2 = arguments[1]
+    } else if (arguments.length === 4) {
+      const mc1 = arguments[0];
+      const start1 = arguments[1];
+      const mc2 = arguments[2];
+      const start2 = arguments[3];
+      mc1.getLineSegment(start1, this._overlapSeg1);
+      mc2.getLineSegment(start2, this._overlapSeg2);
+      this.overlap(this._overlapSeg1, this._overlapSeg2);
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/AbstractNode.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/AbstractNode.js
@@ -1,0 +1,39 @@
+import Assert from "../../util/Assert";
+
+export default class AbstractNode {
+  constructor() {
+    this._childBoundables = [];
+    this._bounds = null;
+    this._level = null;
+    if (arguments.length === 0) {
+    } else if (arguments.length === 1) {
+      let level = arguments[0];
+      this._level = level;
+    }
+  }
+  getLevel() {
+    return this._level;
+  }
+  size() {
+    return this._childBoundables.length;
+  }
+  getChildBoundables() {
+    return this._childBoundables;
+  }
+  setChildBoundables(childBoundables) {
+    this._childBoundables = childBoundables;
+  }
+  addChildBoundable(childBoundable) {
+    Assert.isTrue(this._bounds === null);
+    this._childBoundables.push(childBoundable);
+  }
+  isEmpty() {
+    return !this._childBoundables.length;
+  }
+  getBounds() {
+    if (this._bounds === null) {
+      this._bounds = this.computeBounds();
+    }
+    return this._bounds;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/AbstractSTRtree.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/AbstractSTRtree.js
@@ -1,0 +1,119 @@
+import ItemBoundable from "./ItemBoundable";
+import AbstractNode from "./AbstractNode";
+import Assert from "../../util/Assert";
+
+export default class AbstractSTRtree {
+  constructor(nodeCapacity) {
+    this._root = null;
+    this._built = false;
+    this._itemBoundables = [];
+    Assert.isTrue(nodeCapacity > 1, "Node capacity must be greater than 1");
+    this._nodeCapacity = nodeCapacity;
+  }
+  getNodeCapacity() {
+    return this._nodeCapacity;
+  }
+  lastNode(nodes) {
+    return nodes[nodes.length - 1];
+  }
+  removeItem(node, item) {
+    const count = node.getChildBoundables().length;
+    const result = node
+      .getChildBoundables()
+      .filter(
+        (childBoundable) =>
+          !(
+            childBoundable instanceof ItemBoundable &&
+            childBoundable.getItem() === item
+          )
+      );
+    if (result.length < count) {
+      node.setChildBoundables(result);
+      return true;
+    }
+    return false;
+  }
+  insert(bounds, item) {
+    Assert.isTrue(
+      !this._built,
+      "Cannot insert items into an STR packed R-tree after it has been built."
+    );
+    this._itemBoundables.push(new ItemBoundable(bounds, item));
+  }
+  _query(searchBounds, node, matches) {
+    node.getChildBoundables().forEach((childBoundable) => {
+      if (!childBoundable.getBounds().intersects(searchBounds)) {
+        return;
+      }
+      if (childBoundable instanceof AbstractNode) {
+        this._query(searchBounds, childBoundable, matches);
+      } else if (childBoundable instanceof ItemBoundable) {
+        matches.push(childBoundable.getItem());
+      } else {
+        Assert.shouldNeverReachHere();
+      }
+    });
+  }
+  query(searchBounds) {
+    this.build();
+    const matches = [];
+    if (this.isEmpty()) {
+      return matches;
+    }
+    if (this._root.getBounds().intersects(searchBounds)) {
+      this._query(searchBounds, this._root, matches);
+    }
+
+    return matches;
+  }
+  build() {
+    if (this._built) return null;
+    this._root = !this._itemBoundables.length
+      ? this.createNode(0)
+      : this.createHigherLevels(this._itemBoundables, -1);
+    this._itemBoundables = null;
+    this._built = true;
+  }
+  getRoot() {
+    this.build();
+    return this._root;
+  }
+  createHigherLevels(boundablesOfALevel, level) {
+    Assert.isTrue(boundablesOfALevel.length);
+    const parentBoundables = this.createParentBoundables(
+      boundablesOfALevel,
+      level + 1
+    );
+    return parentBoundables.length === 1
+      ? parentBoundables[0]
+      : this.createHigherLevels(parentBoundables, level + 1);
+  }
+  createParentBoundables(childBoundables, newLevel) {
+    Assert.isTrue(childBoundables.length);
+    const parentBoundables = [this.createNode(newLevel)];
+    const sortedChildBoundables = [...childBoundables];
+    sortedChildBoundables
+      .sort(this.getComparator())
+      .forEach((childBoundable) => {
+        if (
+          this.lastNode(parentBoundables).getChildBoundables().length ===
+          this.getNodeCapacity()
+        ) {
+          parentBoundables.push(this.createNode(newLevel));
+        }
+        this.lastNode(parentBoundables).addChildBoundable(childBoundable);
+      });
+    return parentBoundables;
+  }
+  isEmpty() {
+    if (!this._built) return !this._itemBoundables.length;
+    return this._root.isEmpty();
+  }
+  static compareDoubles(a, b) {
+    return a > b ? 1 : a < b ? -1 : 0;
+  }
+
+  static get DEFAULT_NODE_CAPACITY() {
+    return 10;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/ItemBoundable.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/ItemBoundable.js
@@ -1,0 +1,16 @@
+export default class ItemBoundable {
+  constructor() {
+    this._bounds = null;
+    this._item = null;
+    const bounds = arguments[0];
+    const item = arguments[1];
+    this._bounds = bounds;
+    this._item = item;
+  }
+  getItem() {
+    return this._item;
+  }
+  getBounds() {
+    return this._bounds;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/STRtree.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/index/strtree/STRtree.js
@@ -1,0 +1,124 @@
+import AbstractNode from "./AbstractNode";
+import Envelope from "../../geom/Envelope";
+import Assert from "../../util/Assert";
+import AbstractSTRtree from "./AbstractSTRtree";
+
+export default class STRtree extends AbstractSTRtree {
+  constructor(nodeCapacity) {
+    nodeCapacity = nodeCapacity || STRtree.DEFAULT_NODE_CAPACITY;
+    super(nodeCapacity);
+  }
+  createParentBoundablesFromVerticalSlices(verticalSlices, newLevel) {
+    Assert.isTrue(verticalSlices.length > 0);
+    const parentBoundables = [];
+    for (let i = 0; i < verticalSlices.length; i++) {
+      parentBoundables.push(
+        ...this.createParentBoundablesFromVerticalSlice(
+          verticalSlices[i],
+          newLevel
+        )
+      );
+    }
+    return parentBoundables;
+  }
+  createNode(level) {
+    return new STRtreeNode(level);
+  }
+  insert(itemEnv, item) {
+    if (itemEnv.isNull()) {
+      return null;
+    }
+    AbstractSTRtree.prototype.insert.call(this, itemEnv, item);
+  }
+  verticalSlices(childBoundables, sliceCount) {
+    const sliceCapacity = Math.trunc(
+      Math.ceil(childBoundables.length / sliceCount)
+    );
+    const slices = new Array(sliceCount).fill(null);
+    for (let j = 0; j < sliceCount; j++) {
+      slices[j] = childBoundables.slice(
+        j * sliceCapacity,
+        j * sliceCapacity + sliceCapacity
+      );
+    }
+    return slices;
+  }
+  query(searchEnv) {
+    return AbstractSTRtree.prototype.query.call(this, searchEnv);
+  }
+  getComparator() {
+    return STRtree.yComparator;
+  }
+  createParentBoundablesFromVerticalSlice(childBoundables, newLevel) {
+    return AbstractSTRtree.prototype.createParentBoundables.call(
+      this,
+      childBoundables,
+      newLevel
+    );
+  }
+  createParentBoundables(childBoundables, newLevel) {
+    Assert.isTrue(childBoundables.length);
+    const minLeafCount = Math.trunc(
+      Math.ceil(childBoundables.length / this.getNodeCapacity())
+    );
+    const sortedChildBoundables = [...childBoundables].sort(
+      STRtree.xComparator
+    );
+    const verticalSlices = this.verticalSlices(
+      sortedChildBoundables,
+      Math.trunc(Math.ceil(Math.sqrt(minLeafCount)))
+    );
+    return this.createParentBoundablesFromVerticalSlices(
+      verticalSlices,
+      newLevel
+    );
+  }
+  static centreX(e) {
+    return STRtree.avg(e.getMinX(), e.getMaxX());
+  }
+  static avg(a, b) {
+    return (a + b) / 2;
+  }
+  static centreY(e) {
+    return STRtree.avg(e.getMinY(), e.getMaxY());
+  }
+  static get STRtreeNode() {
+    return STRtreeNode;
+  }
+  static get xComparator() {
+    return function (o1, o2) {
+      return AbstractSTRtree.compareDoubles(
+        STRtree.centreX(o1.getBounds()),
+        STRtree.centreX(o2.getBounds())
+      );
+    };
+  }
+  static get yComparator() {
+    return function (o1, o2) {
+      return AbstractSTRtree.compareDoubles(
+        STRtree.centreY(o1.getBounds()),
+        STRtree.centreY(o2.getBounds())
+      );
+    };
+  }
+  static get DEFAULT_NODE_CAPACITY() {
+    return 10;
+  }
+}
+
+class STRtreeNode extends AbstractNode {
+  constructor(level) {
+    super(level);
+  }
+  computeBounds() {
+    let bounds = null;
+    this.getChildBoundables().forEach((childBoundable) => {
+      if (bounds === null) {
+        bounds = new Envelope(childBoundable.getBounds());
+      } else {
+        bounds.expandToInclude(childBoundable.getBounds());
+      }
+    });
+    return bounds;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/math/DD.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/math/DD.js
@@ -1,0 +1,85 @@
+export default class DD {
+  constructor(hi, lo = 0.0) {
+    this._hi = hi;
+    this._lo = lo;
+  }
+  selfSubtract(y) {
+    if (Number.isNaN(this._hi)) return this;
+    return this.selfAdd(-y._hi, -y._lo);
+  }
+  selfAdd(yhi, ylo) {
+    if (arguments.length === 1) {
+      const y = arguments[0];
+      if (y instanceof DD) {
+        return this.selfAdd(y._hi, y._lo);
+      } else if (typeof y === "number") {
+        let S, e, s, f, H, h;
+        S = this._hi + y;
+        e = S - this._hi;
+        s = S - e;
+        s = y - e + (this._hi - s);
+        f = s + this._lo;
+        H = S + f;
+        h = f + (S - H);
+        this._hi = H + h;
+        this._lo = h + (H - this._hi);
+        return this;
+      }
+    }
+    let S, T, e, f, s, t, H, h;
+    S = this._hi + yhi;
+    T = this._lo + ylo;
+    e = S - this._hi;
+    f = T - this._lo;
+    s = S - e;
+    t = T - f;
+    s = yhi - e + (this._hi - s);
+    t = ylo - f + (this._lo - t);
+    e = s + T;
+    H = S + e;
+    h = e + (S - H);
+    e = t + h;
+    var zhi = H + e;
+    var zlo = e + (H - zhi);
+    this._hi = zhi;
+    this._lo = zlo;
+    return this;
+  }
+  selfMultiply(dd) {
+    const yhi = dd._hi;
+    const ylo = dd._lo;
+    let C, hx, c, tx, hy, ty, zhi, zlo;
+    C = DD.SPLIT * this._hi;
+    hx = C - this._hi;
+    c = DD.SPLIT * yhi;
+    hx = C - hx;
+    tx = this._hi - hx;
+    hy = c - yhi;
+    C = this._hi * yhi;
+    hy = c - hy;
+    ty = yhi - hy;
+    c =
+      hx * hy -
+      C +
+      hx * ty +
+      tx * hy +
+      tx * ty +
+      (this._hi * ylo + this._lo * yhi);
+    zhi = C + c;
+    hx = C - zhi;
+    zlo = c + hx;
+    this._hi = zhi;
+    this._lo = zlo;
+    return this;
+  }
+  signum() {
+    if (this._hi > 0) return 1;
+    if (this._hi < 0) return -1;
+    if (this._lo > 0) return 1;
+    if (this._lo < 0) return -1;
+    return 0;
+  }
+  static get SPLIT() {
+    return 134217729.0;
+  } // DD
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/IntersectionAdder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/IntersectionAdder.js
@@ -1,0 +1,59 @@
+export default class IntersectionAdder {
+  constructor(li) {
+    this._hasIntersection = false;
+    this._isSelfIntersection = null;
+    this.numIntersections = 0;
+    this.numInteriorIntersections = 0;
+    this.numProperIntersections = 0;
+    this.numTests = 0;
+    this._li = li;
+  }
+  _isTrivialIntersection(e0, segIndex0, e1, segIndex1) {
+    if (e0 === e1) {
+      if (this._li.getIntersectionNum() === 1) {
+        if (IntersectionAdder.isAdjacentSegments(segIndex0, segIndex1))
+          return true;
+        if (e0.isClosed()) {
+          const maxSegIndex = e0.size() - 1;
+          if (
+            (segIndex0 === 0 && segIndex1 === maxSegIndex) ||
+            (segIndex1 === 0 && segIndex0 === maxSegIndex)
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+  processIntersections(e0, segIndex0, e1, segIndex1) {
+    if (e0 === e1 && segIndex0 === segIndex1) return null;
+    this.numTests++;
+    const p00 = e0.getCoordinates()[segIndex0];
+    const p01 = e0.getCoordinates()[segIndex0 + 1];
+    const p10 = e1.getCoordinates()[segIndex1];
+    const p11 = e1.getCoordinates()[segIndex1 + 1];
+    // IMPORTANT: Pass copy of coordinates here
+    this._li.computeIntersection([...p00], [...p01], [...p10], [...p11]);
+    if (this._li.hasIntersection()) {
+      this.numIntersections++;
+      if (this._li.isInteriorIntersection()) {
+        this.numInteriorIntersections++;
+      }
+      if (!this._isTrivialIntersection(e0, segIndex0, e1, segIndex1)) {
+        this._hasIntersection = true;
+        e0.addIntersections(this._li, segIndex0, 0);
+        e1.addIntersections(this._li, segIndex1, 1);
+        if (this._li.isProper()) {
+          this.numProperIntersections++;
+        }
+      }
+    }
+  }
+  hasIntersection() {
+    return this._hasIntersection;
+  }
+  static isAdjacentSegments(i1, i2) {
+    return Math.abs(i1 - i2) === 1;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/MCIndexNoder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/MCIndexNoder.js
@@ -1,0 +1,71 @@
+import STRtree from "../index/strtree/STRtree";
+import NodedSegmentString from "./NodedSegmentString";
+import MonotoneChainOverlapAction from "../index/chain/MonotoneChainOverlapAction";
+import MonotoneChainBuilder from "../index/chain/MonotoneChainBuilder";
+
+export default class MCIndexNoder {
+  constructor(si) {
+    this._segInt = si;
+    this._monoChains = [];
+    this._index = new STRtree();
+    this._idCounter = 0;
+    this._nodedSegStrings = null;
+    this._nOverlaps = 0;
+  }
+  getNodedSubstrings() {
+    return NodedSegmentString.getNodedSubstrings(this._nodedSegStrings);
+  }
+  _add(segStr) {
+    const segChains = MonotoneChainBuilder.getChains(
+      segStr.getCoordinates(),
+      segStr
+    );
+    segChains.forEach((mc) => {
+      mc.setId(this._idCounter++);
+      this._index.insert(mc.getEnvelope(), mc);
+      this._monoChains.push(mc);
+    });
+  }
+  computeNodes(inputSegStrings) {
+    this._nodedSegStrings = inputSegStrings;
+    inputSegStrings.forEach((segStr) => this._add(segStr));
+    this.intersectChains();
+  }
+  intersectChains() {
+    const overlapAction = new SegmentOverlapAction(this._segInt);
+    this._monoChains.forEach((queryChain) => {
+      const overlapChains = this._index.query(queryChain.getEnvelope());
+      overlapChains.forEach((testChain) => {
+        if (testChain.getId() > queryChain.getId()) {
+          queryChain.computeOverlaps(testChain, overlapAction);
+          this._nOverlaps++;
+        }
+      });
+    });
+  }
+  static get SegmentOverlapAction() {
+    return SegmentOverlapAction;
+  }
+}
+
+class SegmentOverlapAction extends MonotoneChainOverlapAction {
+  constructor(si) {
+    super();
+    this._si = si;
+  }
+  overlap() {
+    if (arguments.length === 4) {
+      const mc1 = arguments[0];
+      const start1 = arguments[1];
+      const mc2 = arguments[2];
+      const start2 = arguments[3];
+      const ss1 = mc1.getContext();
+      const ss2 = mc2.getContext();
+      this._si.processIntersections(ss1, start1, ss2, start2);
+    } else
+      return MonotoneChainOverlapAction.prototype.overlap.apply(
+        this,
+        arguments
+      );
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/NodedSegmentString.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/NodedSegmentString.js
@@ -1,0 +1,197 @@
+import { coordinates } from "../../../../utils/coordinates";
+import Octant from "./Octant";
+import SegmentNode from "./SegmentNode";
+import RuntimeException from "../../../../java/lang/RuntimeException";
+import Assert from "../util/Assert";
+import TreeMap from "../../../../java/util/TreeMap";
+
+export default class NodedSegmentString {
+  constructor(pts, data) {
+    this._nodeList = new SegmentNodeList(this);
+    this._pts = pts;
+    this._data = data;
+  }
+  getCoordinates() {
+    return this._pts;
+  }
+  size() {
+    return this._pts.length;
+  }
+  getCoordinate(i) {
+    return this._pts[i];
+  }
+  isClosed() {
+    return coordinates.equals(this._pts[0], this._pts[this._pts.length - 1]);
+  }
+  getSegmentOctant(index) {
+    if (index === this._pts.length - 1) return -1;
+    return this.safeOctant(
+      this.getCoordinate(index),
+      this.getCoordinate(index + 1)
+    );
+  }
+  setData(data) {
+    this._data = data;
+  }
+  safeOctant(p0, p1) {
+    if (coordinates.equals(p0, p1)) return 0;
+    return Octant.octant(p0, p1);
+  }
+  getData() {
+    return this._data;
+  }
+  addIntersection(intPt, segmentIndex) {
+    if (arguments.length === 4) {
+      let li, intIndex;
+      [li, segmentIndex, , intIndex] = arguments;
+      intPt = li.getIntersection(intIndex);
+    }
+    this.addIntersectionNode(intPt, segmentIndex);
+  }
+  getNodeList() {
+    return this._nodeList;
+  }
+  addIntersectionNode(intPt, segmentIndex) {
+    var normalizedSegmentIndex = segmentIndex;
+    var nextSegIndex = normalizedSegmentIndex + 1;
+    if (nextSegIndex < this._pts.length) {
+      var nextPt = this._pts[nextSegIndex];
+      if (coordinates.equals(intPt, nextPt)) {
+        normalizedSegmentIndex = nextSegIndex;
+      }
+    }
+    var ei = this._nodeList.add(intPt, normalizedSegmentIndex);
+    return ei;
+  }
+  addIntersections(li, segmentIndex, geomIndex) {
+    for (var i = 0; i < li.getIntersectionNum(); i++) {
+      this.addIntersection(li, segmentIndex, geomIndex, i);
+    }
+  }
+  static getNodedSubstrings(segStrings) {
+    var resultEdgelist = [];
+    segStrings.forEach((segStr) =>
+      segStr.getNodeList().addSplitEdges(resultEdgelist)
+    );
+    return resultEdgelist;
+  }
+}
+
+class SegmentNodeList {
+  constructor(edge) {
+    this._nodeMap = new TreeMap();
+    this._edge = edge;
+  }
+  addCollapsedNodes() {
+    const collapsedVertexIndexes = [];
+    this.findCollapsesFromInsertedNodes(collapsedVertexIndexes);
+    this.findCollapsesFromExistingVertices(collapsedVertexIndexes);
+    collapsedVertexIndexes.forEach((vertexIndex) => {
+      this.add(this._edge.getCoordinate(vertexIndex), vertexIndex);
+    });
+  }
+  findCollapsesFromExistingVertices(collapsedVertexIndexes) {
+    for (let i = 0; i < this._edge.size() - 2; i++) {
+      const p0 = this._edge.getCoordinate(i);
+      // const p1 = this._edge.getCoordinate(i + 1)
+      const p2 = this._edge.getCoordinate(i + 2);
+      if (coordinates.equals(p0, p2)) {
+        collapsedVertexIndexes.push(i + 1);
+      }
+    }
+  }
+  addSplitEdges(edgeList) {
+    this.addEndpoints();
+    this.addCollapsedNodes();
+    const nodes = this._nodeMap.values();
+    let eiPrev = nodes.shift();
+    while (nodes.length) {
+      const ei = nodes.shift();
+      const newEdge = this.createSplitEdge(eiPrev, ei);
+      edgeList.push(newEdge);
+      eiPrev = ei;
+    }
+  }
+  findCollapseIndex(ei0, ei1, collapsedVertexIndex) {
+    if (!coordinates.equals(ei0.coord, ei1.coord)) return false;
+    let numVerticesBetween = ei1.segmentIndex - ei0.segmentIndex;
+    if (!ei1.isInterior()) {
+      numVerticesBetween--;
+    }
+    if (numVerticesBetween === 1) {
+      collapsedVertexIndex[0] = ei0.segmentIndex + 1;
+      return true;
+    }
+    return false;
+  }
+  findCollapsesFromInsertedNodes(collapsedVertexIndexes) {
+    const collapsedVertexIndex = new Array(1).fill(null);
+    const nodes = this._nodeMap.values();
+    let eiPrev = nodes.shift();
+    while (nodes.length) {
+      const ei = nodes.shift();
+      const isCollapsed = this.findCollapseIndex(
+        eiPrev,
+        ei,
+        collapsedVertexIndex
+      );
+      if (isCollapsed) collapsedVertexIndexes.push(collapsedVertexIndex[0]);
+      eiPrev = ei;
+    }
+  }
+  getEdge() {
+    return this._edge;
+  }
+  addEndpoints() {
+    const maxSegIndex = this._edge.size() - 1;
+    this.add(this._edge.getCoordinate(0), 0);
+    this.add(this._edge.getCoordinate(maxSegIndex), maxSegIndex);
+  }
+  createSplitEdge(ei0, ei1) {
+    let npts = ei1.segmentIndex - ei0.segmentIndex + 2;
+    const lastSegStartPt = this._edge.getCoordinate(ei1.segmentIndex);
+    const useIntPt1 =
+      ei1.isInterior() || !coordinates.equals(ei1.coord, lastSegStartPt);
+    if (!useIntPt1) {
+      npts--;
+    }
+    const pts = new Array(npts).fill(null);
+    let ipt = 0;
+    pts[ipt++] = [...ei0.coord];
+    for (let i = ei0.segmentIndex + 1; i <= ei1.segmentIndex; i++) {
+      pts[ipt++] = this._edge.getCoordinate(i);
+    }
+    if (useIntPt1) pts[ipt] = [...ei1.coord];
+    return new NodedSegmentString(pts, this._edge.getData());
+  }
+  add(intPt, segmentIndex) {
+    const eiNew = new SegmentNode(
+      this._edge,
+      intPt,
+      segmentIndex,
+      this._edge.getSegmentOctant(segmentIndex)
+    );
+    const ei = this._nodeMap.get(eiNew);
+    if (ei !== null) {
+      Assert.isTrue(
+        coordinates.equals(ei.coord, intPt),
+        "Found equal nodes with different coordinates"
+      );
+      return ei;
+    }
+    this._nodeMap.put(eiNew, eiNew);
+    return eiNew;
+  }
+  checkSplitEdgesCorrectness(splitEdges) {
+    const edgePts = this._edge.getCoordinates();
+    const split0 = splitEdges.get(0);
+    const pt0 = split0.getCoordinate(0);
+    if (!coordinates.equals(pt0, edgePts[0]))
+      throw new RuntimeException("bad split edge start point at " + pt0);
+    const splitn = splitEdges.get(splitEdges.size() - 1);
+    const splitnPts = splitn.getCoordinates();
+    const ptn = splitnPts[splitnPts.length - 1];
+    if (!coordinates.equals(ptn, edgePts[edgePts.length - 1]))
+      throw new RuntimeException("bad split edge end point at " + ptn);
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/Octant.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/Octant.js
@@ -1,0 +1,47 @@
+import { coordinates, x, y } from "../../../../utils/coordinates";
+import IllegalArgumentException from "../../../../java/lang/IllegalArgumentException";
+
+export default class Octant {
+  static octant() {
+    if (typeof arguments[0] === "number" && typeof arguments[1] === "number") {
+      const dx = arguments[0];
+      const dy = arguments[1];
+      if (dx === 0.0 && dy === 0.0)
+        throw new IllegalArgumentException(
+          "Cannot compute the octant for point ( " + dx + ", " + dy + " )"
+        );
+      const adx = Math.abs(dx);
+      const ady = Math.abs(dy);
+      if (dx >= 0) {
+        if (dy >= 0) {
+          if (adx >= ady) return 0;
+          else return 1;
+        } else {
+          if (adx >= ady) return 7;
+          else return 6;
+        }
+      } else {
+        if (dy >= 0) {
+          if (adx >= ady) return 3;
+          else return 2;
+        } else {
+          if (adx >= ady) return 4;
+          else return 5;
+        }
+      }
+    } else if (
+      coordinates.isCoordinate(arguments[0]) &&
+      coordinates.isCoordinate(arguments[1])
+    ) {
+      const p0 = arguments[0];
+      const p1 = arguments[1];
+      const dx = x(p1) - x(p0);
+      const dy = y(p1) - y(p0);
+      if (dx === 0.0 && dy === 0.0)
+        throw new IllegalArgumentException(
+          "Cannot compute the octant for two identical points " + p0
+        );
+      return Octant.octant(dx, dy);
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/OrientedCoordinateArray.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/OrientedCoordinateArray.js
@@ -1,0 +1,46 @@
+import { coordinates } from "../../../../utils/coordinates";
+
+export default class OrientedCoordinateArray {
+  constructor(pts) {
+    this._pts = pts;
+    this._orientation = OrientedCoordinateArray.increasingDirection(pts) === 1;
+  }
+  compareTo(o1) {
+    const oca = o1;
+    const comp = OrientedCoordinateArray.compareOriented(
+      this._pts,
+      this._orientation,
+      oca._pts,
+      oca._orientation
+    );
+    return comp;
+  }
+  static compareOriented(pts1, orientation1, pts2, orientation2) {
+    const dir1 = orientation1 ? 1 : -1;
+    const dir2 = orientation2 ? 1 : -1;
+    const limit1 = orientation1 ? pts1.length : -1;
+    const limit2 = orientation2 ? pts2.length : -1;
+    let i1 = orientation1 ? 0 : pts1.length - 1;
+    let i2 = orientation2 ? 0 : pts2.length - 1;
+    // const comp = 0
+    while (true) {
+      const compPt = coordinates.compare(pts1[i1], pts2[i2]);
+      if (compPt !== 0) return compPt;
+      i1 += dir1;
+      i2 += dir2;
+      const done1 = i1 === limit1;
+      const done2 = i2 === limit2;
+      if (done1 && !done2) return -1;
+      if (!done1 && done2) return 1;
+      if (done1 && done2) return 0;
+    }
+  }
+  static increasingDirection(pts) {
+    for (var i = 0; i < Math.trunc(pts.length / 2); i++) {
+      var j = pts.length - 1 - i;
+      var comp = coordinates.compare(pts[i], pts[j]);
+      if (comp !== 0) return comp;
+    }
+    return 1;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/SegmentNode.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/SegmentNode.js
@@ -1,0 +1,35 @@
+import { coordinates } from "../../../../utils/coordinates";
+import SegmentPointComparator from "./SegmentPointComparator";
+
+export default class SegmentNode {
+  constructor(segString, coord, segmentIndex, segmentOctant) {
+    this.segmentIndex = null;
+    this._segmentOctant = null;
+    this._isInterior = null;
+    this._segString = segString;
+    this.coord = [...coord];
+    this.segmentIndex = segmentIndex;
+    this._segmentOctant = segmentOctant;
+    this._isInterior = !coordinates.equals(
+      coord,
+      segString.getCoordinate(segmentIndex)
+    );
+  }
+  getCoordinate() {
+    return this.coord;
+  }
+  compareTo(obj) {
+    const other = obj;
+    if (this.segmentIndex < other.segmentIndex) return -1;
+    if (this.segmentIndex > other.segmentIndex) return 1;
+    if (coordinates.equals(this.coord, other.coord)) return 0;
+    return SegmentPointComparator.compare(
+      this._segmentOctant,
+      this.coord,
+      other.coord
+    );
+  }
+  isInterior() {
+    return this._isInterior;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/noding/SegmentPointComparator.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/noding/SegmentPointComparator.js
@@ -1,0 +1,43 @@
+import Assert from "../util/Assert";
+import { coordinates, x, y } from "../../../../utils/coordinates";
+
+export default class SegmentPointComparator {
+  static relativeSign(x0, x1) {
+    if (x0 < x1) return -1;
+    if (x0 > x1) return 1;
+    return 0;
+  }
+  static compare(octant, p0, p1) {
+    if (coordinates.equals(p0, p1)) return 0;
+    var xSign = SegmentPointComparator.relativeSign(x(p0), x(p1));
+    var ySign = SegmentPointComparator.relativeSign(y(p0), y(p1));
+    switch (octant) {
+      case 0:
+        return SegmentPointComparator.compareValue(xSign, ySign);
+      case 1:
+        return SegmentPointComparator.compareValue(ySign, xSign);
+      case 2:
+        return SegmentPointComparator.compareValue(ySign, -xSign);
+      case 3:
+        return SegmentPointComparator.compareValue(-xSign, ySign);
+      case 4:
+        return SegmentPointComparator.compareValue(-xSign, -ySign);
+      case 5:
+        return SegmentPointComparator.compareValue(-ySign, -xSign);
+      case 6:
+        return SegmentPointComparator.compareValue(-ySign, xSign);
+      case 7:
+        return SegmentPointComparator.compareValue(xSign, -ySign);
+      default:
+    }
+    Assert.shouldNeverReachHere("invalid octant value");
+    return 0;
+  }
+  static compareValue(compareSign0, compareSign1) {
+    if (compareSign0 < 0) return -1;
+    if (compareSign0 > 0) return 1;
+    if (compareSign1 < 0) return -1;
+    if (compareSign1 > 0) return 1;
+    return 0;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer.js
@@ -1,0 +1,2 @@
+// operation.buffer
+export { bufferOp } from "./buffer/BufferOp";

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferBuilder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferBuilder.js
@@ -1,0 +1,120 @@
+import Location from "../../geom/Location";
+import BufferSubgraph from "./BufferSubgraph";
+import PolygonBuilder from "../overlay/PolygonBuilder";
+import Position from "../../geomgraph/Position";
+import MCIndexNoder from "../../noding/MCIndexNoder";
+import SubgraphDepthLocater from "./SubgraphDepthLocater";
+import OffsetCurveSetBuilder from "./OffsetCurveSetBuilder";
+import Label from "../../geomgraph/Label";
+import EdgeList from "../../geomgraph/EdgeList";
+import RobustLineIntersector from "../../algorithm/RobustLineIntersector";
+import IntersectionAdder from "../../noding/IntersectionAdder";
+import Edge from "../../geomgraph/Edge";
+import PlanarGraph from "../../geomgraph/PlanarGraph";
+import { coordinates } from "../../../../../utils/coordinates";
+
+export default class BufferBuilder {
+  constructor(quadrantSegments) {
+    this._workingNoder = null;
+    this._edgeList = new EdgeList();
+    this._quadrantSegments = quadrantSegments || null;
+  }
+  insertUniqueEdge(edge) {
+    const existingEdge = this._edgeList.findEqualEdge(edge);
+    if (existingEdge !== null) {
+      const existingLabel = existingEdge.getLabel();
+      let labelToMerge = edge.getLabel();
+      if (!existingEdge.isPointwiseEqual(edge)) {
+        labelToMerge = new Label(edge.getLabel());
+        labelToMerge.flip();
+      }
+      existingLabel.merge(labelToMerge);
+      const mergeDelta = BufferBuilder.depthDelta(labelToMerge);
+      const existingDelta = existingEdge.getDepthDelta();
+      const newDelta = existingDelta + mergeDelta;
+      existingEdge.setDepthDelta(newDelta);
+    } else {
+      this._edgeList.add(edge);
+      edge.setDepthDelta(BufferBuilder.depthDelta(edge.getLabel()));
+    }
+  }
+  buildSubgraphs(subgraphList, polyBuilder) {
+    const processedGraphs = [];
+    subgraphList.forEach((subgraph) => {
+      const p = subgraph.getRightmostCoordinate();
+      const locater = new SubgraphDepthLocater(processedGraphs);
+      const outsideDepth = locater.getDepth(p);
+      subgraph.computeDepth(outsideDepth);
+      subgraph.findResultEdges();
+      processedGraphs.push(subgraph);
+      polyBuilder.add(subgraph.getDirectedEdges(), subgraph.getNodes());
+    });
+  }
+  createSubgraphs(graph) {
+    const subgraphList = [];
+    graph.getNodes().forEach((node) => {
+      if (!node.isVisited()) {
+        const subgraph = new BufferSubgraph();
+        subgraph.create(node);
+        subgraphList.push(subgraph);
+      }
+    });
+    subgraphList.sort((a, b) => b.compareTo(a));
+    return subgraphList;
+  }
+  createEmptyResultGeometry() {
+    return { type: "Polygon", coordinates: [] };
+  }
+  getNoder() {
+    if (this._workingNoder !== null) return this._workingNoder;
+    const li = new RobustLineIntersector();
+    return new MCIndexNoder(new IntersectionAdder(li));
+  }
+  buffer(g, distance) {
+    const curveSetBuilder = new OffsetCurveSetBuilder(
+      g,
+      distance,
+      this._quadrantSegments
+    );
+    const bufferSegStrList = curveSetBuilder.getCurves();
+    if (bufferSegStrList.length <= 0) {
+      return this.createEmptyResultGeometry();
+    }
+    this.computeNodedEdges(bufferSegStrList);
+    const graph = new PlanarGraph();
+    graph.addEdges(this._edgeList.getEdges());
+    const subgraphList = this.createSubgraphs(graph);
+    const polyBuilder = new PolygonBuilder();
+    this.buildSubgraphs(subgraphList, polyBuilder);
+    const resultPolyList = polyBuilder.getPolygons();
+    if (resultPolyList.length <= 0) {
+      return this.createEmptyResultGeometry();
+    }
+    if (resultPolyList.length === 1) {
+      return resultPolyList[0];
+    }
+    const coordinates = resultPolyList.map((polygon) => polygon.coordinates);
+    const multiPolygon = { type: "MultiPolygon", coordinates };
+    return multiPolygon;
+  }
+  computeNodedEdges(bufferSegStrList) {
+    const noder = this.getNoder();
+    noder.computeNodes(bufferSegStrList);
+    const nodedSegStrings = noder.getNodedSubstrings();
+    nodedSegStrings.forEach((segStr) => {
+      const pts = segStr.getCoordinates();
+      if (pts.length === 2 && coordinates.equals(pts[0], pts[1])) return;
+      const oldLabel = segStr.getData();
+      const edge = new Edge(segStr.getCoordinates(), new Label(oldLabel));
+      this.insertUniqueEdge(edge);
+    });
+  }
+  static depthDelta(label) {
+    const lLoc = label.getLocation(0, Position.LEFT);
+    const rLoc = label.getLocation(0, Position.RIGHT);
+    if (lLoc === Location.INTERIOR && rLoc === Location.EXTERIOR) return 1;
+    else if (lLoc === Location.EXTERIOR && rLoc === Location.INTERIOR)
+      return -1;
+    return 0;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferInputLineSimplifier.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferInputLineSimplifier.js
@@ -1,0 +1,97 @@
+import CGAlgorithms from "../../algorithm/CGAlgorithms";
+
+export default class BufferInputLineSimplifier {
+  constructor(inputLine) {
+    this._distanceTol = null;
+    this._isDeleted = [];
+    this._angleOrientation = CGAlgorithms.COUNTERCLOCKWISE;
+    this._inputLine = inputLine || null;
+  }
+  _isDeletable(i0, i1, i2, distanceTol) {
+    const p0 = this._inputLine[i0];
+    const p1 = this._inputLine[i1];
+    const p2 = this._inputLine[i2];
+    if (!this._isConcave(p0, p1, p2)) return false;
+    if (!this._isShallow(p0, p1, p2, distanceTol)) return false;
+    return this._isShallowSampled(p0, p1, i0, i2, distanceTol);
+  }
+  _deleteShallowConcavities() {
+    let index = 1;
+    // const maxIndex = this._inputLine.length - 1;
+    let midIndex = this._findNextNonDeletedIndex(index);
+    let lastIndex = this._findNextNonDeletedIndex(midIndex);
+    let isChanged = false;
+    while (lastIndex < this._inputLine.length) {
+      let isMiddleVertexDeleted = false;
+      if (this._isDeletable(index, midIndex, lastIndex, this._distanceTol)) {
+        this._isDeleted[midIndex] = BufferInputLineSimplifier.DELETE;
+        isMiddleVertexDeleted = true;
+        isChanged = true;
+      }
+      if (isMiddleVertexDeleted) index = lastIndex;
+      else index = midIndex;
+      midIndex = this._findNextNonDeletedIndex(index);
+      lastIndex = this._findNextNonDeletedIndex(midIndex);
+    }
+    return isChanged;
+  }
+  _isShallowSampled(p0, p2, i0, i2, distanceTol) {
+    let inc = Math.trunc(
+      (i2 - i0) / BufferInputLineSimplifier.NUM_PTS_TO_CHECK
+    );
+    if (inc <= 0) inc = 1;
+    for (let i = i0; i < i2; i += inc) {
+      if (!this._isShallow(p0, p2, this._inputLine[i], distanceTol))
+        return false;
+    }
+    return true;
+  }
+  _isConcave(p0, p1, p2) {
+    const orientation = CGAlgorithms.computeOrientation(p0, p1, p2);
+    const isConcave = orientation === this._angleOrientation;
+    return isConcave;
+  }
+  simplify(distanceTol) {
+    this._distanceTol = Math.abs(distanceTol);
+    if (distanceTol < 0) this._angleOrientation = CGAlgorithms.CLOCKWISE;
+    this._isDeleted = [];
+    let isChanged = false;
+    do {
+      isChanged = this._deleteShallowConcavities();
+    } while (isChanged);
+    return this._collapseLine();
+  }
+  _findNextNonDeletedIndex(index) {
+    let next = index + 1;
+    while (
+      next < this._inputLine.length &&
+      this._isDeleted[next] === BufferInputLineSimplifier.DELETE
+    )
+      next++;
+    return next;
+  }
+  _isShallow(p0, p1, p2, distanceTol) {
+    const dist = CGAlgorithms.distancePointLine(p1, p0, p2);
+    return dist < distanceTol;
+  }
+  _collapseLine() {
+    const coordList = [];
+    for (let i = 0; i < this._inputLine.length; i++) {
+      if (this._isDeleted[i] !== BufferInputLineSimplifier.DELETE)
+        coordList.push(this._inputLine[i]);
+    }
+    return coordList;
+  }
+  static simplify(inputLine, distanceTol) {
+    const simp = new BufferInputLineSimplifier(inputLine);
+    return simp.simplify(distanceTol);
+  }
+
+  static get DELETE() {
+    return 1;
+  }
+
+  static get NUM_PTS_TO_CHECK() {
+    return 10;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferOp.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferOp.js
@@ -1,0 +1,14 @@
+import BufferBuilder from "./BufferBuilder";
+
+/**
+ * Buffer Operation
+ *
+ * @param {Geometry} geom is a Geometry in GeoJSON format
+ * @param {number} distance the buffer distance
+ * @param {number} quadrantSegments the number of segments used to approximate a quarter circle
+ * @returns {Geometry} The buffered geometry
+ */
+export function bufferOp(geom, distance, quadrantSegments) {
+  const bufBuilder = new BufferBuilder(quadrantSegments);
+  return bufBuilder.buffer(geom, distance);
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferSubgraph.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/BufferSubgraph.js
@@ -1,0 +1,144 @@
+import Position from "../../geomgraph/Position";
+import RightmostEdgeFinder from "./RightmostEdgeFinder";
+import TopologyException from "../../geom/TopologyException";
+import Envelope from "../../geom/Envelope";
+import { x } from "../../../../../utils/coordinates";
+
+export default class BufferSubgraph {
+  constructor() {
+    this._dirEdgeList = [];
+    this._nodes = [];
+    this._rightMostCoord = null;
+    this._env = null;
+    this._finder = new RightmostEdgeFinder();
+  }
+  clearVisitedEdges() {
+    this._dirEdgeList.forEach((de) => de.setVisited(false));
+  }
+  getRightmostCoordinate() {
+    return this._rightMostCoord;
+  }
+  computeNodeDepth(node) {
+    const startEdge = node
+      .getEdges()
+      .getEdges()
+      .find((de) => de.isVisited() || de.getSym().isVisited());
+    if (startEdge === undefined)
+      throw new TopologyException(
+        "unable to find edge to compute depths at " + node.getCoordinate()
+      );
+    node.getEdges().computeDepths(startEdge);
+    node
+      .getEdges()
+      .getEdges()
+      .forEach((de) => {
+        de.setVisited(true);
+        this.copySymDepths(de);
+      });
+  }
+  computeDepth(outsideDepth) {
+    this.clearVisitedEdges();
+    const de = this._finder.getEdge();
+    // const n = de.getNode()
+    // const label = de.getLabel()
+    de.setEdgeDepths(Position.RIGHT, outsideDepth);
+    this.copySymDepths(de);
+    this.computeDepths(de);
+  }
+  create(node) {
+    this.addReachable(node);
+    this._finder.findEdge(this._dirEdgeList);
+    this._rightMostCoord = this._finder.getCoordinate();
+  }
+  findResultEdges() {
+    this._dirEdgeList.forEach((de) => {
+      if (
+        de.getDepth(Position.RIGHT) >= 1 &&
+        de.getDepth(Position.LEFT) <= 0 &&
+        !de.isInteriorAreaEdge()
+      ) {
+        de.setInResult(true);
+      }
+    });
+  }
+  computeDepths(startEdge) {
+    const nodesVisited = new Set();
+    const nodeQueue = [];
+    const startNode = startEdge.getNode();
+    nodeQueue.push(startNode);
+    nodesVisited.add(startNode);
+    startEdge.setVisited(true);
+    while (nodeQueue.length) {
+      const node = nodeQueue.shift();
+      nodesVisited.add(node);
+      this.computeNodeDepth(node);
+      node
+        .getEdges()
+        .getEdges()
+        .forEach((de) => {
+          const sym = de.getSym();
+          if (sym.isVisited()) return;
+          const adjNode = sym.getNode();
+          if (!nodesVisited.has(adjNode)) {
+            nodeQueue.push(adjNode);
+            nodesVisited.add(adjNode);
+          }
+        });
+    }
+  }
+  compareTo(o) {
+    const graph = o;
+    if (x(this._rightMostCoord) < x(graph._rightMostCoord)) {
+      return -1;
+    }
+    if (x(this._rightMostCoord) > x(graph._rightMostCoord)) {
+      return 1;
+    }
+    return 0;
+  }
+  getEnvelope() {
+    if (this._env === null) {
+      const edgeEnv = new Envelope();
+      this._dirEdgeList.forEach((dirEdge) => {
+        const pts = dirEdge.getEdge().getCoordinates();
+        for (let i = 0; i < pts.length - 1; i++) {
+          edgeEnv.expandToInclude(pts[i]);
+        }
+      });
+      this._env = edgeEnv;
+    }
+    return this._env;
+  }
+  addReachable(startNode) {
+    const nodeStack = [];
+    nodeStack.push(startNode);
+    while (nodeStack.length) {
+      const node = nodeStack.pop();
+      this.add(node, nodeStack);
+    }
+  }
+  copySymDepths(de) {
+    const sym = de.getSym();
+    sym.setDepth(Position.LEFT, de.getDepth(Position.RIGHT));
+    sym.setDepth(Position.RIGHT, de.getDepth(Position.LEFT));
+  }
+  add(node, nodeStack) {
+    node.setVisited(true);
+    this._nodes.push(node);
+    node
+      .getEdges()
+      .getEdges()
+      .forEach((de) => {
+        this._dirEdgeList.push(de);
+        const sym = de.getSym();
+        const symNode = sym.getNode();
+        if (!symNode.isVisited()) nodeStack.push(symNode);
+      });
+  }
+  getNodes() {
+    return this._nodes;
+  }
+  getDirectedEdges() {
+    return this._dirEdgeList;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetCurveBuilder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetCurveBuilder.js
@@ -1,0 +1,78 @@
+import Position from "../../geomgraph/Position";
+import BufferInputLineSimplifier from "./BufferInputLineSimplifier";
+import OffsetSegmentGenerator from "./OffsetSegmentGenerator";
+
+export default class OffsetCurveBuilder {
+  constructor(quadrantSegments) {
+    this._distance = 0.0;
+    this._quadrantSegments = quadrantSegments;
+  }
+  _computeRingBufferCurve(inputPts, side, segGen) {
+    let distTol = this._simplifyTolerance(this._distance);
+    if (side === Position.RIGHT) distTol = -distTol;
+    const simp = BufferInputLineSimplifier.simplify(inputPts, distTol);
+    const n = simp.length - 1;
+    segGen.initSideSegments(simp[n - 1], simp[0], side);
+    for (let i = 1; i <= n; i++) {
+      const addStartPoint = i !== 1;
+      segGen.addNextSegment(simp[i], addStartPoint);
+    }
+    segGen.closeRing();
+  }
+  _computeLineBufferCurve(inputPts, segGen) {
+    const distTol = this._simplifyTolerance(this._distance);
+    const simp1 = BufferInputLineSimplifier.simplify(inputPts, distTol);
+    const n1 = simp1.length - 1;
+    segGen.initSideSegments(simp1[0], simp1[1], Position.LEFT);
+    for (let i = 2; i <= n1; i++) {
+      segGen.addNextSegment(simp1[i], true);
+    }
+    segGen.addLastSegment();
+    segGen.addLineEndCap(simp1[n1 - 1], simp1[n1]);
+    const simp2 = BufferInputLineSimplifier.simplify(inputPts, -distTol);
+    const n2 = simp2.length - 1;
+    segGen.initSideSegments(simp2[n2], simp2[n2 - 1], Position.LEFT);
+    for (let i = n2 - 2; i >= 0; i--) {
+      segGen.addNextSegment(simp2[i], true);
+    }
+    segGen.addLastSegment();
+    segGen.addLineEndCap(simp2[1], simp2[0]);
+    segGen.closeRing();
+  }
+  _computePointCurve(pt, segGen) {
+    segGen.createCircle(pt);
+  }
+  getLineCurve(inputPts, distance) {
+    this._distance = distance;
+    if (distance < 0.0) return null;
+    if (distance === 0.0) return null;
+    const posDistance = Math.abs(distance);
+    const segGen = this._getSegGen(posDistance);
+    if (inputPts.length <= 1) {
+      this._computePointCurve(inputPts[0], segGen);
+      return segGen.getCoordinates();
+    } else {
+      this._computeLineBufferCurve(inputPts, segGen);
+      return segGen.getCoordinates();
+    }
+  }
+  _simplifyTolerance(bufDistance) {
+    return bufDistance * OffsetCurveBuilder.DEFAULT_SIMPLIFY_FACTOR;
+  }
+  getRingCurve(inputPts, side, distance) {
+    this._distance = distance;
+    if (inputPts.length <= 2) return this.getLineCurve(inputPts, distance);
+    if (distance === 0.0) {
+      return inputPts.map((p) => [...p]); // copy points
+    }
+    const segGen = this._getSegGen(distance);
+    this._computeRingBufferCurve(inputPts, side, segGen);
+    return segGen.getCoordinates();
+  }
+  _getSegGen(distance) {
+    return new OffsetSegmentGenerator(this._quadrantSegments, distance);
+  }
+  static get DEFAULT_SIMPLIFY_FACTOR() {
+    return 0.01;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetCurveSetBuilder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetCurveSetBuilder.js
@@ -1,0 +1,194 @@
+import Location from "../../geom/Location";
+import CGAlgorithms from "../../algorithm/CGAlgorithms";
+import Position from "../../geomgraph/Position";
+import NodedSegmentString from "../../noding/NodedSegmentString";
+import LinearRing from "../../geom/LinearRing";
+import Label from "../../geomgraph/Label";
+import OffsetCurveBuilder from "./OffsetCurveBuilder";
+import { coordinates } from "../../../../../utils/coordinates";
+import Envelope from "../../geom/Envelope";
+
+export default class OffsetCurveSetBuilder {
+  constructor(geometry, distance, quadrantSegments) {
+    this._curveList = [];
+    this._geometry = geometry;
+    this._distance = distance;
+    this._curveBuilder = new OffsetCurveBuilder(quadrantSegments);
+  }
+  _addPoint(p) {
+    if (this._distance <= 0.0) return null;
+    const curve = this._curveBuilder.getLineCurve(
+      [p.coordinates],
+      this._distance
+    );
+    this._addCurve(curve, Location.EXTERIOR, Location.INTERIOR);
+  }
+  _addPolygon(p) {
+    let offsetDistance = this._distance;
+    let offsetSide = Position.LEFT;
+    if (this._distance < 0.0) {
+      offsetDistance = -this._distance;
+      offsetSide = Position.RIGHT;
+    }
+    const shell = p.coordinates.shift();
+    const shellCoord = coordinates.removeRepeatedPoints(shell);
+    if (this._distance < 0.0 && this._isErodedCompletely(shell, this._distance))
+      return null;
+    if (this._distance <= 0.0 && shellCoord.length < 3) return null;
+    this._addPolygonRing(
+      shellCoord,
+      offsetDistance,
+      offsetSide,
+      Location.EXTERIOR,
+      Location.INTERIOR
+    );
+    p.coordinates.forEach((hole) => {
+      const holeCoord = coordinates.removeRepeatedPoints(hole);
+      if (
+        this._distance > 0.0 &&
+        this._isErodedCompletely(hole, -this._distance)
+      )
+        return;
+      this._addPolygonRing(
+        holeCoord,
+        offsetDistance,
+        Position.opposite(offsetSide),
+        Location.INTERIOR,
+        Location.EXTERIOR
+      );
+    });
+  }
+  _isTriangleErodedCompletely(triangleCoord, bufferDistance) {
+    const inCentre = triangleInCenter(
+      triangleCoord[0],
+      triangleCoord[1],
+      triangleCoord[2]
+    );
+    const distToCentre = CGAlgorithms.distancePointLine(
+      inCentre,
+      triangleCoord[0],
+      triangleCoord[1]
+    );
+    return distToCentre < Math.abs(bufferDistance);
+  }
+  _addLineString(line) {
+    if (this._distance <= 0.0) return null;
+    const coord = coordinates.removeRepeatedPoints(line.coordinates);
+    const curve = this._curveBuilder.getLineCurve(coord, this._distance);
+    this._addCurve(curve, Location.EXTERIOR, Location.INTERIOR);
+  }
+  _addCurve(coord, leftLoc, rightLoc) {
+    if (coord === null || coord.length < 2) return null;
+    const e = new NodedSegmentString(
+      coord,
+      new Label(0, Location.BOUNDARY, leftLoc, rightLoc)
+    );
+    this._curveList.push(e);
+  }
+  getCurves() {
+    this._add(this._geometry);
+    return this._curveList;
+  }
+  _addPolygonRing(coord, offsetDistance, side, cwLeftLoc, cwRightLoc) {
+    if (offsetDistance === 0.0 && coord.length < LinearRing.MINIMUM_VALID_SIZE)
+      return null;
+    let leftLoc = cwLeftLoc;
+    let rightLoc = cwRightLoc;
+    if (
+      coord.length >= LinearRing.MINIMUM_VALID_SIZE &&
+      CGAlgorithms.isCCW(coord)
+    ) {
+      leftLoc = cwRightLoc;
+      rightLoc = cwLeftLoc;
+      side = Position.opposite(side);
+    }
+    const curve = this._curveBuilder.getRingCurve(coord, side, offsetDistance);
+    this._addCurve(curve, leftLoc, rightLoc);
+  }
+  _add(geometry) {
+    if (isEmptyGeoJSON(geometry)) return null;
+    switch (geometry.type) {
+      case "Point":
+        this._addPoint(geometry);
+        return;
+      case "LineString":
+        this._addLineString(geometry);
+        return;
+      case "Polygon":
+        this._addPolygon(geometry);
+        return;
+      case "MultiPoint":
+        this._addMultiPoint(geometry);
+        return;
+      case "MultiLineString":
+        this._addMultiLineString(geometry);
+        return;
+      case "MultiPolygon":
+        this._addMultiPolygon(geometry);
+        return;
+    }
+  }
+
+  _addMultiPoint(geometry) {
+    geometry.coordinates.forEach((point) =>
+      this._addPoint({
+        type: "Point",
+        coordinates: point,
+      })
+    );
+  }
+
+  _addMultiLineString(geometry) {
+    geometry.coordinates.forEach((lineString) =>
+      this._addLineString({
+        type: "LineString",
+        coordinates: lineString,
+      })
+    );
+  }
+
+  _addMultiPolygon(geometry) {
+    geometry.coordinates.forEach((polygon) =>
+      this._addPolygon({
+        type: "Polygon",
+        coordinates: polygon,
+      })
+    );
+  }
+
+  _isErodedCompletely(ring, bufferDistance) {
+    const ringCoord = ring.map((p) => [...p]);
+    // const minDiam = 0.0
+    if (ringCoord.length < 4) return bufferDistance < 0;
+    if (ringCoord.length === 4)
+      return this._isTriangleErodedCompletely(ringCoord, bufferDistance);
+    const env = new Envelope();
+    ring.forEach((p) => {
+      env.expandToInclude(p);
+    });
+    const envMinDimension = Math.min(env.getHeight(), env.getWidth());
+    if (bufferDistance < 0.0 && 2 * Math.abs(bufferDistance) > envMinDimension)
+      return true;
+    return false;
+  }
+}
+
+function isEmptyGeoJSON(geojson) {
+  return Boolean(geojson.coordinates && !geojson.coordinates.length);
+}
+
+/**
+ *
+ * @param {GeoJSONCoordinate} a
+ * @param {GeoJSONCoordinate} b
+ * @param {GeoJSONCoordinate} c
+ */
+function triangleInCenter(a, b, c) {
+  const len0 = coordinates.distance(b, c);
+  const len1 = coordinates.distance(a, c);
+  const len2 = coordinates.distance(a, b);
+  const circum = len0 + len1 + len2;
+  const inCentreX = (len0 * a[0] + len1 * b[0] + len2 * c[0]) / circum;
+  const inCentreY = (len0 * a[1] + len1 * b[1] + len2 * c[1]) / circum;
+  return [inCentreX, inCentreY];
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetSegmentGenerator.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetSegmentGenerator.js
@@ -1,0 +1,275 @@
+import CGAlgorithms from "../../algorithm/CGAlgorithms";
+import Position from "../../geomgraph/Position";
+import OffsetSegmentString from "./OffsetSegmentString";
+import LineSegment from "../../geom/LineSegment";
+import RobustLineIntersector from "../../algorithm/RobustLineIntersector";
+import { coordinates } from "../../../../../utils/coordinates";
+
+export default class OffsetSegmentGenerator {
+  constructor(quadrantSegments, distance) {
+    this._maxCurveSegmentError = 0.0;
+    this._filletAngleQuantum = null;
+    this._closingSegLengthFactor = 1;
+    this._segList = null;
+    this._distance = 0.0;
+    this._li = new RobustLineIntersector();
+    this._s0 = null;
+    this._s1 = null;
+    this._s2 = null;
+    this._seg0 = new LineSegment();
+    this._seg1 = new LineSegment();
+    this._offset0 = new LineSegment();
+    this._offset1 = new LineSegment();
+    this._side = 0;
+    this._hasNarrowConcaveAngle = false;
+    this._filletAngleQuantum = Math.PI / 2.0 / quadrantSegments;
+    if (quadrantSegments >= 8)
+      this._closingSegLengthFactor =
+        OffsetSegmentGenerator.MAX_CLOSING_SEG_LEN_FACTOR;
+    this.init(distance);
+  }
+  addNextSegment(p, addStartPoint) {
+    this._s0 = [...this._s1];
+    this._s1 = [...this._s2];
+    this._s2 = [...p];
+    this._seg0.setCoordinates(this._s0, this._s1);
+    this.computeOffsetSegment(
+      this._seg0,
+      this._side,
+      this._distance,
+      this._offset0
+    );
+    this._seg1.setCoordinates(this._s1, this._s2);
+    this.computeOffsetSegment(
+      this._seg1,
+      this._side,
+      this._distance,
+      this._offset1
+    );
+    if (coordinates.equals(this._s1, this._s2)) return null;
+    const orientation = CGAlgorithms.computeOrientation(
+      this._s0,
+      this._s1,
+      this._s2
+    );
+    const outsideTurn =
+      (orientation === CGAlgorithms.CLOCKWISE &&
+        this._side === Position.LEFT) ||
+      (orientation === CGAlgorithms.COUNTERCLOCKWISE &&
+        this._side === Position.RIGHT);
+    if (orientation === 0) {
+      this.addCollinear();
+    } else if (outsideTurn) {
+      this.addOutsideTurn(orientation, addStartPoint);
+    } else {
+      this.addInsideTurn();
+    }
+  }
+  addLineEndCap(p0, p1) {
+    const seg = new LineSegment(p0, p1);
+    const offsetL = new LineSegment();
+    this.computeOffsetSegment(seg, Position.LEFT, this._distance, offsetL);
+    const offsetR = new LineSegment();
+    this.computeOffsetSegment(seg, Position.RIGHT, this._distance, offsetR);
+    const dx = p1[0] - p0[0];
+    const dy = p1[1] - p0[1];
+    const angle = Math.atan2(dy, dx);
+    this._segList.addPt(offsetL.p1);
+    this.addFilletArc(
+      p1,
+      angle + Math.PI / 2,
+      angle - Math.PI / 2,
+      CGAlgorithms.CLOCKWISE,
+      this._distance
+    );
+    this._segList.addPt(offsetR.p1);
+  }
+  getCoordinates() {
+    return this._segList.getCoordinates();
+  }
+
+  /**
+   *
+   * @param {GeoJSONCoordinate} p
+   * @param {GeoJSONCoordinate} p0
+   * @param {GeoJSONCoordinate} p1
+   * @param {*} direction
+   * @param {*} radius
+   */
+  _addFilletCorner(p, p0, p1, direction, radius) {
+    const dx0 = p0[0] - p[0];
+    const dy0 = p0[1] - p[1];
+    let startAngle = Math.atan2(dy0, dx0);
+    const dx1 = p1[0] - p[0];
+    const dy1 = p1[1] - p[1];
+    const endAngle = Math.atan2(dy1, dx1);
+    if (direction === CGAlgorithms.CLOCKWISE) {
+      if (startAngle <= endAngle) startAngle += 2.0 * Math.PI;
+    } else {
+      if (startAngle >= endAngle) startAngle -= 2.0 * Math.PI;
+    }
+    this._segList.addPt(p0);
+    this.addFilletArc(p, startAngle, endAngle, direction, radius);
+    this._segList.addPt(p1);
+  }
+  addOutsideTurn(orientation, addStartPoint) {
+    if (
+      coordinates.distance(this._offset0.p1, this._offset1.p0) <
+      this._distance * OffsetSegmentGenerator.OFFSET_SEGMENT_SEPARATION_FACTOR
+    ) {
+      this._segList.addPt(this._offset0.p1);
+      return null;
+    }
+    if (addStartPoint) this._segList.addPt(this._offset0.p1);
+    this._addFilletCorner(
+      this._s1,
+      this._offset0.p1,
+      this._offset1.p0,
+      orientation,
+      this._distance
+    );
+    this._segList.addPt(this._offset1.p0);
+  }
+  addLastSegment() {
+    this._segList.addPt(this._offset1.p1);
+  }
+  initSideSegments(s1, s2, side) {
+    this._s1 = [...s1];
+    this._s2 = [...s2];
+    this._side = side;
+    this._seg1.setCoordinates(s1, s2);
+    this.computeOffsetSegment(this._seg1, side, this._distance, this._offset1);
+  }
+  computeOffsetSegment(seg, side, distance, offset) {
+    const sideSign = side === Position.LEFT ? 1 : -1;
+    const dx = seg.p1[0] - seg.p0[0];
+    const dy = seg.p1[1] - seg.p0[1];
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = (sideSign * distance * dx) / len;
+    const uy = (sideSign * distance * dy) / len;
+    offset.p0 = [seg.p0[0] - uy, seg.p0[1] + ux];
+    offset.p1 = [seg.p1[0] - uy, seg.p1[1] + ux];
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p
+   * @param {*} startAngle
+   * @param {*} endAngle
+   * @param {*} direction
+   * @param {*} radius
+   */
+  addFilletArc(p, startAngle, endAngle, direction, radius) {
+    const directionFactor = direction === CGAlgorithms.CLOCKWISE ? -1 : 1;
+    const totalAngle = Math.abs(startAngle - endAngle);
+    const nSegs = Math.trunc(totalAngle / this._filletAngleQuantum + 0.5);
+    if (nSegs < 1) return null;
+    const initAngle = 0.0;
+    const currAngleInc = totalAngle / nSegs;
+    let currAngle = initAngle;
+
+    while (currAngle < totalAngle) {
+      const angle = startAngle + directionFactor * currAngle;
+      const pt = [
+        p[0] + radius * Math.cos(angle),
+        p[1] + radius * Math.sin(angle),
+      ];
+      this._segList.addPt(pt);
+      currAngle += currAngleInc;
+    }
+  }
+  addInsideTurn() {
+    this._li.computeIntersection(
+      [...this._offset0.p0],
+      [...this._offset0.p1],
+      [...this._offset1.p0],
+      [...this._offset1.p1]
+    );
+    if (this._li.hasIntersection()) {
+      this._segList.addPt(this._li.getIntersection(0));
+    } else {
+      this._hasNarrowConcaveAngle = true;
+      if (
+        coordinates.distance(this._offset0.p1, this._offset1.p0) <
+        this._distance *
+          OffsetSegmentGenerator.INSIDE_TURN_VERTEX_SNAP_DISTANCE_FACTOR
+      ) {
+        this._segList.addPt(this._offset0.p1);
+      } else {
+        this._segList.addPt(this._offset0.p1);
+        if (this._closingSegLengthFactor > 0) {
+          const mid0 = [
+            (this._closingSegLengthFactor * this._offset0.p1[0] + this._s1[0]) /
+              (this._closingSegLengthFactor + 1),
+            (this._closingSegLengthFactor * this._offset0.p1[1] + this._s1[1]) /
+              (this._closingSegLengthFactor + 1),
+          ];
+          this._segList.addPt(mid0);
+          const mid1 = [
+            (this._closingSegLengthFactor * this._offset1.p0[0] + this._s1[0]) /
+              (this._closingSegLengthFactor + 1),
+            (this._closingSegLengthFactor * this._offset1.p0[1] + this._s1[1]) /
+              (this._closingSegLengthFactor + 1),
+          ];
+          this._segList.addPt(mid1);
+        } else {
+          this._segList.addPt(this._s1);
+        }
+        this._segList.addPt(this._offset1.p0);
+      }
+    }
+  }
+  /**
+   *
+   * @param {GeoJSONCoordinate} p
+   */
+  createCircle(p) {
+    const pt = [p[0] + this._distance, p[1]];
+    this._segList.addPt(pt);
+    this.addFilletArc(p, 0.0, 2.0 * Math.PI, -1, this._distance);
+    this._segList.closeRing();
+  }
+  init(distance) {
+    this._distance = distance;
+    this._maxCurveSegmentError =
+      distance * (1 - Math.cos(this._filletAngleQuantum / 2.0));
+    this._segList = new OffsetSegmentString(
+      distance * OffsetSegmentGenerator.CURVE_VERTEX_SNAP_DISTANCE_FACTOR
+    );
+  }
+  addCollinear() {
+    this._li.computeIntersection(
+      [...this._s0],
+      [...this._s1],
+      [...this._s1],
+      [...this._s2]
+    );
+    const numInt = this._li.getIntersectionNum();
+    if (numInt >= 2) {
+      this._addFilletCorner(
+        this._s1,
+        this._offset0.p1,
+        this._offset1.p0,
+        CGAlgorithms.CLOCKWISE,
+        this._distance
+      );
+    }
+  }
+  closeRing() {
+    this._segList.closeRing();
+  }
+  hasNarrowConcaveAngle() {
+    return this._hasNarrowConcaveAngle;
+  }
+  static get OFFSET_SEGMENT_SEPARATION_FACTOR() {
+    return 1.0e-3;
+  }
+  static get INSIDE_TURN_VERTEX_SNAP_DISTANCE_FACTOR() {
+    return 1.0e-3;
+  }
+  static get CURVE_VERTEX_SNAP_DISTANCE_FACTOR() {
+    return 1.0e-6;
+  }
+  static get MAX_CLOSING_SEG_LEN_FACTOR() {
+    return 80;
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetSegmentString.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/OffsetSegmentString.js
@@ -1,0 +1,35 @@
+import { coordinates } from "../../../../../utils/coordinates";
+
+export default class OffsetSegmentString {
+  constructor(minimimVertexDistance = 0.0) {
+    this._minimimVertexDistance = minimimVertexDistance;
+    this._ptList = [];
+  }
+  getCoordinates() {
+    return this._ptList;
+  }
+
+  /**
+   *
+   * @param {GeoJSONCoordinate} pt
+   */
+  addPt(pt) {
+    const bufPt = [...pt]; // copy point
+    if (this._isRedundant(bufPt)) return null;
+    this._ptList.push(bufPt);
+  }
+  _isRedundant(pt) {
+    if (this._ptList.length < 1) return false;
+    const lastPt = this._ptList[this._ptList.length - 1];
+    const ptDist = coordinates.distance(pt, lastPt);
+    if (ptDist < this._minimimVertexDistance) return true;
+    return false;
+  }
+  closeRing() {
+    if (this._ptList.length < 1) return null;
+    const startPt = this._ptList[0];
+    const lastPt = this._ptList[this._ptList.length - 1];
+    if (coordinates.equals(startPt, lastPt)) return null;
+    this._ptList.push([...startPt]); // push a copy
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/RightmostEdgeFinder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/RightmostEdgeFinder.js
@@ -1,0 +1,108 @@
+import CGAlgorithms from "../../algorithm/CGAlgorithms";
+import Position from "../../geomgraph/Position";
+import Assert from "../../util/Assert";
+import { coordinates, x, y } from "../../../../../utils/coordinates";
+
+export default class RightmostEdgeFinder {
+  constructor() {
+    this._minIndex = -1;
+    this._minCoord = null;
+    this._minDe = null;
+    this._orientedDe = null;
+  }
+  getCoordinate() {
+    return this._minCoord;
+  }
+  getRightmostSide(de, index) {
+    var side = this.getRightmostSideOfSegment(de, index);
+    if (side < 0) side = this.getRightmostSideOfSegment(de, index - 1);
+    if (side < 0) {
+      this._minCoord = null;
+      this.checkForRightmostCoordinate(de);
+    }
+    return side;
+  }
+  findRightmostEdgeAtVertex() {
+    var pts = this._minDe.getEdge().getCoordinates();
+    Assert.isTrue(
+      this._minIndex > 0 && this._minIndex < pts.length,
+      "rightmost point expected to be interior vertex of edge"
+    );
+    var pPrev = pts[this._minIndex - 1];
+    var pNext = pts[this._minIndex + 1];
+    var orientation = CGAlgorithms.computeOrientation(
+      this._minCoord,
+      pNext,
+      pPrev
+    );
+    var usePrev = false;
+    if (
+      y(pPrev) < y(this._minCoord) &&
+      y(pNext) < y(this._minCoord) &&
+      orientation === CGAlgorithms.COUNTERCLOCKWISE
+    ) {
+      usePrev = true;
+    } else if (
+      y(pPrev) > y(this._minCoord) &&
+      y(pNext) > y(this._minCoord) &&
+      orientation === CGAlgorithms.CLOCKWISE
+    ) {
+      usePrev = true;
+    }
+    if (usePrev) {
+      this._minIndex = this._minIndex - 1;
+    }
+  }
+  getRightmostSideOfSegment(de, i) {
+    var e = de.getEdge();
+    var coord = e.getCoordinates();
+    if (i < 0 || i + 1 >= coord.length) return -1;
+    if (y(coord[i]) === y(coord[i + 1])) return -1;
+    var pos = Position.LEFT;
+    if (y(coord[i]) < y(coord[i + 1])) pos = Position.RIGHT;
+    return pos;
+  }
+  getEdge() {
+    return this._orientedDe;
+  }
+  checkForRightmostCoordinate(de) {
+    var coord = de.getEdge().getCoordinates();
+    for (var i = 0; i < coord.length - 1; i++) {
+      if (this._minCoord === null || x(coord[i]) > x(this._minCoord)) {
+        this._minDe = de;
+        this._minIndex = i;
+        this._minCoord = coord[i];
+      }
+    }
+  }
+  findRightmostEdgeAtNode() {
+    var node = this._minDe.getNode();
+    var star = node.getEdges();
+    this._minDe = star.getRightmostEdge();
+    if (!this._minDe.isForward()) {
+      this._minDe = this._minDe.getSym();
+      this._minIndex = this._minDe.getEdge().getCoordinates().length - 1;
+    }
+  }
+  findEdge(dirEdgeList) {
+    dirEdgeList.forEach((de) => {
+      if (!de.isForward()) return;
+      this.checkForRightmostCoordinate(de);
+    });
+    Assert.isTrue(
+      this._minIndex !== 0 ||
+        coordinates.equals(this._minCoord, this._minDe.getCoordinate()),
+      "inconsistency in rightmost processing"
+    );
+    if (this._minIndex === 0) {
+      this.findRightmostEdgeAtNode();
+    } else {
+      this.findRightmostEdgeAtVertex();
+    }
+    this._orientedDe = this._minDe;
+    var rightmostSide = this.getRightmostSide(this._minDe, this._minIndex);
+    if (rightmostSide === Position.LEFT) {
+      this._orientedDe = this._minDe.getSym();
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/SubgraphDepthLocater.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/buffer/SubgraphDepthLocater.js
@@ -1,0 +1,79 @@
+import CGAlgorithms from "../../algorithm/CGAlgorithms";
+import Position from "../../geomgraph/Position";
+import LineSegment from "../../geom/LineSegment";
+import { coordinates, x, y } from "../../../../../utils/coordinates";
+
+export default class SubgraphDepthLocater {
+  constructor(subgraphs) {
+    this._seg = new LineSegment();
+    this._subgraphs = subgraphs;
+  }
+  _findStabbedSegments(point) {
+    const stabbingRayLeftPt = point;
+    const stabbedSegments = [];
+    // bsg is BufferSubgraph
+    this._subgraphs.forEach((bsg) => {
+      const env = bsg.getEnvelope();
+      if (
+        y(stabbingRayLeftPt) < env.getMinY() ||
+        y(stabbingRayLeftPt) > env.getMaxY()
+      )
+        return;
+      const dirEdges = bsg.getDirectedEdges();
+      dirEdges.forEach((dirEdge) => {
+        if (!dirEdge.isForward()) return;
+        const pts = dirEdge.getEdge().getCoordinates();
+        for (let i = 0; i < pts.length - 1; i++) {
+          this._seg.p0 = pts[i];
+          this._seg.p1 = pts[i + 1];
+          if (y(this._seg.p0) > y(this._seg.p1)) this._seg.reverse();
+          const maxx = Math.max(x(this._seg.p0), x(this._seg.p1));
+          if (maxx < x(stabbingRayLeftPt)) continue;
+          if (this._seg.isHorizontal()) continue;
+          if (
+            y(stabbingRayLeftPt) < y(this._seg.p0) ||
+            y(stabbingRayLeftPt) > y(this._seg.p1)
+          )
+            continue;
+          if (
+            CGAlgorithms.computeOrientation(
+              [x(this._seg.p0), y(this._seg.p0)],
+              [x(this._seg.p1), y(this._seg.p1)],
+              [x(stabbingRayLeftPt), y(stabbingRayLeftPt)]
+            ) === CGAlgorithms.CLOCKWISE
+          )
+            continue;
+          let depth = dirEdge.getDepth(Position.LEFT);
+          if (!coordinates.equals(this._seg.p0, pts[i]))
+            depth = dirEdge.getDepth(Position.RIGHT);
+          const ds = new DepthSegment(this._seg.p0, this._seg.p1, depth);
+          stabbedSegments.push(ds);
+        }
+      });
+    });
+    return stabbedSegments;
+  }
+  getDepth(point) {
+    const stabbedSegments = this._findStabbedSegments(point);
+    if (stabbedSegments.length === 0) return 0;
+    const ds = stabbedSegments.sort((a, b) => a.compareTo(b)).shift();
+    return ds._leftDepth;
+  }
+}
+
+class DepthSegment {
+  constructor(p0, p1, depth) {
+    this._upwardSeg = new LineSegment(p0, p1);
+    this._leftDepth = depth;
+  }
+  compareTo(obj) {
+    const other = obj;
+    if (this._upwardSeg.minX() >= other._upwardSeg.maxX()) return 1;
+    if (this._upwardSeg.maxX() <= other._upwardSeg.minX()) return -1;
+    let orientIndex = this._upwardSeg.orientationIndex(other._upwardSeg);
+    if (orientIndex !== 0) return orientIndex;
+    orientIndex = -1 * other._upwardSeg.orientationIndex(this._upwardSeg);
+    if (orientIndex !== 0) return orientIndex;
+    return this._upwardSeg.compareTo(other._upwardSeg);
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/overlay/MaximalEdgeRing.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/overlay/MaximalEdgeRing.js
@@ -1,0 +1,34 @@
+import MinimalEdgeRing from "./MinimalEdgeRing";
+import EdgeRing from "../../geomgraph/EdgeRing";
+
+export default class MaximalEdgeRing extends EdgeRing {
+  constructor(start) {
+    super(start);
+  }
+  buildMinimalRings() {
+    const minEdgeRings = [];
+    let de = this._startDe;
+    do {
+      if (de.getMinEdgeRing() === null) {
+        const minEr = new MinimalEdgeRing(de);
+        minEdgeRings.push(minEr);
+      }
+      de = de.getNext();
+    } while (de !== this._startDe);
+    return minEdgeRings;
+  }
+  setEdgeRing(de, er) {
+    de.setEdgeRing(er);
+  }
+  linkDirectedEdgesForMinimalEdgeRings() {
+    let de = this._startDe;
+    do {
+      const node = de.getNode();
+      node.getEdges().linkMinimalDirectedEdges(this);
+      de = de.getNext();
+    } while (de !== this._startDe);
+  }
+  getNext(de) {
+    return de.getNext();
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/overlay/MinimalEdgeRing.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/overlay/MinimalEdgeRing.js
@@ -1,0 +1,13 @@
+import EdgeRing from "../../geomgraph/EdgeRing";
+
+export default class MinimalEdgeRing extends EdgeRing {
+  constructor(start) {
+    super(start);
+  }
+  setEdgeRing(de, er) {
+    de.setMinEdgeRing(er);
+  }
+  getNext(de) {
+    return de.getNextMin();
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/operation/overlay/PolygonBuilder.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/operation/overlay/PolygonBuilder.js
@@ -1,0 +1,128 @@
+import CGAlgorithms from "../../algorithm/CGAlgorithms";
+import TopologyException from "../../geom/TopologyException";
+import MaximalEdgeRing from "./MaximalEdgeRing";
+import Assert from "../../util/Assert";
+import PlanarGraph from "../../geomgraph/PlanarGraph";
+
+export default class PolygonBuilder {
+  constructor() {
+    this._shellList = [];
+  }
+  _sortShellsAndHoles(edgeRings, shellList, freeHoleList) {
+    edgeRings.forEach((er) =>
+      er.isHole() ? freeHoleList.push(er) : shellList.push(er)
+    );
+  }
+  _computePolygons() {
+    const resultPolyList = [];
+    this._shellList.forEach((er) => {
+      const poly = er.toPolygon();
+      resultPolyList.push(poly);
+    });
+    return resultPolyList;
+  }
+  _placeFreeHoles(shellList, freeHoleList) {
+    freeHoleList.forEach((hole) => {
+      if (hole.getShell() === null) {
+        const shell = this._findEdgeRingContaining(hole, shellList);
+        if (shell === null)
+          throw new TopologyException(
+            "unable to assign hole to a shell",
+            hole.getCoordinate(0)
+          );
+        hole.setShell(shell);
+      }
+    });
+  }
+  _buildMinimalEdgeRings(maxEdgeRings, shellList, freeHoleList) {
+    const edgeRings = [];
+    maxEdgeRings.forEach((er) => {
+      if (er.getMaxNodeDegree() > 2) {
+        er.linkDirectedEdgesForMinimalEdgeRings();
+        const minEdgeRings = er.buildMinimalRings();
+        const shell = this._findShell(minEdgeRings);
+        if (shell !== null) {
+          this._placePolygonHoles(shell, minEdgeRings);
+          shellList.push(shell);
+        } else {
+          freeHoleList.push(...minEdgeRings);
+        }
+      } else {
+        edgeRings.push(er);
+      }
+    });
+    return edgeRings;
+  }
+  _buildMaximalEdgeRings(dirEdges) {
+    const maxEdgeRings = [];
+    dirEdges.forEach((de) => {
+      if (de.isInResult() && de.getLabel().isArea()) {
+        if (de.getEdgeRing() === null) {
+          const er = new MaximalEdgeRing(de);
+          maxEdgeRings.push(er);
+          er.setInResult();
+        }
+      }
+    });
+    return maxEdgeRings;
+  }
+  _placePolygonHoles(shell, minEdgeRings) {
+    minEdgeRings.forEach((er) => {
+      if (er.isHole()) {
+        er.setShell(shell);
+      }
+    });
+  }
+  getPolygons() {
+    return this._computePolygons();
+  }
+  _findEdgeRingContaining(testEr, shellList) {
+    const testRing = testEr.getLinearRing();
+    const testEnv = testRing.getEnvelopeInternal();
+    const testPt = testRing.getCoordinateN(0);
+    let minShell = null;
+    let minEnv = null;
+    shellList.forEach((tryShell) => {
+      const tryRing = tryShell.getLinearRing();
+      const tryEnv = tryRing.getEnvelopeInternal();
+      if (minShell !== null)
+        minEnv = minShell.getLinearRing().getEnvelopeInternal();
+      let isContained = false;
+      if (
+        tryEnv.contains(testEnv) &&
+        CGAlgorithms.isPointInRing(testPt, tryRing.getCoordinates())
+      )
+        isContained = true;
+      if (isContained) {
+        if (minShell === null || minEnv.contains(tryEnv)) {
+          minShell = tryShell;
+        }
+      }
+    });
+    return minShell;
+  }
+  _findShell(minEdgeRings) {
+    let shellCount = 0;
+    let shell = null;
+    minEdgeRings.forEach((er) => {
+      if (!er.isHole()) {
+        shell = er;
+        shellCount++;
+      }
+    });
+    Assert.isTrue(shellCount <= 1, "found two shells in MinimalEdgeRing list");
+    return shell;
+  }
+  add(dirEdges, nodes) {
+    PlanarGraph.linkResultDirectedEdges(nodes);
+    const maxEdgeRings = this._buildMaximalEdgeRings(dirEdges);
+    const freeHoleList = [];
+    const edgeRings = this._buildMinimalEdgeRings(
+      maxEdgeRings,
+      this._shellList,
+      freeHoleList
+    );
+    this._sortShellsAndHoles(edgeRings, this._shellList, freeHoleList);
+    this._placeFreeHoles(this._shellList, freeHoleList);
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/util/Assert.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/util/Assert.js
@@ -1,0 +1,55 @@
+import AssertionFailedException from "./AssertionFailedException";
+
+export default class Assert {
+  static shouldNeverReachHere() {
+    if (arguments.length === 0) {
+      Assert.shouldNeverReachHere(null);
+    } else if (arguments.length === 1) {
+      let message = arguments[0];
+      throw new AssertionFailedException(
+        "Should never reach here" + (message !== null ? ": " + message : "")
+      );
+    }
+  }
+  static isTrue() {
+    let assertion;
+    let message;
+    if (arguments.length === 1) {
+      assertion = arguments[0];
+      Assert.isTrue(assertion, null);
+    } else if (arguments.length === 2) {
+      assertion = arguments[0];
+      message = arguments[1];
+      if (!assertion) {
+        if (message === null) {
+          throw new AssertionFailedException();
+        } else {
+          throw new AssertionFailedException(message);
+        }
+      }
+    }
+  }
+  static equals() {
+    let expectedValue;
+    let actualValue;
+    let message;
+    if (arguments.length === 2) {
+      expectedValue = arguments[0];
+      actualValue = arguments[1];
+      Assert.equals(expectedValue, actualValue, null);
+    } else if (arguments.length === 3) {
+      expectedValue = arguments[0];
+      actualValue = arguments[1];
+      message = arguments[2];
+      if (!actualValue.equals(expectedValue)) {
+        throw new AssertionFailedException(
+          "Expected " +
+            expectedValue +
+            " but encountered " +
+            actualValue +
+            (message !== null ? ": " + message : "")
+        );
+      }
+    }
+  }
+}

--- a/packages/turf-buffer/lib/org/locationtech/jts/util/AssertionFailedException.js
+++ b/packages/turf-buffer/lib/org/locationtech/jts/util/AssertionFailedException.js
@@ -1,0 +1,13 @@
+import RuntimeException from "../../../../java/lang/RuntimeException";
+
+export default class AssertionFailedException extends RuntimeException {
+  constructor() {
+    super();
+    if (arguments.length === 0) {
+      RuntimeException.call(this);
+    } else if (arguments.length === 1) {
+      let message = arguments[0];
+      RuntimeException.call(this, message);
+    }
+  }
+}

--- a/packages/turf-buffer/lib/utils/coordinates.js
+++ b/packages/turf-buffer/lib/utils/coordinates.js
@@ -1,0 +1,73 @@
+/**
+ * A coordinate pair (x, y)
+ * @typedef {[number, number]} GeoJSONCoordinate
+ */
+
+function x(p) {
+  return p[0];
+}
+
+function y(p) {
+  return p[1];
+}
+
+const coordinates = {
+  equals: ([ax, ay], [bx, by]) => {
+    return ax === bx && ay === by;
+  },
+  compare: ([ax, ay], [bx, by]) => {
+    if (ax < bx) return -1;
+    if (ax > bx) return 1;
+    if (ay < by) return -1;
+    if (ay > by) return 1;
+    return 0;
+  },
+  distance: ([ax, ay], [bx, by]) => {
+    var dx = ax - bx;
+    var dy = ay - by;
+    return Math.sqrt(dx * dx + dy * dy);
+  },
+  removeRepeatedPoints: (coords) => {
+    if (!coords || coords.length <= 1) return coords;
+    const cleanCoords = [coords[0]];
+    coords.forEach((coordinate) => {
+      if (
+        !coordinates.equals(coordinate, cleanCoords[cleanCoords.length - 1])
+      ) {
+        cleanCoords.push(coordinate);
+      }
+    });
+    return cleanCoords;
+  },
+  intersection: ([p1x, p1y], [p2x, p2y], [q1x, q1y], [q2x, q2y]) => {
+    const px = p1y - p2y;
+    const py = p2x - p1x;
+    const pw = p1x * p2y - p2x * p1y;
+    const qx = q1y - q2y;
+    const qy = q2x - q1x;
+    const qw = q1x * q2y - q2x * q1y;
+    const x = py * qw - qy * pw;
+    const y = qx * pw - px * qw;
+    const w = px * qy - qx * py;
+    const xInt = x / w;
+    const yInt = y / w;
+    if (
+      Number.isNaN(xInt) ||
+      !Number.isFinite(xInt) ||
+      Number.isNaN(yInt) ||
+      !Number.isFinite(yInt)
+    ) {
+      return;
+    }
+    return [xInt, yInt];
+  },
+  isCoordinate: (o) => {
+    return (
+      Array.isArray(o) &&
+      o.length === 2 &&
+      o.every((_) => typeof _ === "number")
+    );
+  },
+};
+
+export { coordinates, x, y };

--- a/packages/turf-buffer/lib/utils/polyfills.js
+++ b/packages/turf-buffer/lib/utils/polyfills.js
@@ -1,0 +1,64 @@
+/**
+ * Polyfill for IE support
+ */
+Math.trunc =
+  Math.trunc ||
+  function (x) {
+    return x < 0 ? Math.ceil(x) : Math.floor(x);
+  };
+/* Polyfill service v3.13.0
+ * For detailed credits and licence information see http://github.com/financial-times/polyfill-service
+ *
+ * - Array.prototype.fill, License: CC0 */
+
+if (!("fill" in Array.prototype)) {
+  Object.defineProperty(Array.prototype, "fill", {
+    configurable: true,
+    value: function fill(value) {
+      if (this === undefined || this === null) {
+        throw new TypeError(this + " is not an object");
+      }
+
+      var arrayLike = Object(this);
+
+      var length =
+        Math.max(Math.min(arrayLike.length, 9007199254740991), 0) || 0;
+
+      var relativeStart =
+        1 in arguments ? parseInt(Number(arguments[1]), 10) || 0 : 0;
+
+      relativeStart =
+        relativeStart < 0
+          ? Math.max(length + relativeStart, 0)
+          : Math.min(relativeStart, length);
+
+      var relativeEnd =
+        2 in arguments && arguments[2] !== undefined
+          ? parseInt(Number(arguments[2]), 10) || 0
+          : length;
+
+      relativeEnd =
+        relativeEnd < 0
+          ? Math.max(length + arguments[2], 0)
+          : Math.min(relativeEnd, length);
+
+      while (relativeStart < relativeEnd) {
+        arrayLike[relativeStart] = value;
+
+        ++relativeStart;
+      }
+
+      return arrayLike;
+    },
+    writable: true,
+  });
+}
+
+/**
+ * Polyfill for IE support
+ */
+Number.isInteger =
+  Number.isInteger ||
+  function (val) {
+    return typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+  };

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -63,12 +63,9 @@
     "write-json-file": "*"
   },
   "dependencies": {
-    "@turf/bbox": "^6.4.0",
     "@turf/center": "^6.4.0",
     "@turf/helpers": "^6.4.0",
     "@turf/meta": "^6.4.0",
-    "@turf/projection": "^6.4.0",
-    "d3-geo": "1.7.1",
-    "turf-jsts": "*"
+    "d3-geo": "1.7.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,11 +4800,6 @@ jsts@^1.4.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/jsts/-/jsts-1.6.0.tgz#ab5d47ca3f9962c4ef94bbe6a317efeacdb41c93"
 
-jsts@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/jsts/-/jsts-2.7.1.tgz#a921c0cc9eefeef588bd53e952e0a7782d812d52"
-  integrity sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -8227,10 +8222,6 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
-
-turf-jsts@*:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/turf-jsts/-/turf-jsts-1.2.3.tgz#59757f542afbff9a577bbf411f183b8f48d38aa4"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,6 +4800,11 @@ jsts@^1.4.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/jsts/-/jsts-1.6.0.tgz#ab5d47ca3f9962c4ef94bbe6a317efeacdb41c93"
 
+jsts@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/jsts/-/jsts-2.7.1.tgz#a921c0cc9eefeef588bd53e952e0a7782d812d52"
+  integrity sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

At the moment JSTS is only used in one module; `turf-buffer`. As it stands we rely on [`turf-jsts`](https://github.com/DenisCarriere/turf-jsts#readme) which although serves its purpose, hasn't been touched in 4 years. 

@rycgar did the work of creating a custom build for JSTS which strips back to the necessary JSTS code that is required to operate `turf-buffer`. I stripped this back very minorly by removing small amounts of dead code + IE polyfills that aren't required.

As it stands building with `terser` and gzipping gives the following file sizes for a minimal use case of `turf-buffer`:

![image](https://user-images.githubusercontent.com/8822075/123513667-2e8ebc00-d686-11eb-9bf1-2df60e298723.png)

This PR, using `turf-buffer` would come in at under half the size for the regular case once minified/gzipped:

![image](https://user-images.githubusercontent.com/8822075/123513688-4cf4b780-d686-11eb-91d7-db2c2c18652a.png)
 