### PR TITLE
polygonSmooth: make options optional

### DIFF
--- a/packages/turf-polygon-smooth/index.js
+++ b/packages/turf-polygon-smooth/index.js
@@ -1,5 +1,5 @@
+import { featureCollection, multiPolygon, polygon } from "@turf/helpers";
 import { coordEach, geomEach } from "@turf/meta";
-import { featureCollection, polygon, multiPolygon } from "@turf/helpers";
 
 /**
  * Smooths a {@link Polygon} or {@link MultiPolygon}. Based on [Chaikin's algorithm](http://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html).
@@ -19,6 +19,7 @@ import { featureCollection, polygon, multiPolygon } from "@turf/helpers";
  * var addToMap = [smoothed, polygon];
  */
 function polygonSmooth(inputPolys, options) {
+  options = options || {};
   var outPolys = [];
   // Optional parameters
   var iterations = options.iterations || 1;

--- a/packages/turf-polygon-smooth/test.js
+++ b/packages/turf-polygon-smooth/test.js
@@ -1,7 +1,8 @@
-import test from "tape";
-import path from "path";
+import { polygon } from "@turf/helpers";
 import glob from "glob";
 import load from "load-json-file";
+import path from "path";
+import test from "tape";
 import write from "write-json-file";
 import polygonSmooth from "./index";
 
@@ -25,5 +26,22 @@ test("turf-polygon-smooth", (t) => {
       if (process.env.REGEN) write.sync(out, results);
       t.deepEqual(results, load.sync(out), path.parse(filepath).name);
     });
+  t.end();
+});
+
+test("turf-polygon-smooth -- options are optional", (t) => {
+  t.doesNotThrow(() =>
+    polygonSmooth(
+      polygon([
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 1],
+          [0, 0],
+        ],
+      ])
+    )
+  );
   t.end();
 });


### PR DESCRIPTION
Noticed I got an error when calling `polygonSmooth` without a second options object, even though it was marked as optional. Fixed it by adding an empty object as default.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.