### PR TITLE
Update GitHub actions to latest versions

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -18,25 +18,12 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      # figure out the yarn cache directory
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      # cache the yarn data to speed up builds
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: "yarn"
 
       - run: yarn --frozen-lockfile
       - run: git diff --exit-code


### PR DESCRIPTION
This PR:

* updates `actions/checkout` to v3 (from v2)
* updates `actions/setup-node` to v3 (from v1)
* removes manual caching for yarn as this is now handled via `setup-node` after version 2 (see: [https://github.com/actions/setup-node/releases/tag/v2.2.0](https://github.com/actions/setup-node/releases/tag/v2.2.0)). Has the nice side effect of removing a lot of noisy and potentially confusing code.

Resolves warnings on build:

<img width="948" alt="Screenshot 2023-09-30 at 09 44 50" src="https://github.com/Turfjs/turf/assets/8822075/2ecba2b9-426f-4722-9019-bd0ae3f8eb82">

