### PR TITLE
Remove references to geojsonhint and geojson-fixtures

### DIFF
--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -55,7 +55,6 @@
     "@types/benchmark": "^2.1.5",
     "@types/tape": "^4.2.32",
     "benchmark": "^2.1.4",
-    "geojson-fixtures": "*",
     "glob": "^10.3.10",
     "load-json-file": "^7.0.1",
     "npm-run-all": "^4.1.5",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -54,7 +54,7 @@
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@placemarkio/check-geojson": "0.1.12",
+    "@placemarkio/check-geojson": "^0.1.12",
     "@turf/truncate": "workspace:^",
     "@types/benchmark": "^2.1.5",
     "@types/tape": "^4.2.32",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -54,7 +54,7 @@
     "test:types": "tsc --esModuleInterop --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@mapbox/geojsonhint": "^3.2.0",
+    "@placemarkio/check-geojson": "0.1.12",
     "@turf/truncate": "workspace:^",
     "@types/benchmark": "^2.1.5",
     "@types/tape": "^4.2.32",

--- a/packages/turf-circle/test.ts
+++ b/packages/turf-circle/test.ts
@@ -5,7 +5,7 @@ import { loadJsonFileSync } from "load-json-file";
 import { writeJsonFileSync } from "write-json-file";
 import { truncate } from "@turf/truncate";
 import { featureCollection } from "@turf/helpers";
