### PR TITLE
[@turf/points-within-polygon] Fix multipoint dropping properties.

### DIFF
--- a/packages/turf-points-within-polygon/index.js
+++ b/packages/turf-points-within-polygon/index.js
@@ -59,7 +59,7 @@ function pointsWithinPolygon(points, polygons) {
         });
       });
       if (contained) {
-        results.push(multiPoint(pointsWithin));
+        results.push(multiPoint(pointsWithin, point.properties || {}));
       }
     } else {
       throw new Error("Input geometry must be a Point or MultiPoint");

--- a/packages/turf-points-within-polygon/test.js
+++ b/packages/turf-points-within-polygon/test.js
@@ -232,3 +232,42 @@ test("turf-points-within-polygon -- no duplicates when multiple geometry contain
   );
   t.end();
 });
+
+test("turf-points-within-polygon -- multipoint with properties", (t) => {
+  t.plan(5);
+
+  var poly1 = polygon([
+    [
+      [0, 0],
+      [0, 100],
+      [100, 100],
+      [100, 0],
+      [0, 0],
+    ],
+  ]);
+
+  var mpt1 = multiPoint(
+    [
+      [50, 50],
+      [150, 150],
+    ],
+    { prop: "yes" }
+  ); // inside and outside poly1
+  var polyFC = featureCollection([poly1]);
+
+  // multipoint within
+  var mpWithin = pointsWithinPolygon(mpt1, polyFC);
+  t.ok(mpWithin, "returns a featurecollection");
+  t.equal(mpWithin.features.length, 1, "1 multipoint in 1 polygon");
+  t.equal(
+    mpWithin.features[0].properties.constructor,
+    Object,
+    "properties found"
+  );
+  t.ok("prop" in mpWithin.features[0].properties, "1 property key found");
+  t.equal(
+    mpWithin.features[0].properties.prop,
+    "yes",
+    "1 property value found"
+  );
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

Fixes #2222:
 - Adds the `properties` attribute from the input feature to the output feature
 - Does not add the optional `bbox` attribute. Not clear what to do. The bounding box may have changed and the overhead decision to compute a new one should probably be left to the user.
 - Does not add the optional `id` attribute. Since this is a new feature the `id` probably should not be carried over.
