### PR TITLE
@turf/boolean-equal Add precision option

### DIFF
--- a/packages/turf-boolean-equal/index.ts
+++ b/packages/turf-boolean-equal/index.ts
@@ -10,6 +10,8 @@ import { getGeom } from "@turf/invariant";
  * @name booleanEqual
  * @param {Geometry|Feature} feature1 GeoJSON input
  * @param {Geometry|Feature} feature2 GeoJSON input
+ * @param {Object} [options={}] Optional parameters
+ * @param {number} [options.precision=6] decimal precision to use when comparing coordinates
  * @returns {boolean} true if the objects are equal, false otherwise
  * @example
  * var pt1 = turf.point([0, 0]);
@@ -23,13 +25,27 @@ import { getGeom } from "@turf/invariant";
  */
 function booleanEqual(
   feature1: Feature<any> | Geometry,
-  feature2: Feature<any> | Geometry
+  feature2: Feature<any> | Geometry,
+  options: {
+    precision?: number;
+  } = {}
 ): boolean {
+  let precision = options.precision;
+
+  precision =
+    precision === undefined || precision === null || isNaN(precision)
+      ? 6
+      : precision;
+
+  if (typeof precision !== "number" || !(precision >= 0)) {
+    throw new Error("precision must be a positive number");
+  }
+
   const type1 = getGeom(feature1).type;
   const type2 = getGeom(feature2).type;
   if (type1 !== type2) return false;
 
-  const equality = new GeojsonEquality({ precision: 6 });
+  const equality = new GeojsonEquality({ precision: precision });
   return equality.compare(cleanCoords(feature1), cleanCoords(feature2));
 }
 

--- a/packages/turf-boolean-equal/test.js
+++ b/packages/turf-boolean-equal/test.js
@@ -15,7 +15,8 @@ test("turf-boolean-equal", (t) => {
       const geojson = load.sync(filepath);
       const feature1 = geojson.features[0];
       const feature2 = geojson.features[1];
-      const result = equal(feature1, feature2);
+      const options = geojson.properties;
+      const result = equal(feature1, feature2, options);
 
       if (process.env.SHAPELY)
         shapely
@@ -31,7 +32,8 @@ test("turf-boolean-equal", (t) => {
       const geojson = load.sync(filepath);
       const feature1 = geojson.features[0];
       const feature2 = geojson.features[1];
-      const result = equal(feature1, feature2);
+      const options = geojson.properties;
+      const result = equal(feature1, feature2, options);
 
       if (process.env.SHAPELY)
         shapely
@@ -90,7 +92,15 @@ test("turf-boolean-equal -- geometries", (t) => {
 });
 
 test("turf-boolean-equal -- throws", (t) => {
-  // t.throws(() => equal(null, line1), /feature1 is required/, 'missing feature1');
-  // t.throws(() => equal(line1, null), /feature2 is required/, 'missing feature2');
+  //t.throws(() => equal(null, line1), /feature1 is required/, 'missing feature1');
+  //t.throws(() => equal(line1, null), /feature2 is required/, 'missing feature2');
+  t.throws(
+    () => equal(line1.geometry, line2.geometry, { precision: "1" }),
+    "precision must be a number"
+  );
+  t.throws(
+    () => equal(line1.geometry, line2.geometry, { precision: -1 }),
+    "precision must be positive"
+  );
   t.end();
 });

--- a/packages/turf-boolean-equal/test/false/precision-default.geojson
+++ b/packages/turf-boolean-equal/test/false/precision-default.geojson
@@ -1,0 +1,21 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.123456, 0]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.123451, 0]
+      }
+    }
+  ]
+}

--- a/packages/turf-boolean-equal/test/false/precision-options.geojson
+++ b/packages/turf-boolean-equal/test/false/precision-options.geojson
@@ -1,0 +1,24 @@
+{
+  "type": "FeatureCollection",
+  "properties": {
+    "precision": 17
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.12345678901234561, 0]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.12345678901234564, 0]
+      }
+    }
+  ]
+}

--- a/packages/turf-boolean-equal/test/true/precision-default.geojson
+++ b/packages/turf-boolean-equal/test/true/precision-default.geojson
@@ -1,0 +1,21 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.1234567, 0]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.1234569, 0]
+      }
+    }
+  ]
+}

--- a/packages/turf-boolean-equal/test/true/precision-options.geojson
+++ b/packages/turf-boolean-equal/test/true/precision-options.geojson
@@ -1,0 +1,24 @@
+{
+  "type": "FeatureCollection",
+  "properties": {
+    "precision": 16
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.12345678901234567, 0]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0.12345678901234569, 0]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #1929 by adding a precision option to booleanEqual.

I didn't include any change to README.md in this commit. It looks like the generate-readmes script doesn't look for typescript files so I'm assuming the docs are generated in another step?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.
