### PR TITLE
[Draft] Rebuild geojson Typescript definitions on @types/geojson

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "devDependencies": {
-    "@types/geojson": "*",
+    "@types/geojson": "7946.0.8",
     "@types/node": "*",
     "@typescript-eslint/eslint-plugin": "^4.8.0",
     "@typescript-eslint/parser": "^4.8.0",

--- a/packages/turf-along/index.ts
+++ b/packages/turf-along/index.ts
@@ -29,6 +29,8 @@ export default function along(
 ): Feature<Point> {
   // Get Coords
   const geom = getGeom(line);
+  if (!geom)
+    throw new Error("Input line feature must have a non-null geometry");
   const coords = geom.coordinates;
   let travelled = 0;
   for (let i = 0; i < coords.length; i++) {

--- a/packages/turf-bbox-clip/index.ts
+++ b/packages/turf-bbox-clip/index.ts
@@ -16,13 +16,14 @@ import { lineclip, polygonclip } from "./lib/lineclip";
 
 /**
  * Takes a {@link Feature} and a bbox and clips the feature to the bbox using
- * [lineclip](https://github.com/mapbox/lineclip). Returns null if Feature geometry is null.
+ * [lineclip](https://github.com/mapbox/lineclip).
  * May result in degenerate edges when clipping Polygons.
  *
  * @name bboxClip
  * @param {Feature<LineString|MultiLineString|Polygon|MultiPolygon>} feature feature to clip to the bbox
  * @param {BBox} bbox extent in [minX, minY, maxX, maxY] order
  * @returns {Feature<LineString|MultiLineString|Polygon|MultiPolygon | null>} clipped Feature
+ * @throws {Error} if input polygon has null geometry
  * @example
  * var bbox = [0, 0, 10, 10];
  * var poly = turf.polygon([[[2, 2], [8, 4], [12, 8], [3, 7], [2, 2]]]);
@@ -37,7 +38,7 @@ export default function bboxClip<
   P = Properties
 >(feature: Feature<G, P> | G, bbox: BBox) {
   const geom = getGeom(feature);
-  if (!geom) return null;
+  if (geom === null) throw new Error("Input polygon must have a geometry");
   const type = geom.type;
   const properties = feature.type === "Feature" ? feature.properties : {};
   let coords: any[] = geom.coordinates;

--- a/packages/turf-bbox-clip/index.ts
+++ b/packages/turf-bbox-clip/index.ts
@@ -16,13 +16,13 @@ import { lineclip, polygonclip } from "./lib/lineclip";
 
 /**
  * Takes a {@link Feature} and a bbox and clips the feature to the bbox using
- * [lineclip](https://github.com/mapbox/lineclip).
+ * [lineclip](https://github.com/mapbox/lineclip). Returns null if Feature geometry is null.
  * May result in degenerate edges when clipping Polygons.
  *
  * @name bboxClip
  * @param {Feature<LineString|MultiLineString|Polygon|MultiPolygon>} feature feature to clip to the bbox
  * @param {BBox} bbox extent in [minX, minY, maxX, maxY] order
- * @returns {Feature<LineString|MultiLineString|Polygon|MultiPolygon>} clipped Feature
+ * @returns {Feature<LineString|MultiLineString|Polygon|MultiPolygon | null>} clipped Feature
  * @example
  * var bbox = [0, 0, 10, 10];
  * var poly = turf.polygon([[[2, 2], [8, 4], [12, 8], [3, 7], [2, 2]]]);
@@ -37,6 +37,7 @@ export default function bboxClip<
   P = Properties
 >(feature: Feature<G, P> | G, bbox: BBox) {
   const geom = getGeom(feature);
+  if (!geom) return null;
   const type = geom.type;
   const properties = feature.type === "Feature" ? feature.properties : {};
   let coords: any[] = geom.coordinates;

--- a/packages/turf-bezier-spline/index.ts
+++ b/packages/turf-bezier-spline/index.ts
@@ -1,5 +1,5 @@
 import { Feature, lineString, LineString, Properties } from "@turf/helpers";
-import { getGeom } from "@turf/invariant";
+import { coordEach } from "@turf/meta";
 import Spline from "./lib/spline";
 
 /**
@@ -44,9 +44,9 @@ function bezier<P = Properties>(
   const resolution = options.resolution || 10000;
   const sharpness = options.sharpness || 0.85;
 
-  const coords: [number, number][] = [];
-  const points = getGeom(line).coordinates.map((pt) => {
-    return { x: pt[0], y: pt[1] };
+  const points: { x: number; y: number }[] = [];
+  coordEach(line, (c) => {
+    points.push({ x: c[0], y: c[1] });
   });
   const spline = new Spline({
     duration: resolution,
@@ -54,6 +54,7 @@ function bezier<P = Properties>(
     sharpness,
   });
 
+  const coords: [number, number][] = [];
   const pushCoord = (time: number) => {
     var pos = spline.pos(time);
     if (Math.floor(time / 100) % 2 === 0) {

--- a/packages/turf-boolean-concave/index.ts
+++ b/packages/turf-boolean-concave/index.ts
@@ -2,11 +2,12 @@ import { Feature, Polygon } from "@turf/helpers";
 import { getGeom } from "@turf/invariant";
 
 /**
- * Takes a polygon and return true or false as to whether it is concave or not.  Returns null if the Feature has a null geometry
+ * Takes a polygon and return true or false as to whether it is concave or not.
  *
  * @name booleanConcave
  * @param {Feature<Polygon>} polygon to be evaluated
  * @returns {boolean} true/false
+ * @throws {Error} if input polygon has null geometry
  * @example
  * var convexPolygon = turf.polygon([[[0,0],[0,1],[1,1],[1,0],[0,0]]]);
  *
@@ -15,8 +16,9 @@ import { getGeom } from "@turf/invariant";
  */
 export default function booleanConcave(polygon: Feature<Polygon> | Polygon) {
   // Taken from https://stackoverflow.com/a/1881201 & https://stackoverflow.com/a/25304159
-  const coords = getGeom(polygon)?.coordinates;
-  if (!coords) return null;
+  const geom = getGeom(polygon);
+  if (geom === null) throw new Error("Input polygon must have a geometry");
+  const coords = geom.coordinates;
   if (coords[0].length <= 4) {
     return false;
   }

--- a/packages/turf-boolean-concave/index.ts
+++ b/packages/turf-boolean-concave/index.ts
@@ -2,7 +2,7 @@ import { Feature, Polygon } from "@turf/helpers";
 import { getGeom } from "@turf/invariant";
 
 /**
- * Takes a polygon and return true or false as to whether it is concave or not.
+ * Takes a polygon and return true or false as to whether it is concave or not.  Returns undefined if the Feature has no geometry
  *
  * @name booleanConcave
  * @param {Feature<Polygon>} polygon to be evaluated
@@ -15,7 +15,8 @@ import { getGeom } from "@turf/invariant";
  */
 export default function booleanConcave(polygon: Feature<Polygon> | Polygon) {
   // Taken from https://stackoverflow.com/a/1881201 & https://stackoverflow.com/a/25304159
-  const coords = getGeom(polygon).coordinates;
+  const coords = getGeom(polygon)?.coordinates;
+  if (!coords) return undefined;
   if (coords[0].length <= 4) {
     return false;
   }

--- a/packages/turf-boolean-concave/index.ts
+++ b/packages/turf-boolean-concave/index.ts
@@ -2,7 +2,7 @@ import { Feature, Polygon } from "@turf/helpers";
 import { getGeom } from "@turf/invariant";
 
 /**
- * Takes a polygon and return true or false as to whether it is concave or not.  Returns null if the Feature has no geometry
+ * Takes a polygon and return true or false as to whether it is concave or not.  Returns null if the Feature has a null geometry
  *
  * @name booleanConcave
  * @param {Feature<Polygon>} polygon to be evaluated

--- a/packages/turf-boolean-concave/index.ts
+++ b/packages/turf-boolean-concave/index.ts
@@ -2,7 +2,7 @@ import { Feature, Polygon } from "@turf/helpers";
 import { getGeom } from "@turf/invariant";
 
 /**
- * Takes a polygon and return true or false as to whether it is concave or not.  Returns undefined if the Feature has no geometry
+ * Takes a polygon and return true or false as to whether it is concave or not.  Returns null if the Feature has no geometry
  *
  * @name booleanConcave
  * @param {Feature<Polygon>} polygon to be evaluated
@@ -16,7 +16,7 @@ import { getGeom } from "@turf/invariant";
 export default function booleanConcave(polygon: Feature<Polygon> | Polygon) {
   // Taken from https://stackoverflow.com/a/1881201 & https://stackoverflow.com/a/25304159
   const coords = getGeom(polygon)?.coordinates;
-  if (!coords) return undefined;
+  if (!coords) return null;
   if (coords[0].length <= 4) {
     return false;
   }

--- a/packages/turf-boolean-contains/index.ts
+++ b/packages/turf-boolean-contains/index.ts
@@ -219,10 +219,14 @@ export function isPolyInPoly(
     return false;
   }
 
-  const coords = getGeom(feature2).coordinates;
+  const geom1 = getGeom(feature1);
+  const geom2 = getGeom(feature2);
+  if (!geom1 || !geom2) return false;
+
+  const coords = geom2.coordinates;
   for (const ring of coords) {
     for (const coord of ring) {
-      if (!booleanPointInPolygon(coord, feature1)) {
+      if (!booleanPointInPolygon(coord, geom1)) {
         return false;
       }
     }

--- a/packages/turf-boolean-contains/index.ts
+++ b/packages/turf-boolean-contains/index.ts
@@ -221,7 +221,7 @@ export function isPolyInPoly(
 
   const geom1 = getGeom(feature1);
   const geom2 = getGeom(feature2);
-  if (!geom1 || !geom2) return false;
+  if (geom1 === null || geom2 === null) return false;
 
   const coords = geom2.coordinates;
   for (const ring of coords) {

--- a/packages/turf-boolean-point-in-polygon/index.ts
+++ b/packages/turf-boolean-point-in-polygon/index.ts
@@ -55,9 +55,9 @@ export default function booleanPointInPolygon<
 
   const pt = getCoord(point);
   const geom = getGeom(polygon);
-  const type = geom.type;
+  const type = geom?.type;
   const bbox = polygon.bbox;
-  let polys: any[] = geom.coordinates;
+  let polys: any[] = geom ? geom.coordinates : [];
 
   // Quick elimination if point is not inside bbox
   if (bbox && inBBox(pt, bbox) === false) {

--- a/packages/turf-center-of-mass/index.ts
+++ b/packages/turf-center-of-mass/index.ts
@@ -28,7 +28,9 @@ function centerOfMass<P = Properties>(
 ): Feature<Point, P> {
   switch (getType(geojson)) {
     case "Point":
-      return point(getCoord(geojson), options.properties);
+      var coord = getCoord(geojson);
+      if (!coord) throw new Error("Input geojson has no geometry");
+      return point(coord, options.properties);
     case "Polygon":
       var coords: Position[] = [];
       coordEach(geojson, function (coord) {
@@ -38,6 +40,7 @@ function centerOfMass<P = Properties>(
       // First, we neutralize the feature (set it around coordinates [0,0]) to prevent rounding errors
       // We take any point to translate all the points around 0
       var centre = centroid(geojson, { properties: options.properties });
+      if (!centre.geometry) throw new Error("Input geojson has no geometry");
       var translation = centre.geometry.coordinates;
       var sx = 0;
       var sy = 0;

--- a/packages/turf-clusters/index.ts
+++ b/packages/turf-clusters/index.ts
@@ -1,5 +1,11 @@
 import { featureEach } from "@turf/meta";
-import { featureCollection, Feature, FeatureCollection } from "@turf/helpers";
+import {
+  featureCollection,
+  Feature,
+  FeatureCollection,
+  GeometryObject,
+  Geometries,
+} from "@turf/helpers";
 
 /**
  * Get Cluster
@@ -30,7 +36,7 @@ import { featureCollection, Feature, FeatureCollection } from "@turf/helpers";
  * turf.getCluster(clustered, {'marker-symbol': 'square'}).length;
  * //= 1
  */
-export function getCluster<G extends any, P = any>(
+export function getCluster<G extends GeometryObject, P = any>(
   geojson: FeatureCollection<G, P>,
   filter: any
 ): FeatureCollection<G, P> {
@@ -98,7 +104,7 @@ export function getCluster<G extends any, P = any>(
  *     values.push(clusterValue);
  * });
  */
-export function clusterEach<G = any, P = any>(
+export function clusterEach<G extends GeometryObject = Geometries, P = any>(
   geojson: FeatureCollection<G, P>,
   property: number | string,
   callback: (
@@ -192,7 +198,7 @@ export function clusterEach<G = any, P = any>(
  *     return previousValue.concat(clusterValue);
  * }, []);
  */
-export function clusterReduce<G = any, P = any>(
+export function clusterReduce<G extends GeometryObject = Geometries, P = any>(
   geojson: FeatureCollection<G, P>,
   property: number | string,
   callback: (

--- a/packages/turf-collect/index.ts
+++ b/packages/turf-collect/index.ts
@@ -2,6 +2,7 @@ import turfbbox from "@turf/bbox";
 import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
 import rbush from "rbush";
 import { FeatureCollection, Polygon, Point } from "@turf/helpers";
+import { geomEach } from "@turf/meta";
 
 interface Entry {
   minX: number;
@@ -49,14 +50,23 @@ function collect(
 ): FeatureCollection<Polygon> {
   var rtree = rbush<Entry>(6);
 
-  var treeItems = points.features.map(function (item) {
-    return {
-      minX: item.geometry.coordinates[0],
-      minY: item.geometry.coordinates[1],
-      maxX: item.geometry.coordinates[0],
-      maxY: item.geometry.coordinates[1],
-      property: item.properties?.[inProperty],
-    };
+  const treeItems: {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+    property: any;
+  }[] = [];
+
+  geomEach(points, (geom, index, properties) => {
+    if (!geom) return true; // skip
+    treeItems.push({
+      minX: geom.coordinates[0],
+      minY: geom.coordinates[1],
+      maxX: geom.coordinates[0],
+      maxY: geom.coordinates[1],
+      property: properties?.[inProperty],
+    });
   });
 
   rtree.load(treeItems);

--- a/packages/turf-combine/index.ts
+++ b/packages/turf-combine/index.ts
@@ -47,6 +47,7 @@ function combine(
     },
   };
 
+  // extract coordinates and properties, skipping features with null geometries
   featureEach(fc, (feature) => {
     switch (feature.geometry?.type) {
       case "Point":
@@ -87,7 +88,10 @@ function combine(
       })
       .sort()
       .map(function (key) {
-        var geometry = { type: key, coordinates: groups[key].coordinates };
+        var geometry = { type: key, coordinates: groups[key].coordinates } as
+          | MultiPoint
+          | MultiLineString
+          | MultiPolygon;
         var properties = { collectedProperties: groups[key].properties };
         return feature(geometry, properties);
       })

--- a/packages/turf-concave/index.ts
+++ b/packages/turf-concave/index.ts
@@ -49,9 +49,9 @@ function concave(
 
   const tinPolys = tin(cleaned);
   // calculate length of all edges and area of all triangles
-  // and remove triangles that fail the max length test
+  // and remove triangles that fail the max length test or have a null geometry
   tinPolys.features = tinPolys.features.filter((triangle) => {
-    if (!triangle.geometry) return false;
+    if (triangle.geometry === null) return false;
     const pt1 = triangle.geometry.coordinates[0][0];
     const pt2 = triangle.geometry.coordinates[0][1];
     const pt3 = triangle.geometry.coordinates[0][2];

--- a/packages/turf-concave/index.ts
+++ b/packages/turf-concave/index.ts
@@ -51,6 +51,7 @@ function concave(
   // calculate length of all edges and area of all triangles
   // and remove triangles that fail the max length test
   tinPolys.features = tinPolys.features.filter((triangle) => {
+    if (!triangle.geometry) return false;
     const pt1 = triangle.geometry.coordinates[0][0];
     const pt2 = triangle.geometry.coordinates[0][1];
     const pt3 = triangle.geometry.coordinates[0][2];

--- a/packages/turf-concave/lib/turf-line-dissolve.ts
+++ b/packages/turf-concave/lib/turf-line-dissolve.ts
@@ -95,6 +95,10 @@ function coordId(coord: number[]) {
  * @returns {Feature<LineString>|null} Merged LineString
  */
 function mergeLineStrings(a: Feature<LineString>, b: Feature<LineString>) {
+  if (!a.geometry && !b.geometry) return null;
+  if (!a.geometry) return b;
+  if (!b.geometry) return a;
+
   const coords1 = a.geometry.coordinates;
   const coords2 = b.geometry.coordinates;
 

--- a/packages/turf-concave/lib/turf-line-dissolve.ts
+++ b/packages/turf-concave/lib/turf-line-dissolve.ts
@@ -92,10 +92,14 @@ function coordId(coord: number[]) {
  * @private
  * @param {Feature<LineString>} a line1
  * @param {Feature<LineString>} b line2
- * @returns {Feature<LineString>|null} Merged LineString
+ * @returns {Feature<LineString>} Merged LineString
+ * @throws {Error} if lines have null geometry
  */
 function mergeLineStrings(a: Feature<LineString>, b: Feature<LineString>) {
-  if (!a.geometry && !b.geometry) return null;
+  if (a.geometry === null && b.geometry === null)
+    throw new Error(
+      "Must input at least one LineString Feature with a non-null geometry"
+    );
   if (!a.geometry) return b;
   if (!b.geometry) return a;
 

--- a/packages/turf-concave/lib/turf-polygon-dissolve.ts
+++ b/packages/turf-concave/lib/turf-polygon-dissolve.ts
@@ -22,7 +22,7 @@ import { topology } from "topojson-server";
 export default function polygonDissolve(
   geojson: FeatureCollection<Polygon | MultiPolygon>,
   options: { mutate?: boolean } = {}
-): Feature<Polygon | MultiPolygon> | null {
+): Feature<Polygon | MultiPolygon> {
   // Validation
   if (getType(geojson) !== "FeatureCollection") {
     throw new Error("geojson must be a FeatureCollection");
@@ -43,7 +43,8 @@ export default function polygonDissolve(
   });
 
   const collGeom = geometryCollection(geoms).geometry;
-  if (!collGeom) return null;
+  if (!collGeom)
+    throw new Error("Input geojson did have at least one non-null geometry");
 
   const topo: any = topology({ geoms: collGeom });
   const merged: any = merge(topo, topo.objects.geoms.geometries);

--- a/packages/turf-concave/lib/turf-polygon-dissolve.ts
+++ b/packages/turf-concave/lib/turf-polygon-dissolve.ts
@@ -37,11 +37,15 @@ export default function polygonDissolve(
     geojson = clone(geojson);
   }
 
-  const geoms: any[] = [];
+  const geoms: (Polygon | MultiPolygon)[] = [];
   flattenEach(geojson, (feature) => {
-    geoms.push(feature.geometry);
+    if (feature.geometry) geoms.push(feature.geometry);
   });
-  const topo: any = topology({ geoms: geometryCollection(geoms).geometry });
+
+  const collGeom = geometryCollection(geoms).geometry;
+  if (!collGeom) return null;
+
+  const topo: any = topology({ geoms: collGeom });
   const merged: any = merge(topo, topo.objects.geoms.geometries);
   return merged;
 }

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -174,7 +174,7 @@ export let areaFactors: any = {
  *
  * //=feature
  */
-export function feature<G extends GeometryObject = Geometries, P = Properties>(
+export function feature<G extends GeometryObject, P = Properties>(
   geom: G,
   properties?: P,
   options: { bbox?: BBox; id?: Id } = {}

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -66,8 +66,8 @@ export type Corners = "sw" | "se" | "nw" | "ne" | "center" | "centroid";
 
 export type Lines = LineString | MultiLineString | Polygon | MultiPolygon;
 export type AllGeoJSON =
-  | Feature<Geometries | GeometryCollection>
-  | FeatureCollection<Geometries | GeometryCollection>
+  | Feature
+  | FeatureCollection
   | Geometry
   | GeometryCollection;
 
@@ -174,7 +174,7 @@ export let areaFactors: any = {
  *
  * //=feature
  */
-export function feature<G extends GeometryObject, P = Properties>(
+export function feature<G extends Geometry | null = Geometry, P = Properties>(
   geom: G,
   properties?: P,
   options: { bbox?: BBox; id?: Id } = {}
@@ -466,7 +466,7 @@ export function lineStrings<P = Properties>(
  * //=collection
  */
 export function featureCollection<
-  G extends GeometryObject = Geometries,
+  G extends Geometry | null = Geometry,
   P = Properties
 >(
   features: Array<Feature<G, P>>,

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -66,8 +66,8 @@ export type Corners = "sw" | "se" | "nw" | "ne" | "center" | "centroid";
 
 export type Lines = LineString | MultiLineString | Polygon | MultiPolygon;
 export type AllGeoJSON =
-  | Feature
-  | FeatureCollection
+  | Feature<Geometries | GeometryCollection>
+  | FeatureCollection<Geometries | GeometryCollection>
   | Geometry
   | GeometryCollection;
 
@@ -174,7 +174,7 @@ export let areaFactors: any = {
  *
  * //=feature
  */
-export function feature<G = Geometry, P = Properties>(
+export function feature<G extends GeometryObject = Geometries, P = Properties>(
   geom: G,
   properties?: P,
   options: { bbox?: BBox; id?: Id } = {}
@@ -465,7 +465,10 @@ export function lineStrings<P = Properties>(
  *
  * //=collection
  */
-export function featureCollection<G = Geometry, P = Properties>(
+export function featureCollection<
+  G extends GeometryObject = Geometries,
+  P = Properties
+>(
   features: Array<Feature<G, P>>,
   options: { bbox?: BBox; id?: Id } = {}
 ): FeatureCollection<G, P> {

--- a/packages/turf-helpers/lib/geojson.ts
+++ b/packages/turf-helpers/lib/geojson.ts
@@ -7,7 +7,6 @@ import {
   MultiPolygon,
   Point,
   Polygon,
-  Position,
   GeoJsonTypes,
 } from "geojson";
 
@@ -15,6 +14,7 @@ export {
   BBox,
   Feature,
   FeatureCollection,
+  Geometry,
   GeometryCollection,
   GeometryObject,
   LineString,
@@ -26,7 +26,7 @@ export {
   Position,
 } from "geojson";
 
-// Export additional types for ease of use
+// Export additional types (historical).  These will be removed.
 
 // /**
 //  * GeometryTypes
@@ -54,19 +54,6 @@ export type CollectionTypes = "FeatureCollection" | "GeometryCollection";
 export type Types = "Feature" | GeometryTypes | CollectionTypes;
 
 // /**
-//  * Bounding box
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-5
-//  * A GeoJSON object MAY have a member named "bbox" to include information on the coordinate range for its Geometries, Features, or FeatureCollections.
-//  * The value of the bbox member MUST be an array of length 2*n where n is the number of dimensions represented in the contained geometries,
-//  * with all axes of the most southwesterly point followed by all axes of the more northeasterly point.
-//  * The axes order of a bbox follows the axes order of geometries.
-//  */
-// export type BBox2d = [number, number, number, number];
-// export type BBox3d = [number, number, number, number, number, number];
-// export type BBox = BBox2d | BBox3d;
-
-// /**
 //  * Id
 //  *
 //  * https://tools.ietf.org/html/rfc7946#section-3.2
@@ -74,16 +61,6 @@ export type Types = "Feature" | GeometryTypes | CollectionTypes;
 //  * the Feature object with the name "id", and the value of this member is either a JSON string or number.
 //  */
 export type Id = string | number;
-
-// /**
-//  * Position
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.1
-//  * Array should contain between two and three elements.
-//  * The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
-//  * but the current specification only allows X, Y, and (optionally) Z to be defined.
-//  */
-// export type Position = number[]; // [number, number] | [number, number, number];
 
 // /**
 //  * Properties
@@ -126,137 +103,3 @@ export interface GeoJSONObject {
    */
   bbox?: BBox;
 }
-
-// /**
-//  * Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3
-//  */
-// export interface GeometryObject extends GeoJSONObject {
-//   type: GeometryTypes;
-// }
-
-// /**
-//  * Geometry
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3
-//  */
-export interface Geometry extends GeoJSONObject {
-  coordinates: Position | Position[] | Position[][] | Position[][][];
-}
-
-// /**
-//  * Point Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.2
-//  */
-// export interface Point extends GeometryObject {
-//   type: "Point";
-//   coordinates: Position;
-// }
-
-// /**
-//  * MultiPoint Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.3
-//  */
-// export interface MultiPoint extends GeometryObject {
-//   type: "MultiPoint";
-//   coordinates: Position[];
-// }
-
-// /**
-//  * LineString Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.4
-//  */
-// export interface LineString extends GeometryObject {
-//   type: "LineString";
-//   coordinates: Position[];
-// }
-
-// /**
-//  * MultiLineString Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.5
-//  */
-// export interface MultiLineString extends GeometryObject {
-//   type: "MultiLineString";
-//   coordinates: Position[][];
-// }
-
-// /**
-//  * Polygon Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.6
-//  */
-// export interface Polygon extends GeometryObject {
-//   type: "Polygon";
-//   coordinates: Position[][];
-// }
-
-// /**
-//  * MultiPolygon Geometry Object
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.7
-//  */
-// export interface MultiPolygon extends GeometryObject {
-//   type: "MultiPolygon";
-//   coordinates: Position[][][];
-// }
-
-// /**
-//  * GeometryCollection
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.1.8
-//  *
-//  * A GeoJSON object with type "GeometryCollection" is a Geometry object.
-//  * A GeometryCollection has a member with the name "geometries".
-//  * The value of "geometries" is an array.  Each element of this array is a GeoJSON Geometry object.
-//  * It is possible for this array to be empty.
-//  */
-// export interface GeometryCollection extends GeometryObject {
-//   type: "GeometryCollection";
-//   geometries: Array<
-//     Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon
-//   >;
-// }
-
-// /**
-//  * Feature
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.2
-//  * A Feature object represents a spatially bounded thing.
-//  * Every Feature object is a GeoJSON object no matter where it occurs in a GeoJSON text.
-//  */
-// export interface Feature<G = Geometry | GeometryCollection, P = Properties>
-//   extends GeoJSONObject {
-//   type: "Feature";
-//   geometry: G;
-//   /**
-//    * A value that uniquely identifies this feature in a
-//    * https://tools.ietf.org/html/rfc7946#section-3.2.
-//    */
-//   id?: Id;
-//   /**
-//    * Properties associated with this feature.
-//    */
-//   properties: P;
-// }
-
-// /**
-//  * Feature Collection
-//  *
-//  * https://tools.ietf.org/html/rfc7946#section-3.3
-//  * A GeoJSON object with the type "FeatureCollection" is a FeatureCollection object.
-//  * A FeatureCollection object has a member with the name "features".
-//  * The value of "features" is a JSON array. Each element of the array is a Feature object as defined above.
-//  * It is possible for this array to be empty.
-//  */
-// export interface FeatureCollection<
-//   G = Geometry | GeometryCollection,
-//   P = Properties
-// > extends GeoJSONObject {
-//   type: "FeatureCollection";
-//   features: Array<Feature<G, P>>;
-// }

--- a/packages/turf-helpers/lib/geojson.ts
+++ b/packages/turf-helpers/lib/geojson.ts
@@ -8,6 +8,7 @@ import {
   Point,
   Polygon,
   Position,
+  GeoJsonTypes,
 } from "geojson";
 
 export {
@@ -118,7 +119,7 @@ export interface GeoJSONObject {
   /**
    * Specifies the type of GeoJSON object.
    */
-  type: string;
+  type: GeoJsonTypes;
   /**
    * Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections.
    * https://tools.ietf.org/html/rfc7946#section-5

--- a/packages/turf-helpers/lib/geojson.ts
+++ b/packages/turf-helpers/lib/geojson.ts
@@ -1,22 +1,38 @@
-// Type definitions for geojson 7946.0
-// Project: https://geojson.org/
-// Definitions by: Jacob Bruun <https://github.com/cobster>
-//                 Arne Schubert <https://github.com/atd-schubert>
-//                 Jeff Jacobson <https://github.com/JeffJacobson>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// Use @types/geojson as foundation
+import {
+  BBox,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon,
+  Position,
+} from "geojson";
 
-// Note: as of the RFC 7946 version of GeoJSON, Coordinate Reference Systems
-// are no longer supported. (See https://tools.ietf.org/html/rfc7946#appendix-B)}
+export {
+  BBox,
+  Feature,
+  FeatureCollection,
+  GeometryCollection,
+  GeometryObject,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon,
+  Position,
+} from "geojson";
 
-// export as namespace GeoJSON;
+// Export additional types for ease of use
 
-/**
- * GeometryTypes
- *
- * https://tools.ietf.org/html/rfc7946#section-1.4
- * The valid values for the "type" property of GeoJSON geometry objects.
- */
+// /**
+//  * GeometryTypes
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-1.4
+//  * The valid values for the "type" property of GeoJSON geometry objects.
+//  */
 export type GeometryTypes =
   | "Point"
   | "LineString"
@@ -28,58 +44,58 @@ export type GeometryTypes =
 
 export type CollectionTypes = "FeatureCollection" | "GeometryCollection";
 
-/**
- * Types
- *
- * https://tools.ietf.org/html/rfc7946#section-1.4
- * The value values for the "type" property of GeoJSON Objects.
- */
+// /**
+//  * Types
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-1.4
+//  * The value values for the "type" property of GeoJSON Objects.
+//  */
 export type Types = "Feature" | GeometryTypes | CollectionTypes;
 
-/**
- * Bounding box
- *
- * https://tools.ietf.org/html/rfc7946#section-5
- * A GeoJSON object MAY have a member named "bbox" to include information on the coordinate range for its Geometries, Features, or FeatureCollections.
- * The value of the bbox member MUST be an array of length 2*n where n is the number of dimensions represented in the contained geometries,
- * with all axes of the most southwesterly point followed by all axes of the more northeasterly point.
- * The axes order of a bbox follows the axes order of geometries.
- */
-export type BBox2d = [number, number, number, number];
-export type BBox3d = [number, number, number, number, number, number];
-export type BBox = BBox2d | BBox3d;
+// /**
+//  * Bounding box
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-5
+//  * A GeoJSON object MAY have a member named "bbox" to include information on the coordinate range for its Geometries, Features, or FeatureCollections.
+//  * The value of the bbox member MUST be an array of length 2*n where n is the number of dimensions represented in the contained geometries,
+//  * with all axes of the most southwesterly point followed by all axes of the more northeasterly point.
+//  * The axes order of a bbox follows the axes order of geometries.
+//  */
+// export type BBox2d = [number, number, number, number];
+// export type BBox3d = [number, number, number, number, number, number];
+// export type BBox = BBox2d | BBox3d;
 
-/**
- * Id
- *
- * https://tools.ietf.org/html/rfc7946#section-3.2
- * If a Feature has a commonly used identifier, that identifier SHOULD be included as a member of
- * the Feature object with the name "id", and the value of this member is either a JSON string or number.
- */
+// /**
+//  * Id
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.2
+//  * If a Feature has a commonly used identifier, that identifier SHOULD be included as a member of
+//  * the Feature object with the name "id", and the value of this member is either a JSON string or number.
+//  */
 export type Id = string | number;
 
-/**
- * Position
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.1
- * Array should contain between two and three elements.
- * The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
- * but the current specification only allows X, Y, and (optionally) Z to be defined.
- */
-export type Position = number[]; // [number, number] | [number, number, number];
+// /**
+//  * Position
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.1
+//  * Array should contain between two and three elements.
+//  * The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
+//  * but the current specification only allows X, Y, and (optionally) Z to be defined.
+//  */
+// export type Position = number[]; // [number, number] | [number, number, number];
 
-/**
- * Properties
- *
- * https://tools.ietf.org/html/rfc7946#section-3.2
- * A Feature object has a member with the name "properties".
- * The value of the properties member is an object (any JSON object or a JSON null value).
- */
+// /**
+//  * Properties
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.2
+//  * A Feature object has a member with the name "properties".
+//  * The value of the properties member is an object (any JSON object or a JSON null value).
+//  */
 export type Properties = { [name: string]: any } | null;
 
-/**
- * Geometries
- */
+// /**
+//  * Geometries
+//  */
 export type Geometries =
   | Point
   | LineString
@@ -88,13 +104,13 @@ export type Geometries =
   | MultiLineString
   | MultiPolygon;
 
-/**
- * GeoJSON Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3
- * The GeoJSON specification also allows [foreign members](https://tools.ietf.org/html/rfc7946#section-6.1)
- * Developers should use "&" type in TypeScript or extend the interface to add these foreign members.
- */
+// /**
+//  * GeoJSON Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3
+//  * The GeoJSON specification also allows [foreign members](https://tools.ietf.org/html/rfc7946#section-6.1)
+//  * Developers should use "&" type in TypeScript or extend the interface to add these foreign members.
+//  */
 export interface GeoJSONObject {
   // Don't include foreign members directly into this type def.
   // in order to preserve type safety.
@@ -110,136 +126,136 @@ export interface GeoJSONObject {
   bbox?: BBox;
 }
 
-/**
- * Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3
- */
-export interface GeometryObject extends GeoJSONObject {
-  type: GeometryTypes;
-}
+// /**
+//  * Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3
+//  */
+// export interface GeometryObject extends GeoJSONObject {
+//   type: GeometryTypes;
+// }
 
-/**
- * Geometry
- *
- * https://tools.ietf.org/html/rfc7946#section-3
- */
+// /**
+//  * Geometry
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3
+//  */
 export interface Geometry extends GeoJSONObject {
   coordinates: Position | Position[] | Position[][] | Position[][][];
 }
 
-/**
- * Point Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.2
- */
-export interface Point extends GeometryObject {
-  type: "Point";
-  coordinates: Position;
-}
+// /**
+//  * Point Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.2
+//  */
+// export interface Point extends GeometryObject {
+//   type: "Point";
+//   coordinates: Position;
+// }
 
-/**
- * MultiPoint Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.3
- */
-export interface MultiPoint extends GeometryObject {
-  type: "MultiPoint";
-  coordinates: Position[];
-}
+// /**
+//  * MultiPoint Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.3
+//  */
+// export interface MultiPoint extends GeometryObject {
+//   type: "MultiPoint";
+//   coordinates: Position[];
+// }
 
-/**
- * LineString Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.4
- */
-export interface LineString extends GeometryObject {
-  type: "LineString";
-  coordinates: Position[];
-}
+// /**
+//  * LineString Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.4
+//  */
+// export interface LineString extends GeometryObject {
+//   type: "LineString";
+//   coordinates: Position[];
+// }
 
-/**
- * MultiLineString Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.5
- */
-export interface MultiLineString extends GeometryObject {
-  type: "MultiLineString";
-  coordinates: Position[][];
-}
+// /**
+//  * MultiLineString Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.5
+//  */
+// export interface MultiLineString extends GeometryObject {
+//   type: "MultiLineString";
+//   coordinates: Position[][];
+// }
 
-/**
- * Polygon Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.6
- */
-export interface Polygon extends GeometryObject {
-  type: "Polygon";
-  coordinates: Position[][];
-}
+// /**
+//  * Polygon Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.6
+//  */
+// export interface Polygon extends GeometryObject {
+//   type: "Polygon";
+//   coordinates: Position[][];
+// }
 
-/**
- * MultiPolygon Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.7
- */
-export interface MultiPolygon extends GeometryObject {
-  type: "MultiPolygon";
-  coordinates: Position[][][];
-}
+// /**
+//  * MultiPolygon Geometry Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.7
+//  */
+// export interface MultiPolygon extends GeometryObject {
+//   type: "MultiPolygon";
+//   coordinates: Position[][][];
+// }
 
-/**
- * GeometryCollection
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.8
- *
- * A GeoJSON object with type "GeometryCollection" is a Geometry object.
- * A GeometryCollection has a member with the name "geometries".
- * The value of "geometries" is an array.  Each element of this array is a GeoJSON Geometry object.
- * It is possible for this array to be empty.
- */
-export interface GeometryCollection extends GeometryObject {
-  type: "GeometryCollection";
-  geometries: Array<
-    Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon
-  >;
-}
+// /**
+//  * GeometryCollection
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.1.8
+//  *
+//  * A GeoJSON object with type "GeometryCollection" is a Geometry object.
+//  * A GeometryCollection has a member with the name "geometries".
+//  * The value of "geometries" is an array.  Each element of this array is a GeoJSON Geometry object.
+//  * It is possible for this array to be empty.
+//  */
+// export interface GeometryCollection extends GeometryObject {
+//   type: "GeometryCollection";
+//   geometries: Array<
+//     Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon
+//   >;
+// }
 
-/**
- * Feature
- *
- * https://tools.ietf.org/html/rfc7946#section-3.2
- * A Feature object represents a spatially bounded thing.
- * Every Feature object is a GeoJSON object no matter where it occurs in a GeoJSON text.
- */
-export interface Feature<G = Geometry | GeometryCollection, P = Properties>
-  extends GeoJSONObject {
-  type: "Feature";
-  geometry: G;
-  /**
-   * A value that uniquely identifies this feature in a
-   * https://tools.ietf.org/html/rfc7946#section-3.2.
-   */
-  id?: Id;
-  /**
-   * Properties associated with this feature.
-   */
-  properties: P;
-}
+// /**
+//  * Feature
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.2
+//  * A Feature object represents a spatially bounded thing.
+//  * Every Feature object is a GeoJSON object no matter where it occurs in a GeoJSON text.
+//  */
+// export interface Feature<G = Geometry | GeometryCollection, P = Properties>
+//   extends GeoJSONObject {
+//   type: "Feature";
+//   geometry: G;
+//   /**
+//    * A value that uniquely identifies this feature in a
+//    * https://tools.ietf.org/html/rfc7946#section-3.2.
+//    */
+//   id?: Id;
+//   /**
+//    * Properties associated with this feature.
+//    */
+//   properties: P;
+// }
 
-/**
- * Feature Collection
- *
- * https://tools.ietf.org/html/rfc7946#section-3.3
- * A GeoJSON object with the type "FeatureCollection" is a FeatureCollection object.
- * A FeatureCollection object has a member with the name "features".
- * The value of "features" is a JSON array. Each element of the array is a Feature object as defined above.
- * It is possible for this array to be empty.
- */
-export interface FeatureCollection<
-  G = Geometry | GeometryCollection,
-  P = Properties
-> extends GeoJSONObject {
-  type: "FeatureCollection";
-  features: Array<Feature<G, P>>;
-}
+// /**
+//  * Feature Collection
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.3
+//  * A GeoJSON object with the type "FeatureCollection" is a FeatureCollection object.
+//  * A FeatureCollection object has a member with the name "features".
+//  * The value of "features" is a JSON array. Each element of the array is a Feature object as defined above.
+//  * It is possible for this array to be empty.
+//  */
+// export interface FeatureCollection<
+//   G = Geometry | GeometryCollection,
+//   P = Properties
+// > extends GeoJSONObject {
+//   type: "FeatureCollection";
+//   features: Array<Feature<G, P>>;
+// }

--- a/packages/turf-helpers/types.ts
+++ b/packages/turf-helpers/types.ts
@@ -38,7 +38,7 @@ const poly = polygon([
     [0, 1],
   ],
 ]);
-const feat = feature({ coordinates: [1, 0], type: "point" });
+const feat = feature({ coordinates: [1, 0], type: "Point" });
 const multiPt = multiPoint([
   [0, 1],
   [2, 3],
@@ -81,7 +81,7 @@ polygon([
     [0, 1],
   ],
 ]);
-feature({ coordinates: [1, 0], type: "point" });
+feature({ coordinates: [1, 0], type: "Point" });
 multiPoint([
   [0, 1],
   [2, 3],

--- a/packages/turf-intersect/index.ts
+++ b/packages/turf-intersect/index.ts
@@ -55,6 +55,8 @@ export default function intersect<P = Properties>(
   const geom1 = getGeom(poly1);
   const geom2 = getGeom(poly2);
 
+  if (!geom1 || !geom2) return null;
+
   const intersection = polygonClipping.intersection(
     geom1.coordinates as any,
     geom2.coordinates as any

--- a/packages/turf-intersect/index.ts
+++ b/packages/turf-intersect/index.ts
@@ -20,6 +20,7 @@ import polygonClipping from "polygon-clipping";
  * @param {Object} [options.properties={}] Translate GeoJSON Properties to Feature
  * @returns {Feature|null} returns a feature representing the area they share (either a {@link Polygon} or
  * {@link MultiPolygon}). If they do not share any area, returns `null`.
+ * @throws {Error} if input polygons are invalid
  * @example
  * var poly1 = turf.polygon([[
  *   [-122.801742, 45.48565],
@@ -55,7 +56,8 @@ export default function intersect<P = Properties>(
   const geom1 = getGeom(poly1);
   const geom2 = getGeom(poly2);
 
-  if (!geom1 || !geom2) return null;
+  if (geom1 === null || geom2 === null)
+    throw new Error("Input polygons must have non-null geometries");
 
   const intersection = polygonClipping.intersection(
     geom1.coordinates as any,

--- a/packages/turf-invariant/index.ts
+++ b/packages/turf-invariant/index.ts
@@ -45,7 +45,9 @@ export function getCoord(coord: Feature<Point> | Point | number[]): number[] {
     return coord;
   }
 
-  throw new Error("coord must be GeoJSON Point or an Array of numbers");
+  throw new Error(
+    "coord must be GeoJSON Point with non-null geometry or an Array of numbers"
+  );
 }
 
 /**

--- a/packages/turf-invariant/index.ts
+++ b/packages/turf-invariant/index.ts
@@ -13,6 +13,7 @@ import {
  * @name getCoord
  * @param {Array<number>|Geometry<Point>|Feature<Point>} coord GeoJSON Point or an Array of numbers
  * @returns {Array<number>} coordinates
+ * @throws if coord is invalid
  * @example
  * var pt = turf.point([10, 10]);
  *
@@ -46,7 +47,7 @@ export function getCoord(coord: Feature<Point> | Point | number[]): number[] {
   }
 
   throw new Error(
-    "coord must be GeoJSON Point with non-null geometry or an Array of numbers"
+    "coord must be a GeoJSON Point Feature with non-null geometry, a Point geometry or an Array of numbers"
   );
 }
 
@@ -56,6 +57,7 @@ export function getCoord(coord: Feature<Point> | Point | number[]): number[] {
  * @name getCoords
  * @param {Array<any>|Geometry|Feature} coords Feature, Geometry Object or an Array
  * @returns {Array<any>} coordinates
+ * @throws if coords are invalid
  * @example
  * var poly = turf.polygon([[[119.32, -8.7], [119.55, -8.69], [119.51, -8.54], [119.32, -8.7]]]);
  *
@@ -82,7 +84,7 @@ export function getCoords<G extends Geometries>(
   }
 
   throw new Error(
-    "coords must be GeoJSON Feature, Geometry Object or an Array"
+    "coords must be a GeoJSON Feature with non-null geometry, a Geometry, or an Array"
   );
 }
 

--- a/packages/turf-invariant/index.ts
+++ b/packages/turf-invariant/index.ts
@@ -235,7 +235,7 @@ export function collectionOf(
  */
 export function getGeom<G extends Geometries | GeometryCollection>(
   geojson: Feature<G> | G
-): G {
+): G | null {
   if (geojson.type === "Feature") {
     return geojson.geometry;
   }

--- a/packages/turf-invariant/test.js
+++ b/packages/turf-invariant/test.js
@@ -388,13 +388,13 @@ test("null geometries", (t) => {
   // t.throws(() => invariant.getGeom(null), /geojson is required/, 'getGeom => geojson is required');
   t.throws(
     () => invariant.getCoords(nullFeature),
-    /coords must be GeoJSON Feature, Geometry Object or an Array/,
-    "getCoords => coords must be GeoJSON Feature, Geometry Object or an Array"
+    /coords must be a GeoJSON Feature with non-null geometry, a Geometry, or an Array/,
+    "getCoords => coords must be a GeoJSON Feature with non-null geometry, a Geometry, or an Array"
   );
   t.throws(
     () => invariant.getCoord(nullFeature),
-    /coord must be GeoJSON Point or an Array of numbers/,
-    "getCoord => coord must be GeoJSON Point or an Array of numbers"
+    /coord must be a GeoJSON Point Feature with non-null geometry, a Point geometry or an Array of numbers/,
+    "getCoord => coord must be a GeoJSON Point Feature with non-null geometry, a Point geometry or an Array of numbers"
   );
 
   // t.equal(invariant.getGeom(nullFeature), null, 'getGeom => null');

--- a/packages/turf-length/index.ts
+++ b/packages/turf-length/index.ts
@@ -33,8 +33,9 @@ export default function length(
   return segmentReduce(
     geojson,
     (previousValue, segment) => {
-      const coords = segment!.geometry.coordinates;
-      return previousValue! + distance(coords[0], coords[1], options);
+      const coords = segment?.geometry?.coordinates;
+      if (!coords) return previousValue;
+      return previousValue + distance(coords[0], coords[1], options);
     },
     0
   );

--- a/packages/turf-line-to-polygon/index.ts
+++ b/packages/turf-line-to-polygon/index.ts
@@ -11,6 +11,7 @@ import {
   Properties,
   BBox,
   Position,
+  Polygon,
 } from "@turf/helpers";
 import clone from "@turf/clone";
 
@@ -81,17 +82,17 @@ function lineStringToPolygon<G extends LineString | MultiLineString>(
   properties: Properties | undefined,
   autoComplete: boolean,
   orderCoords: boolean
-) {
+): Feature<Polygon> {
   properties = properties
     ? properties
     : line.type === "Feature"
     ? line.properties
     : {};
   var geom = getGeom(line);
+  if (!geom || !geom.coordinates || !geom.coordinates.length)
+    throw new Error("line must contain geometry with coordinates");
   var coords: Position[] | Position[][] = geom.coordinates;
   var type = geom.type;
-
-  if (!coords.length) throw new Error("line must contain coordinates");
 
   switch (type) {
     case "LineString":

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -206,7 +206,7 @@ export function segmentReduce<Reducer extends any, P = Properties>(
     | Feature<GeometryCollection, P>
     | GeometryCollection,
   callback: (
-    previousValue?: Reducer,
+    previousValue: Reducer,
     currentSegment?: Feature<LineString, P>,
     featureIndex?: number,
     multiFeatureIndex?: number,

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -95,7 +95,7 @@ export function featureReduce<
 /**
  * http://turfjs.org/docs/#featureeach
  */
-export function featureEach<G extends any, P = Properties>(
+export function featureEach<G extends GeometryObject, P = Properties>(
   geojson:
     | Feature<G, P>
     | FeatureCollection<G, P>
@@ -136,7 +136,7 @@ export function geomReduce<
 /**
  * http://turfjs.org/docs/#geomeach
  */
-export function geomEach<G extends Geometries | null, P = Properties>(
+export function geomEach<G extends GeometryObject, P = Properties>(
   geojson:
     | Feature<G, P>
     | FeatureCollection<G, P>
@@ -178,7 +178,10 @@ export function flattenReduce<
 /**
  * http://turfjs.org/docs/#flatteneach
  */
-export function flattenEach<G = Geometries, P = Properties>(
+export function flattenEach<
+  G extends GeometryObject = Geometries,
+  P = Properties
+>(
   geojson:
     | Feature<G, P>
     | FeatureCollection<G, P>

--- a/packages/turf-meta/index.js
+++ b/packages/turf-meta/index.js
@@ -12,7 +12,7 @@ import { feature, point, lineString, isObject } from "@turf/helpers";
  */
 
 /**
- * Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
+ * Iterate over coordinates in any GeoJSON object, similar to Array.forEach().  Skips null geometries
  *
  * @name coordEach
  * @param {FeatureCollection|Feature|Geometry} geojson any GeoJSON object
@@ -488,7 +488,7 @@ export function coordAll(geojson) {
  *
  * @name geomEach
  * @param {FeatureCollection|Feature|Geometry} geojson any GeoJSON object
- * @param {Function} callback a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
+ * @param {Function} callback a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId).  If currentGeometry is null, caller controls what happens next.  Returning true will continue the loop, false will exit.
  * @returns {void}
  * @example
  * var features = turf.featureCollection([

--- a/packages/turf-polygon-to-line/index.ts
+++ b/packages/turf-polygon-to-line/index.ts
@@ -12,7 +12,7 @@ import { getGeom } from "@turf/invariant";
 
 /**
  * Converts a {@link Polygon} to {@link LineString|(Multi)LineString} or {@link MultiPolygon} to a
- * {@link FeatureCollection} of {@link LineString|(Multi)LineString}.  Returns null if Feature geometry is null.
+ * {@link FeatureCollection} of {@link LineString|(Multi)LineString}.
  *
  * @name polygonToLine
  * @param {Feature<Polygon|MultiPolygon>} poly Feature to convert

--- a/packages/turf-polygon-to-line/index.ts
+++ b/packages/turf-polygon-to-line/index.ts
@@ -19,6 +19,7 @@ import { getGeom } from "@turf/invariant";
  * @param {Object} [options={}] Optional parameters
  * @param {Object} [options.properties={}] translates GeoJSON properties to Feature
  * @returns {FeatureCollection|Feature<LineString|MultiLinestring>} converted (Multi)Polygon to (Multi)LineString
+ * @throws {Error} if input polygon has null geometry
  * @example
  * var poly = turf.polygon([[[125, -30], [145, -30], [145, -20], [125, -20], [125, -30]]]);
  *

--- a/packages/turf-polygon-to-line/index.ts
+++ b/packages/turf-polygon-to-line/index.ts
@@ -12,7 +12,7 @@ import { getGeom } from "@turf/invariant";
 
 /**
  * Converts a {@link Polygon} to {@link LineString|(Multi)LineString} or {@link MultiPolygon} to a
- * {@link FeatureCollection} of {@link LineString|(Multi)LineString}.
+ * {@link FeatureCollection} of {@link LineString|(Multi)LineString}.  Returns null if Feature geometry is null.
  *
  * @name polygonToLine
  * @param {Feature<Polygon|MultiPolygon>} poly Feature to convert
@@ -32,7 +32,8 @@ export default function <G extends Polygon | MultiPolygon, P = Properties>(
   options: { properties?: any } = {}
 ):
   | Feature<LineString | MultiLineString, P>
-  | FeatureCollection<LineString | MultiLineString, P> {
+  | FeatureCollection<LineString | MultiLineString, P>
+  | null {
   const geom: any = getGeom(poly);
   if (!options.properties && poly.type === "Feature") {
     options.properties = poly.properties;
@@ -53,8 +54,9 @@ export default function <G extends Polygon | MultiPolygon, P = Properties>(
 export function polygonToLine<G extends Polygon, P = Properties>(
   poly: Feature<G, P> | G,
   options: { properties?: any } = {}
-): Feature<LineString | MultiLineString, P> {
+): Feature<LineString | MultiLineString, P> | null {
   const geom = getGeom(poly);
+  if (!geom) return null;
   const coords: any[] = geom.coordinates;
   const properties: any = options.properties
     ? options.properties
@@ -71,8 +73,9 @@ export function polygonToLine<G extends Polygon, P = Properties>(
 export function multiPolygonToLine<G extends MultiPolygon, P = Properties>(
   multiPoly: Feature<G, P> | G,
   options: { properties?: P } = {}
-): FeatureCollection<LineString | MultiLineString, P> {
+): FeatureCollection<LineString | MultiLineString, P> | null {
   const geom = getGeom(multiPoly);
+  if (!geom) return null;
   const coords: any[] = geom.coordinates;
   const properties: any = options.properties
     ? options.properties

--- a/packages/turf-polygon-to-line/index.ts
+++ b/packages/turf-polygon-to-line/index.ts
@@ -32,9 +32,9 @@ export default function <G extends Polygon | MultiPolygon, P = Properties>(
   options: { properties?: any } = {}
 ):
   | Feature<LineString | MultiLineString, P>
-  | FeatureCollection<LineString | MultiLineString, P>
-  | null {
+  | FeatureCollection<LineString | MultiLineString, P> {
   const geom: any = getGeom(poly);
+  if (geom === null) throw new Error("Input polygon must have a geometry");
   if (!options.properties && poly.type === "Feature") {
     options.properties = poly.properties;
   }
@@ -54,9 +54,9 @@ export default function <G extends Polygon | MultiPolygon, P = Properties>(
 export function polygonToLine<G extends Polygon, P = Properties>(
   poly: Feature<G, P> | G,
   options: { properties?: any } = {}
-): Feature<LineString | MultiLineString, P> | null {
+): Feature<LineString | MultiLineString, P> {
   const geom = getGeom(poly);
-  if (!geom) return null;
+  if (geom === null) throw new Error("Input polygon must have a geometry");
   const coords: any[] = geom.coordinates;
   const properties: any = options.properties
     ? options.properties
@@ -73,9 +73,9 @@ export function polygonToLine<G extends Polygon, P = Properties>(
 export function multiPolygonToLine<G extends MultiPolygon, P = Properties>(
   multiPoly: Feature<G, P> | G,
   options: { properties?: P } = {}
-): FeatureCollection<LineString | MultiLineString, P> | null {
+): FeatureCollection<LineString | MultiLineString, P> {
   const geom = getGeom(multiPoly);
-  if (!geom) return null;
+  if (geom === null) throw new Error("Input polygon must have a geometry");
   const coords: any[] = geom.coordinates;
   const properties: any = options.properties
     ? options.properties

--- a/packages/turf-polygonize/lib/util.ts
+++ b/packages/turf-polygonize/lib/util.ts
@@ -38,7 +38,8 @@ export function orientationIndex(p1: number[], p2: number[], q: number[]) {
  *
  * @param {Feature<Polygon>} env1 - Envelope
  * @param {Feature<Polygon>} env2 - Envelope
- * @returns {boolean} - True if the envelopes are equal, False if they are not equal, null if a geometry is missing a
+ * @returns {boolean} - True if the envelopes are equal, False if they are not equal
+ * @throws {Error} - if input features have a null geometry
  */
 export function envelopeIsEqual(
   env1: Feature<Polygon>,

--- a/packages/turf-polygonize/lib/util.ts
+++ b/packages/turf-polygonize/lib/util.ts
@@ -38,12 +38,15 @@ export function orientationIndex(p1: number[], p2: number[], q: number[]) {
  *
  * @param {Feature<Polygon>} env1 - Envelope
  * @param {Feature<Polygon>} env2 - Envelope
- * @returns {boolean} - True if the envelopes are equal
+ * @returns {boolean} - True if the envelopes are equal, False if they are not equal, null if a geometry is missing a
  */
 export function envelopeIsEqual(
   env1: Feature<Polygon>,
   env2: Feature<Polygon>
 ) {
+  if (env1.geometry === null || env2.geometry === null)
+    throw new Error("Input geometries must not be null");
+
   const envX1 = env1.geometry.coordinates[0].map((c) => c[0]),
     envY1 = env1.geometry.coordinates[0].map((c) => c[1]),
     envX2 = env2.geometry.coordinates[0].map((c) => c[0]),
@@ -72,6 +75,8 @@ export function envelopeContains(
   self: Feature<Polygon>,
   env: Feature<Polygon>
 ) {
+  if (env.geometry === null || self.geometry === null)
+    throw new Error("Input geometries must not be null");
   return env.geometry.coordinates[0].every((c) =>
     booleanPointInPolygon(point(c), self)
   );

--- a/packages/turf-tin/index.ts
+++ b/packages/turf-tin/index.ts
@@ -69,18 +69,17 @@ export default function tin(
     tinPoints.push(point);
   });
   return featureCollection(
-    triangulate(tinPoints).map((triangle: any) => {
+    triangulate(tinPoints).map((triangle) => {
       const a = [triangle.a.x, triangle.a.y];
       const b = [triangle.b.x, triangle.b.y];
       const c = [triangle.c.x, triangle.c.y];
       let properties = {};
-
       // Add z coordinates to triangle points if user passed
       // them in that way otherwise add it as a property.
       if (isPointZ) {
-        a.push(triangle.a.z);
-        b.push(triangle.b.z);
-        c.push(triangle.c.z);
+        a.push(triangle.a.z!);
+        b.push(triangle.b.z!);
+        c.push(triangle.c.z!);
       } else {
         properties = {
           a: triangle.a.z,

--- a/packages/turf-tin/index.ts
+++ b/packages/turf-tin/index.ts
@@ -53,7 +53,7 @@ export default function tin(
 ): FeatureCollection<Polygon> {
   // break down points
   let isPointZ = false;
-  let tinPoints: Pt[] = [];
+  const tinPoints: Pt[] = [];
   geomEach(points, (geom, index, properties) => {
     if (!geom) return true; // skip
     const point: Pt = {

--- a/packages/turf-transform-rotate/test.js
+++ b/packages/turf-transform-rotate/test.js
@@ -55,8 +55,8 @@ test("rotate -- throws", (t) => {
   t.throws(() => rotate(line, null), /angle is required/, "missing angle");
   t.throws(
     () => rotate(line, 56, { pivot: "notApoint" }),
-    /coord must be GeoJSON Point or an Array of numbers/,
-    "coord must be GeoJSON Point or an Array of numbers"
+    /coord must be a GeoJSON Point Feature with non-null geometry, a Point geometry or an Array of numbers/,
+    "coord must be a GeoJSON Point Feature with non-null geometry, a Point geometry or an Array of numbers"
   );
   t.end();
 });

--- a/packages/turf-union/index.ts
+++ b/packages/turf-union/index.ts
@@ -41,7 +41,8 @@ function union<P = Properties>(
   const geom1 = getGeom(poly1);
   const geom2 = getGeom(poly2);
 
-  if (geom1 === null || geom2 === null) return null;
+  if (geom1 === null || geom2 === null)
+    throw new Error("Input features must have non-null geometry");
 
   const unioned = polygonClipping.union(
     geom1.coordinates as any,

--- a/packages/turf-union/index.ts
+++ b/packages/turf-union/index.ts
@@ -41,6 +41,8 @@ function union<P = Properties>(
   const geom1 = getGeom(poly1);
   const geom2 = getGeom(poly2);
 
+  if (geom1 === null || geom2 === null) return null;
+
   const unioned = polygonClipping.union(
     geom1.coordinates as any,
     geom2.coordinates as any

--- a/packages/turf-union/test.js
+++ b/packages/turf-union/test.js
@@ -36,7 +36,7 @@ test("union", function (t) {
   t.end();
 });
 
-test("union - null geom", function (t) {
+test("union - null feature geom", function (t) {
   const geom1 = {
     type: "Feature",
     properties: {},
@@ -58,10 +58,12 @@ test("union - null geom", function (t) {
       ],
     ],
   };
-  const result = union(geom1, geom2);
-  t.equal(result, null);
+  t.throws(() => {
+    union(geom1, geom2);
+  });
 
-  const result2 = union(geom1, geom3);
-  t.equal(result2, null);
+  t.throws(() => {
+    union(geom1, geom3);
+  });
   t.end();
 });

--- a/packages/turf-union/test.js
+++ b/packages/turf-union/test.js
@@ -35,3 +35,33 @@ test("union", function (t) {
   }
   t.end();
 });
+
+test("union - null geom", function (t) {
+  const geom1 = {
+    type: "Feature",
+    properties: {},
+    geometry: null,
+  };
+  const geom2 = {
+    type: "Feature",
+    properties: {},
+    geometry: null,
+  };
+  const geom3 = {
+    type: "Polygon",
+    coordinates: [
+      [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 0],
+      ],
+    ],
+  };
+  const result = union(geom1, geom2);
+  t.equal(result, null);
+
+  const result2 = union(geom1, geom3);
+  t.equal(result2, null);
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,11 @@
   version "7946.0.1"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.1.tgz#1fc41280e42f08f0d568401a556bc97c34f5262e"
 
+"@types/geojson@7946.0.8":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"


### PR DESCRIPTION
This PR refactors the geojson types to build on @types/geojson.

After some study, it's clear that for the most part Turf's internal geojson types are a copy of the `geojson` package, with some additions.  Where there are differences, we need either adapt the Turf code to use the new types or potentially contribute a change to @types/geojson.

Strategy:
- [x] Leave `packages/turf-helpers/lib/geojson.ts` in place as the exporter of base types for use in Turf.
- [x] Switch it to re-export base types from `geojson` package.
- [x] Keep any type additions that Turf has come to use over time (that aren't found in geojson package).  These will get dropped in a follow-on PR.
- [x] See what code breaks with the type changes and fix them. Keep blast radius small.
  - [x] features/feature collections with null geometry must now be supported.  Strategy - if function can intelligently handle it, then do so, otherwise throw with a good error message, because the code would have thrown before anyway, just with no clear error message.
- [x] Pin turf to the latest version of @types/geojson instead of '*'

Resolves #1658

Checklist:
- [ ] add docs for how *Each functions handle null geometries (e.g. coordEach, geomEach).  There is useful handling already in place!
- [ ] Add new turf sub-dependencies to package.json for packages that pick up new ones
- [ ] Add tests with null geometry to changed packages
- [ ] verify jsdocs are updated, particularly throws

Follow-on tasks to research/ticket (as observed):
- some function types don't carry on the support for null, even though the base feature/featurecollection generic do, surprised it's not complaining -- `export function featureEach<G extends GeometryObject, P = Properties>(`
- [geojson-rbush](https://github.com/DenisCarriere/geojson-rbush) package is used by multiple turf packages, which in turn imports turf types. geojson-rbush should decouple and migrate to @types/geojson.
- feature() should accept a null geometry parameter so that people can create them
- make function parameter names more accurate, at times they are overly generic or specific to what it currently accepts.  polygonDissolve(geojson), getCoord(coord).
- resolve remaining use of `any` in Typescript function signatures

----
Observations on handling features with null geometry. Conclusion - it's not exactly consistent but there is some support.  There is little documentation of null behavior.
- some Turf functions will return null if a null geometry is encountered and it can't continue or return a useful result
- some utility functions like `lineToPolygon`, `getCoord` will throw an error if null geometry encountered.  Users of this function will thus also throw - `centerOfMass`
- `coordEach` will skip null geometries
- `geomEach` will make the callback and let the user handle null geometry, and whether to keep looping
