### PR TITLE
Add the support/6.x branch to the CI config so it builds when pushed to.

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -2,9 +2,9 @@ name: Turf.js CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, support/6.x]
   pull_request:
-    branches: [master]
+    branches: [master, support/6.x]
 
 permissions:
   contents: read


### PR DESCRIPTION
Configure github tools so CI builds the support/6.x branch when it is updated.