### PR TITLE
pointsWithinPolygon: add MultiPoint support

### DIFF
--- a/packages/turf-points-within-polygon/index.d.ts
+++ b/packages/turf-points-within-polygon/index.d.ts
@@ -3,6 +3,7 @@ import {
   FeatureCollection,
   Polygon,
   MultiPolygon,
+  MultiPoint,
   Point,
   Properties,
 } from "@turf/helpers";
@@ -14,6 +15,8 @@ export default function pointsWithinPolygon<
   G extends Polygon | MultiPolygon,
   P = Properties
 >(
-  points: Feature<Point, P> | FeatureCollection<Point, P>,
+  points:
+    | Feature<Point | MultiPoint, P>
+    | FeatureCollection<Point | MultiPoint, P>,
   polygons: Feature<G> | FeatureCollection<G> | G
 ): FeatureCollection<Point, P>;

--- a/packages/turf-points-within-polygon/index.d.ts
+++ b/packages/turf-points-within-polygon/index.d.ts
@@ -12,11 +12,10 @@ import {
  * http://turfjs.org/docs/#pointswithinpolygon
  */
 export default function pointsWithinPolygon<
+  F extends Point | MultiPoint,
   G extends Polygon | MultiPolygon,
   P = Properties
 >(
-  points:
-    | Feature<Point | MultiPoint, P>
-    | FeatureCollection<Point | MultiPoint, P>,
+  points: Feature<F, P> | FeatureCollection<F, P>,
   polygons: Feature<G> | FeatureCollection<G> | G
-): FeatureCollection<Point | MultiPoint, P>;
+): FeatureCollection<F, P>;

--- a/packages/turf-points-within-polygon/index.d.ts
+++ b/packages/turf-points-within-polygon/index.d.ts
@@ -19,4 +19,4 @@ export default function pointsWithinPolygon<
     | Feature<Point | MultiPoint, P>
     | FeatureCollection<Point | MultiPoint, P>,
   polygons: Feature<G> | FeatureCollection<G> | G
