### PR TITLE
Update @turf/circle units typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ We intend to keep making breaking changes before 7.0.0 is fully released. If you
 - [`@turf/turf](turf) Add booleanTouches export (#2170)
 - [`@turf/turf](turf) Add booleanConcave export (#2265)
 - [`@turf/helpers](helpers) Make isObject a little more accurate (#2176)
+- [`@turf/circle](circle) Improve units option typing (#2387)
 - types.ts tests are now run in strict mode (#2363)
 - Uses tslib now for smaller bundles (#2165)
 - Remove object-assign dependency from all packages (#2241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ We intend to keep making breaking changes before 7.0.0 is fully released. If you
 - [`@turf/turf](turf) Add booleanTouches export (#2170)
 - [`@turf/turf](turf) Add booleanConcave export (#2265)
 - [`@turf/helpers](helpers) Make isObject a little more accurate (#2176)
-- [`@turf/circle](circle) Improve units option typing (#2387)
+- [`@turf/circle](circle) Improve units option typing (#2392)
 - types.ts tests are now run in strict mode (#2363)
 - Uses tslib now for smaller bundles (#2165)
 - Remove object-assign dependency from all packages (#2241)

--- a/packages/turf-circle/index.ts
+++ b/packages/turf-circle/index.ts
@@ -27,7 +27,7 @@ function circle<P = GeoJsonProperties>(
   radius: number,
   options: {
     steps?: number;
-    units?: Units;
+    units?: Extract<Units, "miles" | "kilometers" | "degrees" | "radians">;
     properties?: P;
   } = {}
 ): Feature<Polygon, P> {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

[Issue is filed here](https://github.com/Turfjs/turf/issues/2391).

This corrects the typing for units in @turf/circle. 

It looks like this change could be a shared with other packages (e.g. turf-distance has this issue as well, and many others). I could update those and was thinking to abstract the type but I'm not sure what to name the new type.

e.g. `export type UnitsBasic = Extract<Units, "miles" | "kilometers" | "degrees" | "radians">`

Then apply that new type to various packages with these units documented.
