### PR TITLE
featureEach: add properties generic, drop unneeded casting

### DIFF
--- a/packages/turf-center-median/index.ts
+++ b/packages/turf-center-median/index.ts
@@ -143,13 +143,13 @@ function findMedian(
     if (weight > 0) {
       centroidCount += 1;
       var distanceFromCandidate =
-        weight * distance(theCentroid as Feature<Point>, candidateMedian);
+        weight * distance(theCentroid, candidateMedian);
       if (distanceFromCandidate === 0) distanceFromCandidate = 1;
       var k = weight / distanceFromCandidate;
       candidateXsum +=
-        (theCentroid as Feature<Point>).geometry.coordinates[0] * k;
+        (theCentroid).geometry.coordinates[0] * k;
       candidateYsum +=
-        (theCentroid as Feature<Point>).geometry.coordinates[1] * k;
+        (theCentroid).geometry.coordinates[1] * k;
       kSum += k;
     }
   });

--- a/packages/turf-center-median/index.ts
+++ b/packages/turf-center-median/index.ts
@@ -146,10 +146,8 @@ function findMedian(
         weight * distance(theCentroid, candidateMedian);
       if (distanceFromCandidate === 0) distanceFromCandidate = 1;
       var k = weight / distanceFromCandidate;
-      candidateXsum +=
-        (theCentroid).geometry.coordinates[0] * k;
-      candidateYsum +=
-        (theCentroid).geometry.coordinates[1] * k;
+      candidateXsum += theCentroid.geometry.coordinates[0] * k;
+      candidateYsum += theCentroid.geometry.coordinates[1] * k;
       kSum += k;
     }
   });

--- a/packages/turf-clusters/index.ts
+++ b/packages/turf-clusters/index.ts
@@ -45,8 +45,7 @@ export function getCluster<G extends GeometryObject, P = any>(
   // Filter Features
   var features: Feature<G, P>[] = [];
   featureEach(geojson, function (feature) {
-    if (applyFilter(feature.properties, filter))
-      features.push(feature);
+    if (applyFilter(feature.properties, filter)) features.push(feature);
   });
   return featureCollection(features);
 }

--- a/packages/turf-clusters/index.ts
+++ b/packages/turf-clusters/index.ts
@@ -46,7 +46,7 @@ export function getCluster<G extends GeometryObject, P = any>(
   var features: Feature<G, P>[] = [];
   featureEach(geojson, function (feature) {
     if (applyFilter(feature.properties, filter))
-      features.push(feature as Feature<G, P>);
+      features.push(feature);
   });
   return featureCollection(features);
 }

--- a/packages/turf-concave/index.ts
+++ b/packages/turf-concave/index.ts
@@ -92,9 +92,9 @@ function removeDuplicates(
     if (!pt.geometry) {
       return;
     }
-    const key = (pt as Feature<Point>).geometry.coordinates.join("-");
+    const key = pt.geometry.coordinates.join("-");
     if (!Object.prototype.hasOwnProperty.call(existing, key)) {
-      cleaned.push(pt as Feature<Point>);
+      cleaned.push(pt);
       existing[key] = true;
     }
   });

--- a/packages/turf-directional-mean/index.ts
+++ b/packages/turf-directional-mean/index.ts
@@ -96,7 +96,7 @@ export default function directionalMean(
         isPlanar
       );
       const lenOfLine = getLengthOfLineString(
-        currentFeature as Feature<LineString>,
+        currentFeature,
         isPlanar
       );
       if (isNaN(sin1) || isNaN(cos1)) {

--- a/packages/turf-directional-mean/index.ts
+++ b/packages/turf-directional-mean/index.ts
@@ -95,10 +95,7 @@ export default function directionalMean(
         currentFeature.geometry.coordinates,
         isPlanar
       );
-      const lenOfLine = getLengthOfLineString(
-        currentFeature,
-        isPlanar
-      );
+      const lenOfLine = getLengthOfLineString(currentFeature, isPlanar);
       if (isNaN(sin1) || isNaN(cos1)) {
         return;
       } else {

--- a/packages/turf-line-overlap/index.ts
+++ b/packages/turf-line-overlap/index.ts
@@ -70,8 +70,7 @@ function lineOverlap<
     }
 
     // Iterate over each segments which falls within the same bounds
-    featureEach(tree.search(segment), function (matchUntyped) {
-      const match = matchUntyped;
+    featureEach(tree.search(segment), function (match) {
       if (doesOverlaps === false) {
         var coordsSegment = getCoords(segment).sort();
         var coordsMatch = getCoords(match).sort();

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -455,9 +455,9 @@ export function propReduce<T = GeoJsonProperties>(
  *   //=featureIndex
  * });
  */
-export function featureEach<T extends Geometry>(
-  geojson: Feature<T> | FeatureCollection<T>,
-  callback: (feature: Feature<T>, featureIndex: number) => boolean | void
+export function featureEach<T extends Geometry, P extends GeoJsonProperties>(
+  geojson: Feature<T, P> | FeatureCollection<T, P>,
+  callback: (feature: Feature<T, P>, featureIndex: number) => boolean | void
 ): void {
   if (geojson.type === "Feature") {
     callback(geojson, 0);


### PR DESCRIPTION
Small improvement to #2275 .  Make featureEach feature property also generic.  Remove some of the casting no longer needed.