-): FeatureCollection<Point, P>;
+): FeatureCollection<Point | MultiPoint, P>;

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -3,12 +3,12 @@ import { featureCollection, multiPoint } from "@turf/helpers";
 import { geomEach, featureEach, coordEach } from "@turf/meta";
 
 /**
- * Finds {@link Points} that fall within {@link (Multi)Polygon(s)}.
+ * Finds {@link Points} or {@link MultiPoint} coordinates that fall within {@link (Multi)Polygon(s)}.
  *
  * @name pointsWithinPolygon
- * @param {Feature|FeatureCollection<Point>} points Points as input search
- * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons Points must be within these (Multi)Polygon(s)
- * @returns {FeatureCollection<Point>} points that land within at least one polygon
+ * @param {Feature|FeatureCollection<Point|MultiPoint>} points Points or MultiPoints as input search
+ * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons Polygon(s) or MultiPolygon(s) to check if points are within
+ * @returns {FeatureCollection<Point>} Points that land within at least one polygon
  * @example
  * var points = turf.points([
  *     [-46.6318, -23.5523],

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -49,7 +49,7 @@ function pointsWithinPolygon(points, polygons) {
         results.push(point);
       }
     } else if (point.geometry.type === "MultiPoint") {
-      let pointsWithin = [];
+      var pointsWithin = [];
       geomEach(polygons, function (polygon) {
         coordEach(point, function (pointCoord) {
           if (pointInPolygon(pointCoord, polygon)) {

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -1,6 +1,6 @@
 import pointInPolygon from "@turf/boolean-point-in-polygon";
 import { featureCollection } from "@turf/helpers";
-import { geomEach, featureEach } from "@turf/meta";
+import { geomEach, featureEach, coordEach } from "@turf/meta";
 
 /**
  * Finds {@link Points} that fall within {@link (Multi)Polygon(s)}.
@@ -42,7 +42,9 @@ function pointsWithinPolygon(points, polygons) {
   featureEach(points, function (point) {
     var contained = false;
     geomEach(polygons, function (polygon) {
-      if (pointInPolygon(point, polygon)) contained = true;
+      coordEach(point, function (pointCoord) {
+        if (pointInPolygon(pointCoord, polygon)) contained = true;
+      });
     });
     if (contained) {
       results.push(point);

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -6,9 +6,9 @@ import { geomEach, featureEach, coordEach } from "@turf/meta";
  * Finds {@link Points} or {@link MultiPoint} coordinates that fall within {@link (Multi)Polygon(s)}.
  *
  * @name pointsWithinPolygon
- * @param {Feature|FeatureCollection<Point|MultiPoint>} points Points or MultiPoints as input search
- * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons Polygon(s) or MultiPolygon(s) to check if points are within
- * @returns {FeatureCollection<Point>} Points that land within at least one polygon
+ * @param {Feature|FeatureCollection<Point|MultiPoint>} points (Multi)Point(s) as input search
+ * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons (Multi)Polygon(s) to check if points are within
+ * @returns {FeatureCollection<Point>} (Multi)Points that land within at least one polygon
  * @example
  * var points = turf.points([
  *     [-46.6318, -23.5523],

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -6,9 +6,9 @@ import { geomEach, featureEach, coordEach } from "@turf/meta";
  * Finds {@link Points} or {@link MultiPoint} coordinate positions that fall within {@link (Multi)Polygon(s)}.
  *
  * @name pointsWithinPolygon
- * @param {Feature|FeatureCollection<Point|MultiPoint>} points (Multi)Point(s) as input search
+ * @param {Feature|FeatureCollection<Point|MultiPoint>} points Point(s) or MultiPoint(s) as input search
  * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons (Multi)Polygon(s) to check if points are within
- * @returns {FeatureCollection<Point|MultiPoint>} (Multi)Points that land within at least one polygon
+ * @returns {FeatureCollection<Point|MultiPoint>} Point(s) or MultiPoint(s) with positions that land within at least one polygon.  The geometry type will match what was passsed in
  * @example
  * var points = turf.points([
  *     [-46.6318, -23.5523],

--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -3,12 +3,12 @@ import { featureCollection, multiPoint } from "@turf/helpers";
 import { geomEach, featureEach, coordEach } from "@turf/meta";
 
 /**
- * Finds {@link Points} or {@link MultiPoint} coordinates that fall within {@link (Multi)Polygon(s)}.
+ * Finds {@link Points} or {@link MultiPoint} coordinate positions that fall within {@link (Multi)Polygon(s)}.
  *
  * @name pointsWithinPolygon
  * @param {Feature|FeatureCollection<Point|MultiPoint>} points (Multi)Point(s) as input search
  * @param {FeatureCollection|Geometry|Feature<Polygon|MultiPolygon>} polygons (Multi)Polygon(s) to check if points are within
- * @returns {FeatureCollection<Point>} (Multi)Points that land within at least one polygon
+ * @returns {FeatureCollection<Point|MultiPoint>} (Multi)Points that land within at least one polygon
  * @example
  * var points = turf.points([
  *     [-46.6318, -23.5523],

--- a/packages/turf-points-within-polygon/test.js
+++ b/packages/turf-points-within-polygon/test.js
@@ -4,7 +4,7 @@ import { polygon } from "@turf/helpers";
 import { featureCollection } from "@turf/helpers";
 import pointsWithinPolygon from "./index";
 
-test("turf-points-within-polygon -- single point", (t) => {
+test("turf-points-within-polygon -- point", (t) => {
   t.plan(4);
 
   // test with a single point
@@ -59,10 +59,10 @@ test("turf-points-within-polygon -- single point", (t) => {
   t.equal(counted.features.length, 5, "multiple points in multiple polygons");
 });
 
-test("turf-points-within-polygon -- single multipoint", (t) => {
+test("turf-points-within-polygon -- multipoint", (t) => {
   t.plan(12);
 
-  const poly1 = polygon([
+  var poly1 = polygon([
     [
       [0, 0],
       [0, 100],
@@ -72,17 +72,17 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
     ],
   ]);
 
-  const mpt1 = multiPoint([[50, 50]]); // inside poly1
-  const mpt2 = multiPoint([[150, 150]]); // outside poly1
-  const mpt3 = multiPoint([
+  var mpt1 = multiPoint([[50, 50]]); // inside poly1
+  var mpt2 = multiPoint([[150, 150]]); // outside poly1
+  var mpt3 = multiPoint([
     [50, 50],
     [150, 150],
   ]); // inside and outside poly1
-  const mpt1FC = featureCollection([mpt1]);
-  const polyFC = featureCollection([poly1]);
+  var mpt1FC = featureCollection([mpt1]);
+  var polyFC = featureCollection([poly1]);
 
   // multipoint within
-  const mpWithin = pointsWithinPolygon(mpt1, polyFC);
+  var mpWithin = pointsWithinPolygon(mpt1, polyFC);
   t.ok(
     mpWithin && mpWithin.type === "FeatureCollection",
     "returns a featurecollection"
@@ -95,7 +95,7 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
   );
 
   // multipoint fc within
-  const fcWithin = pointsWithinPolygon(mpt1FC, polyFC);
+  var fcWithin = pointsWithinPolygon(mpt1FC, polyFC);
   t.ok(
     fcWithin && fcWithin.type === "FeatureCollection",
     "returns a featurecollection"
@@ -103,7 +103,7 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
   t.equal(fcWithin.features.length, 1, "1 multipoint in 1 polygon");
 
   // multipoint not within
-  const mpNotWithin = pointsWithinPolygon(mpt2, polyFC);
+  var mpNotWithin = pointsWithinPolygon(mpt2, polyFC);
   t.ok(
     mpNotWithin && mpNotWithin.type === "FeatureCollection",
     "returns an empty featurecollection"
@@ -111,9 +111,9 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
   t.equal(mpNotWithin.features.length, 0, "0 multipoint in 1 polygon");
 
   // multipoint with point coords both within and not within
-  const mpPartWithin = pointsWithinPolygon(mpt3, polyFC);
+  var mpPartWithin = pointsWithinPolygon(mpt3, polyFC);
   t.ok(mpPartWithin, "returns a featurecollection");
-  const partCoords = mpPartWithin.features[0].geometry.coordinates;
+  var partCoords = mpPartWithin.features[0].geometry.coordinates;
   t.equal(
     partCoords.length,
     1,
@@ -128,7 +128,7 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
 
   // multiple multipoints and multiple polygons
 
-  const poly2 = polygon([
+  var poly2 = polygon([
     [
       [10, 0],
       [20, 10],
@@ -147,6 +147,33 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
     2,
     "multiple points in multiple polygons"
   );
+});
+
+test("turf-points-within-polygon -- point and multipoint", (t) => {
+  t.plan(4);
+
+  var poly = polygon([
+    [
+      [0, 0],
+      [0, 100],
+      [100, 100],
+      [100, 0],
+      [0, 0],
+    ],
+  ]);
+  var polyFC = featureCollection([poly]);
+
+  var pt = point([50, 50]);
+  var mpt1 = multiPoint([[50, 50]]); // inside poly1
+  var mpt2 = multiPoint([[150, 150]]); // outside poly1
+  var mixedFC = featureCollection([pt, mpt1, mpt2]);
+
+  var counted = pointsWithinPolygon(mixedFC, polyFC);
+
+  t.ok(counted, "returns a featurecollection");
+  t.equal(counted.features.length, 2, "1 point and 1 multipoint in 1 polygon");
+  t.equal(counted.features[0].geometry.type, "Point");
+  t.equal(counted.features[1].geometry.type, "MultiPoint");
 });
 
 test("turf-points-within-polygon -- support extra point geometry", (t) => {

--- a/packages/turf-points-within-polygon/test.js
+++ b/packages/turf-points-within-polygon/test.js
@@ -60,7 +60,7 @@ test("turf-points-within-polygon -- single point", (t) => {
 });
 
 test("turf-points-within-polygon -- single multipoint", (t) => {
-  t.plan(8);
+  t.plan(12);
 
   const poly1 = polygon([
     [
@@ -73,10 +73,10 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
   ]);
 
   const mpt1 = multiPoint([[50, 50]]); // inside poly1
-  const mpt2 = multiPoint([[1000, 1000]]); // outside poly1
+  const mpt2 = multiPoint([[150, 150]]); // outside poly1
   const mpt3 = multiPoint([
     [50, 50],
-    [1000, 1000],
+    [150, 150],
   ]); // inside and outside poly1
   const mpt1FC = featureCollection([mpt1]);
   const polyFC = featureCollection([poly1]);
@@ -113,11 +113,16 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
   // multipoint with point coords both within and not within
   const mpPartWithin = pointsWithinPolygon(mpt3, polyFC);
   t.ok(mpPartWithin, "returns a featurecollection");
-  // maintains the whole multipoint, including coordinates that are outside the polygon(s)
+  const partCoords = mpPartWithin.features[0].geometry.coordinates;
   t.equal(
-    mpPartWithin.features[0].geometry.coordinates.length,
-    2,
-    "1 multipoint with 2 points in polygon"
+    partCoords.length,
+    1,
+    "multipoint result should have 1 remaining coord that was within polygon"
+  );
+  t.equal(
+    partCoords[0][0] === 50 && partCoords[0][1] === 50,
+    true,
+    "remaining coord should have expected values"
   );
 
   // multiple multipoints and multiple polygons

--- a/packages/turf-points-within-polygon/test.js
+++ b/packages/turf-points-within-polygon/test.js
@@ -120,7 +120,8 @@ test("turf-points-within-polygon -- single multipoint", (t) => {
     "multipoint result should have 1 remaining coord that was within polygon"
   );
   t.equal(
-    partCoords[0][0] === 50 && partCoords[0][1] === 50,
+    partCoords[0][0] === mpt3.geometry.coordinates[0][0] &&
+      partCoords[0][1] === mpt3.geometry.coordinates[0][1],
     true,
     "remaining coord should have expected values"
   );

--- a/packages/turf-points-within-polygon/types.ts
+++ b/packages/turf-points-within-polygon/types.ts
@@ -1,5 +1,5 @@
 import pointsWithinPolygon from "./";
-import { points, polygon } from "@turf/helpers";
+import { points, polygon, multiPoint, featureCollection } from "@turf/helpers";
 
 const pts = points([
   [-46.6318, -23.5523],
@@ -8,6 +8,22 @@ const pts = points([
   [-46.663, -23.554],
   [-46.643, -23.557],
 ]);
+const mpt1 = multiPoint(
+  [
+    [50, 50],
+    [100, 100],
+  ],
+  {}
+);
+const mpt2 = multiPoint(
+  [
+    [75, 75],
+    [150, 150],
+  ],
+  {}
+);
+const mpts = featureCollection([mpt1, mpt2]);
+
 const searchWithin = polygon([
   [
     [-46.653, -23.543],
@@ -20,3 +36,4 @@ const searchWithin = polygon([
   ],
 ]);
 const ptsWithin = pointsWithinPolygon(pts, searchWithin);
+const mptsWithin = pointsWithinPolygon(mpts, searchWithin);

--- a/packages/turf-points-within-polygon/types.ts
+++ b/packages/turf-points-within-polygon/types.ts
@@ -1,5 +1,12 @@
 import pointsWithinPolygon from "./";
-import { points, polygon, multiPoint, featureCollection } from "@turf/helpers";
+import {
+  points,
+  polygon,
+  multiPoint,
+  featureCollection,
+  Point,
+  MultiPoint,
+} from "@turf/helpers";
 
 const pts = points([
   [-46.6318, -23.5523],
@@ -37,3 +44,7 @@ const searchWithin = polygon([
 ]);
 const ptsWithin = pointsWithinPolygon(pts, searchWithin);
 const mptsWithin = pointsWithinPolygon(mpts, searchWithin);
+
+// Accepts a mixture of Point and MultiPoint
+const mix = featureCollection<Point | MultiPoint>([...pts.features, mpt1]);
+const mixWithin = pointsWithinPolygon(mix, searchWithin);


### PR DESCRIPTION
This PR adds support for MultiPoints to pointsWithinPolygon per issue #2099.

This implements Option 3 discussed, for each MultiPoint passed, returns a MultiPoint with just the point coordinates that fall within a Polygon.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.
