### PR TITLE
@turf/clean-coords - Allow 3 coordinate closed LineStrings

### DIFF
--- a/packages/turf-clean-coords/test/in/closed-linestring.geojson
+++ b/packages/turf-clean-coords/test/in/closed-linestring.geojson
@@ -1,0 +1,12 @@
+{
+  "type": "Feature",
+  "properties": {},
+  "geometry": {
+    "type": "LineString",
+    "coordinates": [
+      [0, 0],
+      [1, 1],
+      [0, 0]
+    ]
+  }
+}

--- a/packages/turf-clean-coords/test/out/closed-linestring.geojson
+++ b/packages/turf-clean-coords/test/out/closed-linestring.geojson
@@ -1,0 +1,12 @@
+{
+  "type": "Feature",
+  "properties": {},
+  "geometry": {
+    "type": "LineString",
+    "coordinates": [
+      [0, 0],
+      [1, 1],
+      [0, 0]
+    ]
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/Turfjs/turf/issues/1563

Thanks to @ka7eh for the work, I just updated the PR to today's codebase.