-import geojsonhint from "@mapbox/geojsonhint";
+import { check } from "@placemarkio/check-geojson";
 import { circle } from "./index";
 
 const directories = {
@@ -43,6 +43,11 @@ test("turf-circle", (t) => {
 
 test("turf-circle -- validate geojson", (t) => {
   const C = circle([0, 0], 100);
-  geojsonhint.hint(C).forEach((hint) => t.fail(hint.message));
+  try {
+    check(JSON.stringify(C));
+    t.pass();
+  } catch (e) {
+    t.fail(e.message);
+  }
   t.end();
 });

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -52,7 +52,7 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@placemarkio/check-geojson": "0.1.12",
+    "@placemarkio/check-geojson": "^0.1.12",
     "@turf/bbox-polygon": "workspace:^",
     "@turf/circle": "workspace:^",
     "@turf/destination": "workspace:^",

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -52,7 +52,7 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@mapbox/geojsonhint": "^3.2.0",
+    "@placemarkio/check-geojson": "0.1.12",
     "@turf/bbox-polygon": "workspace:^",
     "@turf/circle": "workspace:^",
     "@turf/destination": "workspace:^",

--- a/packages/turf-ellipse/test.ts
+++ b/packages/turf-ellipse/test.ts
@@ -5,7 +5,7 @@ import { loadJsonFileSync } from "load-json-file";
 import { writeJsonFileSync } from "write-json-file";
 import { circle } from "@turf/circle";
 import { truncate } from "@turf/truncate";
-import geojsonhint from "@mapbox/geojsonhint";
+import { check } from "@placemarkio/check-geojson";
 import { bboxPolygon } from "@turf/bbox-polygon";
 import { rhumbDestination } from "@turf/rhumb-destination";
 // import { destination } from '@turf/destination';
@@ -132,7 +132,12 @@ test("turf-ellipse -- with coordinates", (t) => {
 
 test("turf-ellipse -- validate geojson", (t) => {
   const E = ellipse([0, 0], 10, 20);
-  geojsonhint.hint(E).forEach((hint) => t.fail(hint.message));
+  try {
+    check(JSON.stringify(E));
+    t.pass();
+  } catch (e) {
+    t.fail(e.message);
+  }
   t.end();
 });
 

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -54,7 +54,6 @@
     "@types/benchmark": "^2.1.5",
     "@types/tape": "^4.2.32",
     "benchmark": "^2.1.4",
-    "geojson-fixtures": "*",
     "load-json-file": "^7.0.1",
     "npm-run-all": "^4.1.5",
     "tape": "^5.7.2",

--- a/packages/turf-explode/test.ts
+++ b/packages/turf-explode/test.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 import tape from "tape";
-import { all as fixtures } from "geojson-fixtures";
 import { loadJsonFileSync } from "load-json-file";
 import { writeJsonFileSync } from "write-json-file";
 import { explode } from "./index";
@@ -11,14 +10,7 @@ const directories = {
   out: path.join(__dirname, "test", "out") + path.sep,
 };
 
-// Save input fixtures
-if (process.env.REGEN) {
-  Object.keys(fixtures).forEach((name) => {
-    writeJsonFileSync(directories.in + name + ".json", fixtures[name]);
-  });
-}
-
-tape("explode - geojson-fixtures", (t) => {
+tape("explode - fixtures", (t) => {
   fs.readdirSync(directories.in).forEach((filename) => {
     const name = filename.replace(".json", "");
     const features = loadJsonFileSync(directories.in + filename);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1876,9 +1876,6 @@ importers:
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
-      geojson-fixtures:
-        specifier: '*'
-        version: 1.0.0
       glob:
         specifier: ^10.3.10
         version: 10.3.10
@@ -1916,9 +1913,9 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
     devDependencies:
-      '@mapbox/geojsonhint':
-        specifier: ^3.2.0
-        version: 3.3.0
+      '@placemarkio/check-geojson':
+        specifier: 0.1.12
+        version: 0.1.12
       '@turf/truncate':
         specifier: workspace:^
         version: link:../turf-truncate
@@ -2727,9 +2724,9 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
     devDependencies:
-      '@mapbox/geojsonhint':
-        specifier: ^3.2.0
-        version: 3.3.0
+      '@placemarkio/check-geojson':
+        specifier: 0.1.12
+        version: 0.1.12
       '@turf/bbox-polygon':
         specifier: workspace:^
         version: link:../turf-bbox-polygon
@@ -2840,9 +2837,6 @@ importers:
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
-      geojson-fixtures:
-        specifier: '*'
-        version: 1.0.0
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
@@ -7678,11 +7672,6 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@gerhobbelt/linewrap@0.2.2-3:
-    resolution: {integrity: sha512-u2eUbXgNtqckBI4gxds/uiUNoytT+qIqpePmVDI5isW8A18uB3Qz1P+UxAHgFafGOZWJNrpR0IKnZhl7QhaUng==}
-    engines: {node: '>=4.0'}
-    dev: true
-
   /@gwhitney/detect-indent@7.0.1:
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
     engines: {node: '>=12.20'}
@@ -7869,18 +7858,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.5
-    dev: true
-
-  /@mapbox/geojsonhint@3.3.0:
-    resolution: {integrity: sha512-+2F3ZpVYeIcMRuN+lxNG4FrP5jct8tArR39RVsZE6Yh5lEbe7zlE/U8zKP3ezsfOckFskGfwC2u7COdH5MbEvA==}
-    hasBin: true
-    dependencies:
-      '@gerhobbelt/nomnom': github.com/gerhobbelt/nomnom/559dfcd9436b3beeeccdc0a4f28f0e3f988379ca
-      concat-stream: 1.6.2
-      jsonlint-lines: 1.7.1
-      minimist: 1.2.8
-      vfile: 4.2.1
-      vfile-reporter: 5.1.2
     dev: true
 
   /@monorepolint/cli@0.5.0-alpha.132:
@@ -8317,6 +8294,11 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       tslib: 2.6.2
+    dev: true
+
+  /@placemarkio/check-geojson@0.1.12:
+    resolution: {integrity: sha512-sSNPtPDVB0oKwImi4NYg1LVE2QSCIqs/jIRmu8U4fQVWdRjlGy+C/n7AbNO2FycE9rVWtz256f33aMGzvKC7gg==}
+    engines: {node: '>=10'}
     dev: true
 
   /@pnpm/constants@6.1.0:
@@ -9046,10 +9028,6 @@ packages:
       through: 2.3.8
     dev: true
 
-  /JSV@4.0.2:
-    resolution: {integrity: sha512-ZJ6wx9xaKJ3yFUhq5/sk82PJMuUyLk277I8mQeyDgCTjGdjWJIvPfaU5LIXaMuaN2UO1X3kZH4+lgphublZUHw==}
-    dev: true
-
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
@@ -9148,16 +9126,6 @@ packages:
     hasBin: true
     dev: true
 
-  /ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
-    engines: {node: '>=4'}
-    dev: true
-
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -9166,16 +9134,6 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: true
-
-  /ansi-styles@1.0.0:
-    resolution: {integrity: sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==}
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  /ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /ansi-styles@3.2.1:
@@ -9721,26 +9679,6 @@ packages:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
     dev: true
 
-  /chalk@0.4.0:
-    resolution: {integrity: sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      ansi-styles: 1.0.0
-      has-color: 0.1.7
-      strip-ansi: 0.1.1
-    dev: true
-
-  /chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
-    dev: true
-
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -10044,15 +9982,6 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-    dev: true
-
-  /concat-stream@1.4.11:
-    resolution: {integrity: sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==}
-    engines: {'0': node >= 0.8}
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 1.1.14
-      typedarray: 0.0.7
     dev: true
 
   /concat-stream@1.5.2:
@@ -11377,11 +11306,6 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
-  /exit@0.1.2:
-    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
-    engines: {node: '>= 0.8.0'}
-    dev: true
-
   /expand-brackets@2.1.4:
     resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
     engines: {node: '>=0.10.0'}
@@ -11763,29 +11687,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /geojson-fixtures@1.0.0:
-    resolution: {integrity: sha512-px8brZEL2HbIUoytDCsmQCEYXU5RHZYrSBMdfOH0MIp7dPqWO54ULi+E/vtwZCF8iVFxidj8GN2ysfOWpo+Gkw==}
-    dependencies:
-      geojsonhint: 1.2.1
-    dev: true
-
   /geojson-polygon-self-intersections@1.2.1:
     resolution: {integrity: sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==}
     dependencies:
       rbush: 2.0.2
     dev: false
-
-  /geojsonhint@1.2.1:
-    resolution: {integrity: sha512-jR1pLHEjzO+6jNs4hAg3ZM1raFQZo8Lu9vyUpKCWZP6g6QqHSfk1Y9eWLURGqC7Vn5r3eROfcnfJ7vwPDKTgsg==}
-    deprecated: 'This module is now under the @mapbox namespace: install @mapbox/geojsonhint instead'
-    hasBin: true
-    dependencies:
-      chalk: 1.1.3
-      concat-stream: 1.4.11
-      jsonlint-lines: 1.7.1
-      minimist: 1.1.1
-      text-table: 0.2.0
-    dev: true
 
   /get-amd-module-type@3.0.2:
     resolution: {integrity: sha512-PcuKwB8ouJnKuAPn6Hk3UtdfKoUV3zXRqVEvj8XGIXqjWfgd1j7QGdXy5Z9OdQfzVt1Sk29HVe/P+X74ccOuqw==}
@@ -12148,20 +12054,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: true
-
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
-
-  /has-color@0.1.7:
-    resolution: {integrity: sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /has-dynamic-import@2.0.1:
     resolution: {integrity: sha512-X3fbtsZmwb6W7fJGR9o7x65fZoodygCrZ3TVycvghP62yYQfS0t4RS0Qcz+j5tQYUKeSWS09tHkWW6WhFV3XhQ==}
@@ -12662,11 +12556,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
-    engines: {node: '>=4'}
-    dev: true
-
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -12923,10 +12812,6 @@ packages:
       is-docker: 2.2.1
     dev: true
 
-  /isarray@0.0.1:
-    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
-    dev: true
-
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
     dev: true
@@ -13072,15 +12957,6 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
-
-  /jsonlint-lines@1.7.1:
-    resolution: {integrity: sha512-Xp9w20GzfOiwabOqi3bH4Gnx85WFwpaWebmaspaDwX9fBISlEnKYoMtIR9bu6OGFIKzt50BRVyXLxRKDZXQ8Hg==}
-    engines: {node: '>= 0.6'}
-    hasBin: true
-    dependencies:
-      JSV: 4.0.2
-      nomnom: 1.8.1
     dev: true
 
   /jsonparse@1.3.1:
@@ -13915,10 +13791,6 @@ packages:
       kind-of: 6.0.3
     dev: true
 
-  /minimist@1.1.1:
-    resolution: {integrity: sha512-FzcUe2HULkO6NxOnADCRJos39lkw3Uy+i8hpVfHDrBK0fdbTLkeo6LveAY6dEJwoSxwB3z6MyQSOJDRZ6w9kvA==}
-    dev: true
-
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
@@ -14233,14 +14105,6 @@ packages:
     engines: {node: '>=6.0'}
     dependencies:
       '@babel/parser': 7.23.5
-    dev: true
-
-  /nomnom@1.8.1:
-    resolution: {integrity: sha512-5s0JxqhDx9/rksG2BTMVN1enjWSvPidpoSgViZU4ZXULyTe+7jxcCRLB6f42Z0l1xYJpleCBtSyY6Lwg3uu5CQ==}
-    deprecated: Package no longer supported. Contact support@npmjs.com for more info.
-    dependencies:
-      chalk: 0.4.0
-      underscore: 1.6.0
     dev: true
 
   /nopt@6.0.0:
@@ -15363,15 +15227,6 @@ packages:
       mute-stream: 1.0.0
     dev: true
 
-  /readable-stream@1.1.14:
-    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: true
-
   /readable-stream@2.0.6:
     resolution: {integrity: sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==}
     dependencies:
@@ -16271,14 +16126,6 @@ packages:
     resolution: {integrity: sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==}
     dev: true
 
-  /string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-    dev: true
-
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -16367,26 +16214,6 @@ packages:
   /stringify-package@1.0.1:
     resolution: {integrity: sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==}
     deprecated: This module is not used anymore, and has been replaced by @npmcli/package-json
-    dev: true
-
-  /strip-ansi@0.1.1:
-    resolution: {integrity: sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dev: true
-
-  /strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: true
-
-  /strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-regex: 3.0.1
     dev: true
 
   /strip-ansi@6.0.1:
@@ -16483,11 +16310,6 @@ packages:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
-    dev: true
-
-  /supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
     dev: true
 
   /supports-color@5.5.0:
@@ -17037,10 +16859,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /underscore@1.6.0:
-    resolution: {integrity: sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==}
-    dev: true
-
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -17264,17 +17082,6 @@ packages:
     dependencies:
       '@types/unist': 2.0.10
       unist-util-stringify-position: 2.0.3
-    dev: true
-
-  /vfile-reporter@5.1.2:
-    resolution: {integrity: sha512-b15sTuss1wOPWVlyWOvu+n6wGJ/eTYngz3uqMLimQvxZ+Q5oFQGYZZP1o3dR9sk58G5+wej0UPCZSwQBX/mzrQ==}
-    dependencies:
-      repeat-string: 1.6.1
-      string-width: 2.1.1
-      supports-color: 5.5.0
-      unist-util-stringify-position: 2.0.3
-      vfile-sort: 2.2.2
-      vfile-statistics: 1.1.4
     dev: true
 
   /vfile-reporter@6.0.2:
@@ -17712,15 +17519,4 @@ packages:
 
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
-    dev: true
-
-  github.com/gerhobbelt/nomnom/559dfcd9436b3beeeccdc0a4f28f0e3f988379ca:
-    resolution: {tarball: https://codeload.github.com/gerhobbelt/nomnom/tar.gz/559dfcd9436b3beeeccdc0a4f28f0e3f988379ca}
-    name: '@gerhobbelt/nomnom'
-    version: 1.8.4-32
-    engines: {node: '>=4.0'}
-    dependencies:
-      '@gerhobbelt/linewrap': 0.2.2-3
-      chalk: 4.1.0
-      exit: 0.1.2
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1914,7 +1914,7 @@ importers:
         version: 2.6.2
     devDependencies:
       '@placemarkio/check-geojson':
-        specifier: 0.1.12
+        specifier: ^0.1.12
         version: 0.1.12
       '@turf/truncate':
         specifier: workspace:^
@@ -2725,7 +2725,7 @@ importers:
         version: 2.6.2
     devDependencies:
       '@placemarkio/check-geojson':
-        specifier: 0.1.12
+        specifier: ^0.1.12
         version: 0.1.12
       '@turf/bbox-polygon':
         specifier: workspace:^


### PR DESCRIPTION
There were transitively bringing in a weird dependency to a specific git commit of gerhobbelt/nomnom and was [breaking CI](https://github.com/Turfjs/turf/pull/2566) for dependabot.
