### PR TITLE
Update supported node-versions based on node EOL

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Per https://endoflife.date/nodejs only 16, 18, and 20 are still supported by the node team