### PR TITLE
Migrate to @types/geojson package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "devDependencies": {
-    "@types/geojson": "*",
+    "@types/geojson": "7946.0.8",
     "@types/node": "*",
     "@typescript-eslint/eslint-plugin": "^4.8.0",
     "@typescript-eslint/parser": "^4.8.0",

--- a/packages/turf-clusters/index.ts
+++ b/packages/turf-clusters/index.ts
@@ -1,5 +1,10 @@
 import { featureEach } from "@turf/meta";
-import { featureCollection, Feature, FeatureCollection } from "@turf/helpers";
+import {
+  featureCollection,
+  Feature,
+  FeatureCollection,
+  GeometryObject,
+} from "@turf/helpers";
 
 /**
  * Get Cluster
@@ -30,7 +35,7 @@ import { featureCollection, Feature, FeatureCollection } from "@turf/helpers";
  * turf.getCluster(clustered, {'marker-symbol': 'square'}).length;
  * //= 1
  */
-export function getCluster<G extends any, P = any>(
+export function getCluster<G extends GeometryObject, P = any>(
   geojson: FeatureCollection<G, P>,
   filter: any
 ): FeatureCollection<G, P> {
@@ -98,7 +103,7 @@ export function getCluster<G extends any, P = any>(
  *     values.push(clusterValue);
  * });
  */
-export function clusterEach<G = any, P = any>(
+export function clusterEach<G extends GeometryObject, P = any>(
   geojson: FeatureCollection<G, P>,
   property: number | string,
   callback: (
@@ -192,7 +197,7 @@ export function clusterEach<G = any, P = any>(
  *     return previousValue.concat(clusterValue);
  * }, []);
  */
-export function clusterReduce<G = any, P = any>(
+export function clusterReduce<G extends GeometryObject, P = any>(
   geojson: FeatureCollection<G, P>,
   property: number | string,
   callback: (

--- a/packages/turf-combine/index.ts
+++ b/packages/turf-combine/index.ts
@@ -87,7 +87,10 @@ function combine(
       })
       .sort()
       .map(function (key) {
-        var geometry = { type: key, coordinates: groups[key].coordinates };
+        var geometry = { type: key, coordinates: groups[key].coordinates } as
+          | MultiPoint
+          | MultiLineString
+          | MultiPolygon;
         var properties = { collectedProperties: groups[key].properties };
         return feature(geometry, properties);
       })

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -174,7 +174,7 @@ export let areaFactors: any = {
  *
  * //=feature
  */
-export function feature<G = Geometry, P = Properties>(
+export function feature<G extends GeometryObject = Geometry, P = Properties>(
   geom: G,
   properties?: P,
   options: { bbox?: BBox; id?: Id } = {}
@@ -465,7 +465,10 @@ export function lineStrings<P = Properties>(
  *
  * //=collection
  */
-export function featureCollection<G = Geometry, P = Properties>(
+export function featureCollection<
+  G extends GeometryObject = Geometry,
+  P = Properties
+>(
   features: Array<Feature<G, P>>,
   options: { bbox?: BBox; id?: Id } = {}
 ): FeatureCollection<G, P> {

--- a/packages/turf-helpers/lib/geojson.ts
+++ b/packages/turf-helpers/lib/geojson.ts
@@ -1,22 +1,39 @@
-// Type definitions for geojson 7946.0
-// Project: https://geojson.org/
-// Definitions by: Jacob Bruun <https://github.com/cobster>
-//                 Arne Schubert <https://github.com/atd-schubert>
-//                 Jeff Jacobson <https://github.com/JeffJacobson>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// Use @types/geojson as foundation
+import {
+  BBox,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon,
+  GeoJsonTypes,
+} from "geojson";
 
-// Note: as of the RFC 7946 version of GeoJSON, Coordinate Reference Systems
-// are no longer supported. (See https://tools.ietf.org/html/rfc7946#appendix-B)}
+export {
+  BBox,
+  Feature,
+  FeatureCollection,
+  Geometry,
+  GeometryCollection,
+  GeometryObject,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon,
+  Position,
+} from "geojson";
 
-// export as namespace GeoJSON;
+// Export additional types (historical).  These will be removed.
 
-/**
- * GeometryTypes
- *
- * https://tools.ietf.org/html/rfc7946#section-1.4
- * The valid values for the "type" property of GeoJSON geometry objects.
- */
+// /**
+//  * GeometryTypes
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-1.4
+//  * The valid values for the "type" property of GeoJSON geometry objects.
+//  */
 export type GeometryTypes =
   | "Point"
   | "LineString"
@@ -28,58 +45,35 @@ export type GeometryTypes =
 
 export type CollectionTypes = "FeatureCollection" | "GeometryCollection";
 
-/**
- * Types
- *
- * https://tools.ietf.org/html/rfc7946#section-1.4
- * The value values for the "type" property of GeoJSON Objects.
- */
+// /**
+//  * Types
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-1.4
+//  * The value values for the "type" property of GeoJSON Objects.
+//  */
 export type Types = "Feature" | GeometryTypes | CollectionTypes;
 
-/**
- * Bounding box
- *
- * https://tools.ietf.org/html/rfc7946#section-5
- * A GeoJSON object MAY have a member named "bbox" to include information on the coordinate range for its Geometries, Features, or FeatureCollections.
- * The value of the bbox member MUST be an array of length 2*n where n is the number of dimensions represented in the contained geometries,
- * with all axes of the most southwesterly point followed by all axes of the more northeasterly point.
- * The axes order of a bbox follows the axes order of geometries.
- */
-export type BBox2d = [number, number, number, number];
-export type BBox3d = [number, number, number, number, number, number];
-export type BBox = BBox2d | BBox3d;
-
-/**
- * Id
- *
- * https://tools.ietf.org/html/rfc7946#section-3.2
- * If a Feature has a commonly used identifier, that identifier SHOULD be included as a member of
- * the Feature object with the name "id", and the value of this member is either a JSON string or number.
- */
+// /**
+//  * Id
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.2
+//  * If a Feature has a commonly used identifier, that identifier SHOULD be included as a member of
+//  * the Feature object with the name "id", and the value of this member is either a JSON string or number.
+//  */
 export type Id = string | number;
 
-/**
- * Position
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.1
- * Array should contain between two and three elements.
- * The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
- * but the current specification only allows X, Y, and (optionally) Z to be defined.
- */
-export type Position = number[]; // [number, number] | [number, number, number];
-
-/**
- * Properties
- *
- * https://tools.ietf.org/html/rfc7946#section-3.2
- * A Feature object has a member with the name "properties".
- * The value of the properties member is an object (any JSON object or a JSON null value).
- */
+// /**
+//  * Properties
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3.2
+//  * A Feature object has a member with the name "properties".
+//  * The value of the properties member is an object (any JSON object or a JSON null value).
+//  */
 export type Properties = { [name: string]: any } | null;
 
-/**
- * Geometries
- */
+// /**
+//  * Geometries
+//  */
 export type Geometries =
   | Point
   | LineString
@@ -88,13 +82,13 @@ export type Geometries =
   | MultiLineString
   | MultiPolygon;
 
-/**
- * GeoJSON Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3
- * The GeoJSON specification also allows [foreign members](https://tools.ietf.org/html/rfc7946#section-6.1)
- * Developers should use "&" type in TypeScript or extend the interface to add these foreign members.
- */
+// /**
+//  * GeoJSON Object
+//  *
+//  * https://tools.ietf.org/html/rfc7946#section-3
+//  * The GeoJSON specification also allows [foreign members](https://tools.ietf.org/html/rfc7946#section-6.1)
+//  * Developers should use "&" type in TypeScript or extend the interface to add these foreign members.
+//  */
 export interface GeoJSONObject {
   // Don't include foreign members directly into this type def.
   // in order to preserve type safety.
@@ -102,144 +96,10 @@ export interface GeoJSONObject {
   /**
    * Specifies the type of GeoJSON object.
    */
-  type: string;
+  type: GeoJsonTypes;
   /**
    * Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections.
    * https://tools.ietf.org/html/rfc7946#section-5
    */
   bbox?: BBox;
-}
-
-/**
- * Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3
- */
-export interface GeometryObject extends GeoJSONObject {
-  type: GeometryTypes;
-}
-
-/**
- * Geometry
- *
- * https://tools.ietf.org/html/rfc7946#section-3
- */
-export interface Geometry extends GeoJSONObject {
-  coordinates: Position | Position[] | Position[][] | Position[][][];
-}
-
-/**
- * Point Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.2
- */
-export interface Point extends GeometryObject {
-  type: "Point";
-  coordinates: Position;
-}
-
-/**
- * MultiPoint Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.3
- */
-export interface MultiPoint extends GeometryObject {
-  type: "MultiPoint";
-  coordinates: Position[];
-}
-
-/**
- * LineString Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.4
- */
-export interface LineString extends GeometryObject {
-  type: "LineString";
-  coordinates: Position[];
-}
-
-/**
- * MultiLineString Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.5
- */
-export interface MultiLineString extends GeometryObject {
-  type: "MultiLineString";
-  coordinates: Position[][];
-}
-
-/**
- * Polygon Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.6
- */
-export interface Polygon extends GeometryObject {
-  type: "Polygon";
-  coordinates: Position[][];
-}
-
-/**
- * MultiPolygon Geometry Object
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.7
- */
-export interface MultiPolygon extends GeometryObject {
-  type: "MultiPolygon";
-  coordinates: Position[][][];
-}
-
-/**
- * GeometryCollection
- *
- * https://tools.ietf.org/html/rfc7946#section-3.1.8
- *
- * A GeoJSON object with type "GeometryCollection" is a Geometry object.
- * A GeometryCollection has a member with the name "geometries".
- * The value of "geometries" is an array.  Each element of this array is a GeoJSON Geometry object.
- * It is possible for this array to be empty.
- */
-export interface GeometryCollection extends GeometryObject {
-  type: "GeometryCollection";
-  geometries: Array<
-    Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon
-  >;
-}
-
-/**
- * Feature
- *
- * https://tools.ietf.org/html/rfc7946#section-3.2
- * A Feature object represents a spatially bounded thing.
- * Every Feature object is a GeoJSON object no matter where it occurs in a GeoJSON text.
- */
-export interface Feature<G = Geometry | GeometryCollection, P = Properties>
-  extends GeoJSONObject {
-  type: "Feature";
-  geometry: G;
-  /**
-   * A value that uniquely identifies this feature in a
-   * https://tools.ietf.org/html/rfc7946#section-3.2.
-   */
-  id?: Id;
-  /**
-   * Properties associated with this feature.
-   */
-  properties: P;
-}
-
-/**
- * Feature Collection
- *
- * https://tools.ietf.org/html/rfc7946#section-3.3
- * A GeoJSON object with the type "FeatureCollection" is a FeatureCollection object.
- * A FeatureCollection object has a member with the name "features".
- * The value of "features" is a JSON array. Each element of the array is a Feature object as defined above.
- * It is possible for this array to be empty.
- */
-export interface FeatureCollection<
-  G = Geometry | GeometryCollection,
-  P = Properties
-> extends GeoJSONObject {
-  type: "FeatureCollection";
-  features: Array<Feature<G, P>>;
 }

--- a/packages/turf-helpers/types.ts
+++ b/packages/turf-helpers/types.ts
@@ -38,7 +38,7 @@ const poly = polygon([
     [0, 1],
   ],
 ]);
-const feat = feature({ coordinates: [1, 0], type: "point" });
+const feat = feature({ coordinates: [1, 0], type: "Point" });
 const multiPt = multiPoint([
   [0, 1],
   [2, 3],
@@ -81,7 +81,8 @@ polygon([
     [0, 1],
   ],
 ]);
-feature({ coordinates: [1, 0], type: "point" });
+feature({ coordinates: [1, 0], type: "Point" });
+feature(null);
 multiPoint([
   [0, 1],
   [2, 3],

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -95,7 +95,7 @@ export function featureReduce<
 /**
  * http://turfjs.org/docs/#featureeach
  */
-export function featureEach<G extends any, P = Properties>(
+export function featureEach<G extends GeometryObject, P = Properties>(
   geojson:
     | Feature<G, P>
     | FeatureCollection<G, P>
@@ -178,7 +178,10 @@ export function flattenReduce<
 /**
  * http://turfjs.org/docs/#flatteneach
  */
-export function flattenEach<G = Geometries, P = Properties>(
+export function flattenEach<
+  G extends GeometryObject = Geometries,
+  P = Properties
+>(
   geojson:
     | Feature<G, P>
     | FeatureCollection<G, P>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,9 +1227,10 @@
   dependencies:
     "@types/geojson" "*"
 
-"@types/geojson@*":
-  version "7946.0.1"
-  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.1.tgz#1fc41280e42f08f0d568401a556bc97c34f5262e"
+"@types/geojson@*", "@types/geojson@7946.0.8":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
 
 "@types/glob@^7.1.1":
   version "7.1.1"


### PR DESCRIPTION
This PR refactors the geojson types to build on @types/geojson.  Resolves #1658

This is a simpler version of PR #2154, which had also took on null feature geometry handling in functions, and there's a way we don't need to do that yet.  Let's keep the PR's small.

Strategy:
- [x] Pin turf to the latest version of @types/geojson instead of '*'.  This had actually been resolving to a slightly older version of the types, and led to the size of PR #2154.
- [x] Switch `packages/turf-helpers/lib/geojson.ts` to use base types from `geojson` package.
- [ ] Drop the exporting of geojson types from turf-helpers.  Other turf packages and turf consumers should simply depend on and import from `geojson` directly.
- [ ] Drop the geojson type additions that Turf has come to use over time.  Contribute items of value upstream to `geojson`.
  - [ ] `Id`, ...