### PR TITLE
Fix #2059 turf-boolean-within returning false positive when line ends outside poly

### DIFF
--- a/packages/turf-boolean-within/index.ts
+++ b/packages/turf-boolean-within/index.ts
@@ -173,7 +173,7 @@ function isLineInPoly(linestring: LineString, polygon: Polygon) {
   }
   var foundInsidePoint = false;
 
-  for (var i = 0; i < linestring.coordinates.length - 1; i++) {
+  for (var i = 0; i < linestring.coordinates.length; i++) {
     if (!booleanPointInPolygon(linestring.coordinates[i], polygon)) {
       return false;
     }
@@ -184,7 +184,7 @@ function isLineInPoly(linestring: LineString, polygon: Polygon) {
         { ignoreBoundary: true }
       );
     }
-    if (!foundInsidePoint) {
+    if (!foundInsidePoint && i < linestring.coordinates.length - 1) {
       var midpoint = getMidpoint(
         linestring.coordinates[i],
         linestring.coordinates[i + 1]


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Have read [How To Contribute](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#how-to-contribute).
- [x] Run `npm test` at the sub modules where changes have occurred.
- [x] Run `npm run lint` to ensure code style at the turf module level.

In boolean-within check if the LineString ends outside of the Polygon.
This PR fixes issue #2059.

Tested by the following two test cases:

```ts
// should return false
const resRobertOrthofer = turf.booleanWithin({
  "type": "LineString",
  "coordinates": [
    [ -26.19140625, 46.800059446787316 ],
    [ -38.14453125, 45.82879925192134 ],
    [-35.15625, 39.90973623453719]
  ]
}, {
  "type": "Polygon",
  "coordinates": [[
    [ -54.84375, 43.70759350405294 ],
    [ -55.1953125, 29.53522956294847 ],
    [ -39.375, 30.14512718337613 ],
    [ -43.59375, 41.11246878918088 ],
    [ -25.48828125, 43.32517767999296 ],
    [ -21.796875, 34.30714385628804 ],
    [ -15.468749999999998, 36.59788913307022 ],
    [ -19.16015625, 49.26780455063753 ],
    [ -54.84375, 43.70759350405294 ]
  ]]
});

// should return false
const resKudlav = turf.booleanWithin({
  "type": "LineString",
  "coordinates": [
    [9.15, 32.46],
    [12.33, 41.6]
  ]
}, {
  "type": "Polygon",
  "coordinates": [[
    [ -0.64, 23.73 ],
    [ 2.22, 24.89 ],
    [ 7.13, 31.6 ],
    [ 14.9, 33.93 ],
    [ 23.41, 32.26 ],
    [ 23.99, 34.46 ],
    [ 27.12, 34.89 ],
    [ 28.56, 38.13 ],
    [ 33.68, 41.6 ],
    [ 13.6, 41.36 ],
    [ 2.53, 38.38 ],
    [ -0.3, 36.01 ],
    [ -0.64, 23.73 ]
  ]]
});
```