### PR TITLE
Export dist/es/index.d.ts files for use with Volar

### DIFF
--- a/.monorepolint.config.ts
+++ b/.monorepolint.config.ts
@@ -176,7 +176,7 @@ module.exports = {
             build: "npm-run-all --npm-path npm build:*",
             "build:js": "tsc",
             "build:es":
-              'tsc --outDir dist/es --module esnext --declaration false && echo \'{"type":"module"}\' > dist/es/package.json',
+              'tsc --outDir dist/es --module esnext && echo \'{"type":"module"}\' > dist/es/package.json',
           },
         },
         includePackages: TS_PACKAGES,

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "tsx bench.js",
     "build": "npm-run-all --npm-path npm build:*",
-    "build:es": "tsc --outDir dist/es --module esnext --declaration false && echo '{\"type\":\"module\"}' > dist/es/package.json",
+    "build:es": "tsc --outDir dist/es --module esnext && echo '{\"type\":\"module\"}' > dist/es/package.json",
     "build:js": "tsc",
     "docs": "tsx ../../scripts/generate-readmes",
     "test": "npm-run-all --npm-path npm test:*",


### PR DESCRIPTION
**Description of Changes**
- Removed the `--declaration=false` to output `dist/es/index.d.ts` files for use with volar
- Volar is the vue + typescript toolchain for vscode: https://marketplace.visualstudio.com/items?itemName=Vue.volar

![image](https://github.com/Turfjs/turf/assets/3267774/aa5ede1a-8ae3-4db7-b9e6-1f5cacec61da)

**Current Workaround**
- `yarn add --dev @types/turf`
- This is kind of confusing because the micro-packages like `@turf/intersect` should be in the typing package `@types/turf__intersect` package for the auto search to work


**Checklist**
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [X] Run `npm test` at the sub modules where changes have occurred.
- [X] Run `npm run lint` to ensure code style at the turf module level.
