### PR TITLE
Fix boolean-equal docs and added new tests (#2401)

### DIFF
--- a/packages/turf-boolean-equal/README.md
+++ b/packages/turf-boolean-equal/README.md
@@ -4,7 +4,7 @@
 
 ## booleanEqual
 
-Determine whether two geometries of the same type have identical X,Y coordinate values.
+Determines whether two geometries or features of the same type have identical X,Y coordinate values and properties.
 See [http://edndoc.esri.com/arcsde/9.0/general_topics/understand_spatial_relations.htm][1]
 
 ### Parameters
@@ -21,11 +21,17 @@ See [http://edndoc.esri.com/arcsde/9.0/general_topics/understand_spatial_relatio
 var pt1 = turf.point([0, 0]);
 var pt2 = turf.point([0, 0]);
 var pt3 = turf.point([1, 1]);
+var pt4 = turf.point([0, 0], {prop: 'A'});
+var pt5 = turf.point([0, 0], {prop: 'B'});
 
 turf.booleanEqual(pt1, pt2);
 //= true
 turf.booleanEqual(pt2, pt3);
 //= false
+turf.booleanEqual(pt4, pt5);
+//= false
+turf.booleanEqual(pt4.geometry, pt5.geometry);
+//= true
 ```
 
 Returns **[boolean][6]** true if the objects are equal, false otherwise

--- a/packages/turf-boolean-equal/test.js
+++ b/packages/turf-boolean-equal/test.js
@@ -55,24 +55,30 @@ const line2 = lineString([
   [8, 50],
   [9, 50],
 ]);
-const poly1 = polygon([
+const poly1 = polygon(
   [
-    [8.5, 50],
-    [9.5, 50],
-    [9.5, 49],
-    [8.5, 49],
-    [8.5, 50],
+    [
+      [8.5, 50],
+      [9.5, 50],
+      [9.5, 49],
+      [8.5, 49],
+      [8.5, 50],
+    ],
   ],
-]);
-const poly2 = polygon([
+  { prop: "A" }
+);
+const poly2 = polygon(
   [
-    [8.5, 50],
-    [9.5, 50],
-    [9.5, 49],
-    [8.5, 49],
-    [8.5, 50],
+    [
+      [8.5, 50],
+      [9.5, 50],
+      [9.5, 49],
+      [8.5, 49],
+      [8.5, 50],
+    ],
   ],
-]);
+  { prop: "B" }
+);
 const poly3 = polygon([
   [
     [10, 50],
@@ -82,12 +88,26 @@ const poly3 = polygon([
     [10, 50],
   ],
 ]);
+const poly4 = polygon(
+  [
+    [
+      [8.5, 50],
+      [9.5, 50],
+      [9.5, 49],
+      [8.5, 49],
+      [8.5, 50],
+    ],
+  ],
+  { prop: "A" }
+);
 
 test("turf-boolean-equal -- geometries", (t) => {
   t.true(equal(line1.geometry, line2.geometry), "[true] LineString geometry");
   t.true(equal(poly1.geometry, poly2.geometry), "[true] Polygon geometry");
+  t.true(equal(poly1, poly4), "[true] Polygon feature");
   t.false(equal(poly1.geometry, poly3.geometry), "[false] Polygon geometry");
   t.false(equal(pt, line1), "[false] different types");
+  t.false(equal(poly1, poly2), "[false] different properties");
   t.end();
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x ] Run `npm test` at the sub modules where changes have occurred.
- [x ] Run `npm run lint` to ensure code style at the turf module level.

I tried to fix the documentation issue mentioned in #2401 . I am not sure if booleanEqual should compare properties at all but currently it does. And so does the "geojson-equality" package used for comparing. It all depends on whether you compare two geometries or two features. I updated the documentation and added some tests to reflect the current behaviour.

If you say booleanEqual should always omit properties and only compare geometries regardless whether the input is a geometry or a feature, I could create a fix for that and update the pull request with it.
