### PR TITLE
Remove @turf/turf re-exports for 4.x compatability

### DIFF
--- a/packages/turf/index.d.ts
+++ b/packages/turf/index.d.ts
@@ -121,27 +121,3 @@ export { default as mask } from "@turf/mask";
 export { default as squareGrid } from "@turf/square-grid";
 export { default as triangleGrid } from "@turf/triangle-grid";
 export { default as interpolate } from "@turf/interpolate";
-
-// Renamed modules (Backwards compatitble with v4.0)
-// https://github.com/Turfjs/turf/issues/860
-export { default as pointOnSurface } from "@turf/point-on-feature";
-export { default as polygonToLineString } from "@turf/polygon-to-line";
-export { default as lineStringToPolygon } from "@turf/line-to-polygon";
-export { default as inside } from "@turf/boolean-point-in-polygon";
-export { default as within } from "@turf/points-within-polygon";
-export { default as bezier } from "@turf/bezier-spline";
-export { default as nearest } from "@turf/nearest-point";
-export { default as pointOnLine } from "@turf/nearest-point-on-line";
-export { default as lineDistance } from "@turf/length";
-
-// Renamed methods (Backwards compatitble with v4.0)
-// https://github.com/Turfjs/turf/issues/860
-export {
-  radiansToDegrees as radians2degrees,
-  degreesToRadians as degrees2radians,
-  lengthToDegrees as distanceToDegrees,
-  lengthToRadians as distanceToRadians,
-  radiansToLength as radiansToDistance,
-  bearingToAzimuth as bearingToAngle,
-  convertLength as convertDistance,
-} from "@turf/helpers";

--- a/packages/turf/index.mjs
+++ b/packages/turf/index.mjs
@@ -121,27 +121,3 @@ export { default as mask } from "@turf/mask";
 export { default as squareGrid } from "@turf/square-grid";
 export { default as triangleGrid } from "@turf/triangle-grid";
 export { default as interpolate } from "@turf/interpolate";
-
-// Renamed modules (Backwards compatitble with v4.0)
-// https://github.com/Turfjs/turf/issues/860
-export { default as pointOnSurface } from "@turf/point-on-feature";
-export { default as polygonToLineString } from "@turf/polygon-to-line";
-export { default as lineStringToPolygon } from "@turf/line-to-polygon";
-export { default as inside } from "@turf/boolean-point-in-polygon";
-export { default as within } from "@turf/points-within-polygon";
-export { default as bezier } from "@turf/bezier-spline";
-export { default as nearest } from "@turf/nearest-point";
-export { default as pointOnLine } from "@turf/nearest-point-on-line";
-export { default as lineDistance } from "@turf/length";
-
-// Renamed methods (Backwards compatitble with v4.0)
-// https://github.com/Turfjs/turf/issues/860
-export {
-  radiansToDegrees as radians2degrees,
-  degreesToRadians as degrees2radians,
-  lengthToDegrees as distanceToDegrees,
-  lengthToRadians as distanceToRadians,
-  radiansToLength as radiansToDistance,
-  bearingToAzimuth as bearingToAngle,
-  convertLength as convertDistance,
-} from "@turf/helpers";


### PR DESCRIPTION
Fixes #2180 

Reasoning here is that these have deprecated for a long while now, and people have had time to move off of them.