### PR TITLE
TypeScript types: Separate out length units from area units

### DIFF
--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -31,14 +31,16 @@ export type Units =
   | "centimetres"
   | "kilometers"
   | "kilometres"
-  | "acres"
   | "miles"
   | "nauticalmiles"
   | "inches"
   | "yards"
   | "feet"
   | "radians"
-  | "degrees"
+  | "degrees";
+export type AreaUnits =
+  | Exclude<Units, "radians" | "degrees">
+  | "acres"
   | "hectares";
 export type Grid = "point" | "square" | "hex" | "triangle";
 export type Corners = "sw" | "se" | "nw" | "ne" | "center" | "centroid";
@@ -70,7 +72,7 @@ export const earthRadius = 6371008.8;
  * @memberof helpers
  * @type {Object}
  */
-export const factors: { [key: string]: number } = {
+export const factors: Record<Units, number> = {
   centimeters: earthRadius * 100,
   centimetres: earthRadius * 100,
   degrees: 360 / (2 * Math.PI),
@@ -95,7 +97,7 @@ export const factors: { [key: string]: number } = {
  * @memberof helpers
  * @type {Object}
  */
-export const areaFactors: { [key: string]: number } = {
+export const areaFactors: Record<AreaUnits, number> = {
   acres: 0.000247105,
   centimeters: 10000,
   centimetres: 10000,
@@ -107,6 +109,7 @@ export const areaFactors: { [key: string]: number } = {
   meters: 1,
   metres: 1,
   miles: 3.86e-7,
+  nauticalmiles: 2.9155334959812285e-7,
   millimeters: 1000000,
   millimetres: 1000000,
   yards: 1.195990046,
@@ -716,8 +719,8 @@ export function convertLength(
  */
 export function convertArea(
   area: number,
-  originalUnit: Units = "meters",
-  finalUnit: Units = "kilometers"
+  originalUnit: AreaUnits = "meters",
+  finalUnit: AreaUnits = "kilometers"
 ): number {
   if (!(area >= 0)) {
     throw new Error("area must be a positive number");

--- a/packages/turf-nearest-neighbor-analysis/index.ts
+++ b/packages/turf-nearest-neighbor-analysis/index.ts
@@ -12,11 +12,11 @@ import centroid from "@turf/centroid";
 import distance from "@turf/distance";
 import nearestPoint from "@turf/nearest-point";
 import { featureEach } from "@turf/meta";
-import { convertArea, featureCollection } from "@turf/helpers";
+import { convertArea, featureCollection, AreaUnits } from "@turf/helpers";
 import { Units } from "@turf/helpers";
 
 export interface NearestNeighborStatistics {
-  units: Units;
+  units: Units & AreaUnits;
   arealUnits: string;
   observedMeanDistance: number;
   expectedMeanDistance: number;
@@ -86,7 +86,7 @@ function nearestNeighborAnalysis(
   dataset: FeatureCollection<any>,
   options?: {
     studyArea?: Feature<Polygon>;
-    units?: Units;
+    units?: Units & AreaUnits;
     properties?: GeoJsonProperties;
   }
 ): NearestNeighborStudyArea {

--- a/packages/turf-nearest-neighbor-analysis/index.ts
+++ b/packages/turf-nearest-neighbor-analysis/index.ts
@@ -12,8 +12,12 @@ import centroid from "@turf/centroid";
 import distance from "@turf/distance";
 import nearestPoint from "@turf/nearest-point";
 import { featureEach } from "@turf/meta";
-import { convertArea, featureCollection, AreaUnits } from "@turf/helpers";
-import { Units } from "@turf/helpers";
+import {
+  convertArea,
+  featureCollection,
+  Units,
+  AreaUnits,
+} from "@turf/helpers";
 
 export interface NearestNeighborStatistics {
   units: Units & AreaUnits;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

This PR aims to fix https://github.com/Turfjs/turf/issues/2391 - here `acres` and `hectares` can be passed into many functions where this is inappropriate (i.e. `circle`, `destination` etc) where measurements of area are not logically possible.

The PR also adds a conversion for nautical miles for the `convertArea` function, as this is theoretically possible, if somewhat esoteric.