### PR TITLE
Fix issues with prerelease builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v2.4.0
         with:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:prettier": "prettier --check .",
     "preinstall": "npx only-allow pnpm",
     "prepare": "lerna run build && husky install",
-    "publish:prerelease": "lerna publish --force-publish --canary major --dist-tag prerelease --yes",
+    "publish:prerelease": "lerna publish --force-publish --canary major --dist-tag prerelease --ignore-scripts true --yes",
     "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
   },
   "lint-staged": {

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -86,6 +86,7 @@
     "documentation": "^13.2.5",
     "glob": "^10.3.10",
     "rollup": "^2.79.1",
+    "rollup-plugin-polyfill-node": "^0.13.0",
     "tape": "^5.7.2",
     "tsup": "^8.0.1",
     "tsx": "^4.6.2",

--- a/packages/turf/rollup.config.js
+++ b/packages/turf/rollup.config.js
@@ -2,6 +2,7 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import terser from "@rollup/plugin-terser";
 import { babel } from "@rollup/plugin-babel";
+import nodePolyfills from "rollup-plugin-polyfill-node";
 
 const pckg = require("./package.json");
 const input = "index.ts";
@@ -13,6 +14,7 @@ export default [
     plugins: [
       commonjs(),
       nodeResolve(),
+      nodePolyfills(),
       babel({ babelHelpers: "bundled" }),
       terser(),
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
+      rollup-plugin-polyfill-node:
+        specifier: ^0.13.0
+        version: 0.13.0(rollup@2.79.1)
       tape:
         specifier: ^5.7.2
         version: 5.7.2
@@ -8419,6 +8422,21 @@ packages:
       rollup: 2.79.1
     dev: true
 
+  /@rollup/plugin-inject@5.0.5(rollup@2.79.1):
+    resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      estree-walker: 2.0.2
+      magic-string: 0.30.5
+      rollup: 2.79.1
+    dev: true
+
   /@rollup/plugin-node-resolve@15.2.3(rollup@2.79.1):
     resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
     engines: {node: '>=14.0.0'}
@@ -15693,6 +15711,15 @@ packages:
 
   /robust-predicates@2.0.4:
     resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
+
+  /rollup-plugin-polyfill-node@0.13.0(rollup@2.79.1):
+    resolution: {integrity: sha512-FYEvpCaD5jGtyBuBFcQImEGmTxDTPbiHjJdrYIp+mFIwgXiXabxvKUK7ZT9P31ozu2Tqm9llYQMRWsfvTMTAOw==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@2.79.1)
+      rollup: 2.79.1
+    dev: true
 
   /rollup@2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}


### PR DESCRIPTION
- Added a fetch-depth: 0 config that should give us the git history and correctly calculate the canary versions
- Don't run scripts as part of the lerna release step, they were already run by the github actions steps
- Fix issue with reference to the node 'util' package that was preventing the browser version of @turf/turf from working

I think that the `undefined` references from the previous attempt are being caused by the root package.json not having a version. I think that's fine though?