### PR TITLE
Replace ts-node with tsx in doc and test related build scripts

### DIFF
--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -270,6 +270,7 @@ module.exports = {
         options: {
           devDependencies: {
             rollup: "*",
+            tsx: "*",
           },
         },
         includePackages: JS_PACKAGES,

--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -164,7 +164,7 @@ module.exports = {
       {
         options: {
           scripts: {
-            docs: "node ../../scripts/generate-readmes",
+            docs: "tsx ../../scripts/generate-readmes",
             test: "npm-run-all test:*",
           },
         },
@@ -202,7 +202,7 @@ module.exports = {
       {
         options: {
           scripts: {
-            "test:tape": "node -r esm test.js",
+            "test:tape": "tsx test.js",
           },
         },
         includePackages: JS_TAPE_PACKAGES,
@@ -210,7 +210,7 @@ module.exports = {
       {
         options: {
           scripts: {
-            "test:tape": "ts-node -r esm test.js",
+            "test:tape": "tsx test.js",
           },
         },
         includePackages: TS_TAPE_PACKAGES,
@@ -218,7 +218,7 @@ module.exports = {
       {
         options: {
           scripts: {
-            bench: "node -r esm bench.js",
+            bench: "tsx bench.js",
           },
         },
         includePackages: JS_TAPE_PACKAGES,
@@ -226,7 +226,7 @@ module.exports = {
       {
         options: {
           scripts: {
-            bench: "ts-node bench.js",
+            bench: "tsx bench.js",
           },
         },
         includePackages: TS_TAPE_PACKAGES,
@@ -260,7 +260,7 @@ module.exports = {
             tslib: "^2.3.0",
           },
           devDependencies: {
-            "ts-node": "*",
+            tsx: "*",
             typescript: "*",
           },
         },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "progress": "*",
     "rollup": "^2.34.2",
     "tape": "*",
-    "ts-node": "^9.0.0",
+    "tsx": "^3.12.8",
     "typescript": "^3.8.3",
     "yamljs": "*"
   }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "progress": "*",
     "rollup": "^2.34.2",
     "tape": "*",
+    "ts-node": "^9.0.0",
     "tsx": "^3.12.8",
     "typescript": "^3.8.3",
     "yamljs": "*"

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/distance": "^7.0.0-alpha.0",
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -38,13 +38,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -52,8 +52,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/bbox": "^7.0.0-alpha.0",
@@ -59,8 +59,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -39,21 +39,21 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -40,21 +40,21 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -36,13 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/destination": "^7.0.0-alpha.0",
@@ -50,8 +50,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -43,13 +43,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -58,8 +58,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -59,8 +59,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -58,8 +58,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -45,13 +45,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/geojson-equality": "^0.2.0",
@@ -62,8 +62,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/geojson-equality": "^0.2.0",
@@ -61,8 +61,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -41,13 +41,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -55,8 +55,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -40,21 +40,21 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -54,8 +54,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -43,13 +43,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -61,8 +61,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -59,8 +59,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -43,13 +43,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -61,8 +61,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -47,11 +47,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -61,6 +61,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -62,8 +62,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/center": "^7.0.0-alpha.0",
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -36,13 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -52,8 +52,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -58,8 +58,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -38,13 +38,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -55,8 +55,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -56,8 +56,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -54,8 +54,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -46,13 +46,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -66,8 +66,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -45,13 +45,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -67,8 +67,8 @@
     "matrix-to-grid": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -56,8 +56,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -43,13 +43,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/rbush": "^3.0.0",
@@ -57,8 +57,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -39,21 +39,21 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -49,13 +49,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -65,8 +65,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -36,13 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/concaveman": "^1.1.3",
@@ -52,8 +52,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/truncate": "^7.0.0-alpha.0",
@@ -56,8 +56,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -37,11 +37,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
@@ -50,6 +50,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -40,11 +40,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
@@ -52,6 +52,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -38,13 +38,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -52,8 +52,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -40,11 +40,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@mapbox/geojsonhint": "*",
@@ -58,6 +58,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -40,18 +40,19 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/bbox": "^7.0.0-alpha.0",

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -39,11 +39,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
@@ -52,6 +52,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -44,11 +44,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -39,11 +39,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -52,6 +52,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -45,11 +45,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -59,6 +59,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -58,8 +58,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -48,13 +48,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -65,8 +65,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -41,11 +41,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -56,6 +56,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -37,13 +37,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -41,21 +41,21 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/envelope": "^7.0.0-alpha.0",
@@ -65,8 +65,8 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -43,13 +43,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -64,8 +64,8 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -37,13 +37,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -52,7 +52,7 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -58,8 +58,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -36,13 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -51,7 +51,7 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -46,11 +46,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -60,6 +60,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -43,13 +43,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/truncate": "^7.0.0-alpha.0",
@@ -58,8 +58,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -44,11 +44,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -58,6 +58,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -58,8 +58,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -37,13 +37,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -51,8 +51,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -38,11 +38,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/along": "^7.0.0-alpha.0",
@@ -50,7 +50,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/bearing": "^7.0.0-alpha.0",

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -42,11 +42,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/truncate": "^7.0.0-alpha.0",
@@ -55,6 +55,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -43,11 +43,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
@@ -55,6 +55,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -38,11 +38,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -52,6 +52,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -60,11 +60,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -72,7 +72,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/helpers": "^7.0.0-alpha.0"

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -40,17 +40,18 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/bearing": "^7.0.0-alpha.0",

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/truncate": "^7.0.0-alpha.0",
@@ -54,8 +54,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -32,13 +32,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -50,8 +50,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -60,8 +60,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -54,8 +54,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -40,18 +40,19 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/helpers": "^7.0.0-alpha.0",

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -59,8 +59,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -41,11 +41,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/meta": "^7.0.0-alpha.0",
@@ -53,7 +53,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "^7.0.0-alpha.0",

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -56,8 +56,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -40,18 +40,19 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "^7.0.0-alpha.0",

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -41,11 +41,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -55,6 +55,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -44,11 +44,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -53,8 +53,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
-    "ts-node": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -50,13 +50,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -67,8 +67,8 @@
     "npm-run-all": "*",
     "proj4": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/nearest-neighbor-analysis": "^7.0.0-alpha.0",
@@ -54,8 +54,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -36,13 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@types/tape": "*",
@@ -50,8 +50,8 @@
     "glob": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -42,13 +42,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^7.0.0-alpha.0",
@@ -58,7 +58,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
-    "ts-node": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -45,11 +45,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -58,6 +58,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -44,13 +44,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/destination": "^7.0.0-alpha.0",
@@ -58,8 +58,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -48,13 +48,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/truncate": "^7.0.0-alpha.0",
@@ -63,8 +63,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -46,13 +46,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/distance": "^7.0.0-alpha.0",
@@ -61,8 +61,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -39,17 +39,18 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/helpers": "^7.0.0-alpha.0"

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -37,11 +37,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -51,6 +51,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -42,11 +42,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -56,6 +56,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -45,11 +45,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -59,6 +59,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -39,13 +39,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "^7.0.0-alpha.0",
@@ -54,8 +54,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -39,17 +39,18 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/distance": "^7.0.0-alpha.0",

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -42,11 +42,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -43,18 +43,19 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
     "load-json-file": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "^7.0.0-alpha.0",

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -47,17 +47,18 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
     "npm-run-all": "*",
     "rollup": "*",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/helpers": "^7.0.0-alpha.0",

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -37,13 +37,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -51,8 +51,8 @@
     "benchmark": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -43,11 +43,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -47,11 +47,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -63,6 +63,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -45,11 +45,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -59,6 +59,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -40,13 +40,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -57,8 +57,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -41,13 +41,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -56,8 +56,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -36,13 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "bench": "ts-node bench.js",
+    "bench": "tsx bench.js",
     "build": "npm-run-all build:*",
     "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "ts-node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -52,8 +52,8 @@
     "load-json-file": "*",
     "npm-run-all": "*",
     "tape": "*",
-    "ts-node": "*",
     "tslint": "*",
+    "tsx": "*",
     "typescript": "*",
     "write-json-file": "*"
   },

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -40,11 +40,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js",
+    "test:tape": "tsx test.js",
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
@@ -54,6 +54,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -46,11 +46,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "bench": "node -r esm bench.js",
+    "bench": "tsx bench.js",
     "build": "rollup -c ../../rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
-    "docs": "node ../../scripts/generate-readmes",
+    "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all test:*",
-    "test:tape": "node -r esm test.js"
+    "test:tape": "tsx test.js"
   },
   "devDependencies": {
     "benchmark": "*",
@@ -59,6 +59,7 @@
     "npm-run-all": "*",
     "rollup": "*",
     "tape": "*",
+    "tsx": "*",
     "write-json-file": "*"
   },
   "dependencies": {

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -64,8 +64,8 @@
   "scripts": {
     "build": "rollup -c rollup.config.js && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "last-checks": "npm-run-all last-checks:testjs last-checks:example",
-    "last-checks:example": "node test.example.js",
-    "last-checks:testjs": "node test.js",
+    "last-checks:example": "tsx test.example.js",
+    "last-checks:testjs": "tsx test.js",
     "test": "echo '@turf/turf tests run in the last-checks step'"
   },
   "devDependencies": {
@@ -79,7 +79,8 @@
     "glob": "*",
     "rollup": "^2.34.2",
     "rollup-plugin-terser": "^7.0.2",
-    "tape": "*"
+    "tape": "*",
+    "tsx": "*"
   },
   "dependencies": {
     "@turf/along": "^7.0.0-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,140 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@esbuild-kit/cjs-loader@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz#cb4dde00fbf744a68c4f20162ea15a8242d0fa54"
+  integrity sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==
+  dependencies:
+    "@esbuild-kit/core-utils" "^3.0.0"
+    get-tsconfig "^4.4.0"
+
+"@esbuild-kit/core-utils@^3.0.0", "@esbuild-kit/core-utils@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/core-utils/-/core-utils-3.2.2.tgz#ac3fe38d6ddcb3aa4658425034bb7a9cefa83495"
+  integrity sha512-Ub6LaRaAgF80dTSzUdXpFLM1pVDdmEVB9qb5iAzSpyDlX/mfJTFGOnZ516O05p5uWWteNviMKi4PAyEuRxI5gA==
+  dependencies:
+    esbuild "~0.18.20"
+    source-map-support "^0.5.21"
+
+"@esbuild-kit/esm-loader@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz#b82da14fcee3fc1d219869756c06f43f67d1ca71"
+  integrity sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==
+  dependencies:
+    "@esbuild-kit/core-utils" "^3.0.0"
+    get-tsconfig "^4.4.0"
+
+"@esbuild/android-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
+  integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+
+"@esbuild/android-arm@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
+  integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
+
+"@esbuild/android-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
+  integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+
+"@esbuild/darwin-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
+  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
+
+"@esbuild/darwin-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
+  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+
+"@esbuild/freebsd-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
+  integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
+
+"@esbuild/freebsd-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
+  integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+
+"@esbuild/linux-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
+  integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
+
+"@esbuild/linux-arm@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
+  integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
+
+"@esbuild/linux-ia32@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
+  integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
+
+"@esbuild/linux-loong64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
+  integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
+
+"@esbuild/linux-mips64el@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
+  integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
+
+"@esbuild/linux-ppc64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
+  integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
+
+"@esbuild/linux-riscv64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
+  integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
+
+"@esbuild/linux-s390x@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
+  integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
+
+"@esbuild/linux-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
+  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
+
+"@esbuild/netbsd-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
+  integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
+
+"@esbuild/openbsd-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
+  integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
+
+"@esbuild/sunos-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
+  integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
+
+"@esbuild/win32-arm64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
+  integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
+
+"@esbuild/win32-ia32@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
+  integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
+
+"@esbuild/win32-x64@0.18.20":
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
+  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+
 "@eslint/eslintrc@^0.2.1":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
@@ -2705,7 +2839,7 @@ are-we-there-yet@~1.1.2:
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha1-Jp/HrVuOQstjyJbVZmAXJhwUQIk=
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.9"
@@ -3758,6 +3892,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4352,6 +4491,34 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+esbuild@~0.18.20:
+  version "0.18.20"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.20.tgz#4709f5a34801b43b799ab7d6d82f7284a9b7a7a6"
+  integrity sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.18.20"
+    "@esbuild/android-arm64" "0.18.20"
+    "@esbuild/android-x64" "0.18.20"
+    "@esbuild/darwin-arm64" "0.18.20"
+    "@esbuild/darwin-x64" "0.18.20"
+    "@esbuild/freebsd-arm64" "0.18.20"
+    "@esbuild/freebsd-x64" "0.18.20"
+    "@esbuild/linux-arm" "0.18.20"
+    "@esbuild/linux-arm64" "0.18.20"
+    "@esbuild/linux-ia32" "0.18.20"
+    "@esbuild/linux-loong64" "0.18.20"
+    "@esbuild/linux-mips64el" "0.18.20"
+    "@esbuild/linux-ppc64" "0.18.20"
+    "@esbuild/linux-riscv64" "0.18.20"
+    "@esbuild/linux-s390x" "0.18.20"
+    "@esbuild/linux-x64" "0.18.20"
+    "@esbuild/netbsd-x64" "0.18.20"
+    "@esbuild/openbsd-x64" "0.18.20"
+    "@esbuild/sunos-x64" "0.18.20"
+    "@esbuild/win32-arm64" "0.18.20"
+    "@esbuild/win32-ia32" "0.18.20"
+    "@esbuild/win32-x64" "0.18.20"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5022,6 +5189,13 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-tsconfig@^4.4.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.0.tgz#06ce112a1463e93196aa90320c35df5039147e34"
+  integrity sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -6511,7 +6685,7 @@ make-dir@^3.0.0:
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-fetch-happen@^8.0.9:
   version "8.0.14"
@@ -8660,6 +8834,11 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -9052,7 +9231,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17, source-map-support@~0.5.20:
+source-map-support@^0.5.17, source-map-support@^0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -9749,12 +9928,13 @@ trough@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
 
-ts-node@*, ts-node@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
-  integrity sha1-52mdKhEMyMDTuDFxXkF2iGg0YLM=
+ts-node@^9.0.0:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
   dependencies:
     arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.17"
@@ -9806,6 +9986,17 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tsx@*, tsx@^3.12.8:
+  version "3.12.8"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-3.12.8.tgz#e9ec95c6b116e28f0187467f839029a3ce17a851"
+  integrity sha512-Lt9KYaRGF023tlLInPj8rgHwsZU8qWLBj4iRXNWxTfjIkU7canGL806AqKear1j722plHuiYNcL2ZCo6uS9UJA==
+  dependencies:
+    "@esbuild-kit/cjs-loader" "^2.4.2"
+    "@esbuild-kit/core-utils" "^3.2.2"
+    "@esbuild-kit/esm-loader" "^2.5.5"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -10545,7 +10736,7 @@ yargs@^16.0.0, yargs@^16.2.0:
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR replaces ts-node with tsx in doc generation and test scripts wherever possible to allow us more flexible use of third party libraries.

Background: as part of working on issue #1726 and associated PR #2476 I ran in to some problems where ts-node fell over trying to run the turf unit tests. A third party library we would like to use introduced import mechanisms that ts-node wasn't coping with when running tests. This seems to be related to mixing CJS / ESM imports.

Note that the turf library itself was building fine - just the tests were failing.

Once this PR is merged it will clear the way for PR #2476 to progress.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

Submitting a new TurfJS Module.
n/a
