### PR TITLE
Updates messy description of bbox

### DIFF
--- a/packages/turf-bbox/README.md
+++ b/packages/turf-bbox/README.md
@@ -4,7 +4,7 @@
 
 ## bbox
 
-Takes a set of features, calculates the bbox of all input features, and returns a bounding box.
+Calculates the bounding box for any GeoJSON object, including FeatureCollection.
 
 **Parameters**
 

--- a/packages/turf-bbox/index.ts
+++ b/packages/turf-bbox/index.ts
@@ -2,7 +2,7 @@ import { BBox } from "@turf/helpers";
 import { coordEach } from "@turf/meta";
 
 /**
- * Takes a set of features, calculates the bbox of all input features, and returns a bounding box.
+ * Calculates the bounding box for any GeoJSON object, including FeatureCollection.
  *
  * @name bbox
  * @param {GeoJSON} geojson any GeoJSON object


### PR DESCRIPTION
Updates messy description of bbox 

FROM: "Takes a set of features calculates the bbox of all input features, and returns a bounding box."

TO: "Calculates the bounding box for any GeoJSON object, including FeatureCollection."

"Resolves #2147"