### PR TITLE
Turf/Buffer - More precise documentation of supported units for buffering

### DIFF
--- a/packages/turf-buffer/README.md
+++ b/packages/turf-buffer/README.md
@@ -4,7 +4,19 @@
 
 ## buffer
 
-Calculates a buffer for input features for a given radius. Units supported are miles, kilometers, and degrees.
+Calculates a buffer for input features for a given radius. Units supported are:
+
+*   centimeters or centimetres
+*   degrees
+*   feet
+*   inches
+*   kilometers or kilometres
+*   meters, metres
+*   miles
+*   millimeters, millimetres
+*   nauticalmiles
+*   radians
+*   yards
 
 When using a negative radius, the resulting geometry may be invalid if
 it's too small compared to the radius magnitude. If the input is a
@@ -12,15 +24,16 @@ FeatureCollection, only valid members will be returned in the output
 FeatureCollection - i.e., the output collection may have fewer members than
 the input, or even be empty.
 
-**Parameters**
+### Parameters
 
--   `geojson` **([FeatureCollection][1] \| [Geometry][2] \| [Feature][3]&lt;any>)** input to be buffered
--   `radius` **[number][4]** distance to draw the buffer (negative values are allowed)
--   `options` **[Object][5]** Optional parameters (optional, default `{}`)
-    -   `options.units` **[string][6]** any of the options supported by turf units (optional, default `"kilometers"`)
-    -   `options.steps` **[number][4]** number of steps (optional, default `8`)
+*   `geojson` **([FeatureCollection][1] | [Geometry][2] | [Feature][3]\<any>)** input to be buffered
+*   `radius` **[number][4]** distance to draw the buffer (negative values are allowed)
+*   `options` **[Object][5]** Optional parameters (optional, default `{}`)
 
-**Examples**
+    *   `options.units` **[string][6]** any of the options supported by turf units (optional, default `"kilometers"`)
+    *   `options.steps` **[number][4]** number of steps (optional, default `8`)
+
+### Examples
 
 ```javascript
 var point = turf.point([-90.548630, 14.616599]);
@@ -30,7 +43,7 @@ var buffered = turf.buffer(point, 500, {units: 'miles'});
 var addToMap = [point, buffered]
 ```
 
-Returns **([FeatureCollection][1] \| [Feature][3]&lt;([Polygon][7] \| [MultiPolygon][8])> | [undefined][9])** buffered features
+Returns **([FeatureCollection][1] | [Feature][3]<([Polygon][7] | [MultiPolygon][8])> | [undefined][9])** buffered features
 
 [1]: https://tools.ietf.org/html/rfc7946#section-3.3
 

--- a/packages/turf-buffer/index.js
+++ b/packages/turf-buffer/index.js
@@ -11,7 +11,18 @@ import {
 } from "@turf/helpers";
 
 /**
- * Calculates a buffer for input features for a given radius. Units supported are miles, kilometers, and degrees.
+ * Calculates a buffer for input features for a given radius. Units supported are:
+ *   * centimeters or centimetres
+ *   * degrees
+ *   * feet
+ *   * inches
+ *   * kilometers or kilometres
+ *   * meters, metres
+ *   * miles
+ *   * millimeters, millimetres
+ *   * nauticalmiles
+ *   * radians
+ *   * yards
  *
  * When using a negative radius, the resulting geometry may be invalid if
  * it's too small compared to the radius magnitude. If the input is a


### PR DESCRIPTION
This changes the documentation of the buffer module to list all supported units. 

[`lengthToUnits`](https://github.com/Turfjs/turf/blob/cd719cde909db79340d390de39d2c6afe3173062/packages/turf-helpers/index.ts#L624-L633) (which is used when buffering) supports more than _just_ `miles, kilometers, and degrees`. I am not sure if this was not documented on purpose. 

I also wasn't sure whether I was supposed to commit the changed `README.md` as well.

Please review.

-------------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.


~~Submitting a new TurfJS Module.~~

Not applicable
