### PR TITLE
Strict type tests

### DIFF
--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -2,17 +2,17 @@ const path = require("path");
 const glob = require("glob");
 const fs = require("fs");
 
-const TS_PACKAGES = []; // projects that use typescript to build
-const JS_PACKAGES = []; // projects that use javascript/rollup to build
+const TS_PACKAGES: string[] = []; // projects that use typescript to build
+const JS_PACKAGES: string[] = []; // projects that use javascript/rollup to build
 const MAIN_PACKAGE = "@turf/turf";
 
-const TAPE_PACKAGES = []; // projects that have tape tests
-const TYPES_PACKAGES = []; // projects that have types tests
-const BENCH_PACKAGES = []; // projects that have benchmarks
+const TAPE_PACKAGES: string[] = []; // projects that have tape tests
+const TYPES_PACKAGES: string[] = []; // projects that have types tests
+const BENCH_PACKAGES: string[] = []; // projects that have benchmarks
 
 // iterate all the packages and figure out what buckets everything falls into
 glob.sync(path.join(__dirname, "packages", "turf-*")).forEach((pk) => {
-  const name = JSON.parse(
+  const name: string = JSON.parse(
     fs.readFileSync(path.join(pk, "package.json"), "utf8")
   ).name;
 

--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -224,7 +224,7 @@ module.exports = {
       {
         options: {
           scripts: {
-            "test:types": "tsc --esModuleInterop --noEmit types.ts",
+            "test:types": "tsc --esModuleInterop --noEmit --strict types.ts",
           },
         },
         includePackages: TYPES_PACKAGES,

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -51,7 +51,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -50,7 +50,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/center": "^6.5.0",

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -42,7 +42,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^6.5.0",

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -44,7 +44,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@mapbox/geojsonhint": "*",

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -45,7 +45,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/meta": "^6.5.0",

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -52,7 +52,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/centroid": "^6.5.0",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -51,7 +51,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/centroid": "^6.5.0",

--- a/packages/turf-clusters/index.ts
+++ b/packages/turf-clusters/index.ts
@@ -103,7 +103,7 @@ export function clusterEach<G extends GeometryObject, P = any>(
   geojson: FeatureCollection<G, P>,
   property: number | string,
   callback: (
-    cluster?: FeatureCollection<G, P>,
+    cluster: FeatureCollection<G, P>,
     clusterValue?: any,
     currentIndex?: number
   ) => void
@@ -197,8 +197,8 @@ export function clusterReduce<G extends GeometryObject, P = any>(
   geojson: FeatureCollection<G, P>,
   property: number | string,
   callback: (
-    previousValue?: any,
-    cluster?: FeatureCollection<G, P>,
+    previousValue: any | undefined,
+    cluster: FeatureCollection<G, P>,
     clusterValue?: any,
     currentIndex?: number
   ) => void,

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -43,7 +43,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -136,7 +136,7 @@ export function feature<
   G extends GeometryObject = Geometry,
   P = GeoJsonProperties
 >(
-  geom: G,
+  geom: G | null,
   properties?: P,
   options: { bbox?: BBox; id?: Id } = {}
 ): Feature<G, P> {

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -50,7 +50,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -54,7 +54,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^6.5.0",

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -45,7 +45,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-interpolate/types.ts
+++ b/packages/turf-interpolate/types.ts
@@ -18,7 +18,7 @@ const grid = interpolate(points, cellSize, {
   units,
   weight,
 });
-grid.features[0].properties.pressure;
+grid.features[0].properties?.pressure;
 
 // Optional properties
 interpolate(points, cellSize, { gridType, property, units });

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -43,7 +43,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -47,7 +47,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/envelope": "^6.5.0",

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -43,7 +43,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/meta": "^6.5.0",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -42,7 +42,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -50,7 +50,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/deep-equal": "^1.0.1",

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -42,7 +42,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-meta/index.d.ts
+++ b/packages/turf-meta/index.d.ts
@@ -258,7 +258,7 @@ export function lineEach<P = GeoJsonProperties>(
     | Feature<GeometryCollection, P>
     | GeometryCollection,
   callback: (
-    currentLine?: Feature<LineString, P>,
+    currentLine: Feature<LineString, P>,
     featureIndex?: number,
     multiFeatureIndex?: number,
     geometryIndex?: number

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -64,7 +64,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/random": "^6.5.0",

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -38,7 +38,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/along": "^6.5.0",

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/circle": "^6.5.0",

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -44,7 +44,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^6.5.0",

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/circle": "^6.5.0",

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -44,7 +44,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -45,7 +45,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -48,7 +48,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -56,7 +56,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -41,7 +41,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/random": "^6.5.0",

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -43,7 +43,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -47,7 +47,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -51,7 +51,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^6.5.0",

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -49,7 +49,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "^6.5.0",

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -46,7 +46,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^6.5.0",

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -47,7 +47,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -42,7 +42,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "ts-node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/tape": "*",

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -44,7 +44,7 @@
     "docs": "node ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
     "test:tape": "node -r esm test.js",
-    "test:types": "tsc --esModuleInterop --noEmit types.ts"
+    "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/kinks": "^6.5.0",


### PR DESCRIPTION
The types.ts tests weren't being applied with the same typescript strict flag that we are using in our editors. That means we're introducing errors and not catching them in CI. This caught me by surprise over on #2275 so lets clean this up before going forward there.

Commit 1 is just some type annotations to make my editor happy
Commit 2 is the monorepolint change itself
Commit 3 is the automatic application of monorepolint (and can be mostly ignored for review)
Commit 4 is the changes required by step 3 adding some new build failures
