### PR TITLE
line-intersect additional type cleanup

### DIFF
--- a/packages/turf-line-intersect/index.ts
+++ b/packages/turf-line-intersect/index.ts
@@ -66,12 +66,17 @@ function lineIntersect<
     features.push(feature(line2));
   }
 
+  /**
+   * Intersection point between two geometries
+   */
+  type Intersection = [number, number];
+
   const intersections = findIntersections(
     featureCollection(features),
     ignoreSelfIntersections
-  ) as [number, number][];
+  ) as Intersection[];
 
-  let results = [];
+  let results: Intersection[] = [];
   if (removeDuplicates) {
     const unique: Record<string, boolean> = {};
     intersections.forEach((intersection) => {

--- a/packages/turf-line-intersect/index.ts
+++ b/packages/turf-line-intersect/index.ts
@@ -40,15 +40,8 @@ function lineIntersect<
     ignoreSelfIntersections?: boolean;
   } = {}
 ): FeatureCollection<Point> {
-  let removeDuplicates = true;
-  let ignoreSelfIntersections = false;
-  if ("removeDuplicates" in options) {
-    removeDuplicates = options.removeDuplicates!;
-  }
-  if ("ignoreSelfIntersections" in options) {
-    ignoreSelfIntersections = options.ignoreSelfIntersections!;
-  }
-  let features: Feature<any>[] = [];
+  const { removeDuplicates = true, ignoreSelfIntersections = false } = options;
+  let features: Feature<G1 | G2>[] = [];
   if (line1.type === "FeatureCollection")
     features = features.concat(line1.features);
   else if (line1.type === "Feature") features.push(line1);
@@ -73,13 +66,14 @@ function lineIntersect<
     features.push(feature(line2));
   }
 
-  const intersections: any[] = findIntersections(
+  const intersections = findIntersections(
     featureCollection(features),
     ignoreSelfIntersections
-  );
-  let results: any[] = [];
+  ) as [number, number][];
+
+  let results = [];
   if (removeDuplicates) {
-    const unique: { [key: string]: any } = {};
+    const unique: Record<string, boolean> = {};
     intersections.forEach((intersection) => {
       const key = intersection.join(",");
       if (!unique[key]) {


### PR DESCRIPTION
@rowanwins Please consider this bit of type cleanup for #2033, removing use of any.  Plus one more bit of cleanup while I was there.  Seemed easier than trying to comment on it.

I tried to add a default function signature for findIntersections to the empty sweepline-intersections module declaration file you created,  but could not get VSCode to pick up the types.  Failing that, I at least improved from use of any to a more explicit cast for result of findIntersections()