### PR TITLE
Remove node 12 and add in node 18 and 20 to CI build matrix

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [ ] Run `npm test` at the sub modules where changes have occurred.
- [ ] Run `npm run lint` to ensure code style at the turf module level.

Here we remove node 12 and add in node 18 and 20 into the CI build matrix. Node 12 is end of life.

Resolves https://github.com/Turfjs/turf/issues/2417 