### PR TITLE
V7 prep

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,4 +1,4 @@
-name: prerelease
+name: Publish canary
 
 on:
   push:
@@ -41,6 +41,6 @@ jobs:
       - run: pnpm test
 
       - name: run publish
-        run: pnpm run publish:prerelease
+        run: lerna publish major --canary --force-publish --dist-tag prerelease --ignore-scripts true --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: prerelease
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        node:
+          - 18
+        platform:
+          - ubuntu-latest
+    name: "${{matrix.platform}} / Node.js ${{ matrix.node }}"
+    runs-on: ${{matrix.platform}}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v2.4.0
+        with:
+          version: 8
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test
+
+      - name: run publish
+        run: pnpm run publish:prerelease
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Turf to npmjs
+name: Publish release
 
 on:
   release:
@@ -17,7 +17,8 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checking out v${{ github.event.tag }}
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.tag }}
@@ -33,15 +34,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      # Temp disabled for testing publish with junk NPM token
-      # - run: pnpm whoami
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test
 
-      - run: pnpx lerna publish from-git --yes
+      - name: run publish
+        run: pnpx lerna publish from-git --ignore-scripts --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: prerelease
+name: Publish Turf to npmjs
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -32,15 +32,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      - run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Temp disabled for testing publish with junk NPM token
+      # - run: pnpm whoami
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test
 
-      - name: run publish
-        run: pnpm run publish:prerelease
+      - run: pnpm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.tag }}
 
       - uses: pnpm/action-setup@v2.4.0
         with:
@@ -41,6 +42,6 @@ jobs:
 
       - run: pnpm test
 
-      - run: pnpm publish
+      - run: pnpx lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -1,4 +1,4 @@
-name: Turf.js CI
+name: CI build
 
 on:
   push:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "lint:prettier": "prettier --check .",
     "preinstall": "npx only-allow pnpm",
     "prepare": "lerna run build && husky install",
-    "publish:prerelease": "lerna publish --force-publish --canary major --dist-tag prerelease --ignore-scripts true --yes",
     "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
   },
   "lint-staged": {


### PR DESCRIPTION
Preparatory setup for v7 release. Summary of changes:

- new github workflow to publish releases to npm
- updated CHANGELOG TODO in a later commit

@mfedderly your thoughts? The way I envisage this working once these changes are merged would be:

1. branch HEAD into releases/v7.0.0
2. pull branch to local repo
3. run ```lerna version major ...``` to update package.jsons, creates v7.0.0 tag, etc
4. push branch and tag back to origin - shouldn't do anything as we're not committing to master
5. use github UI to create a release based on v7.0.0 tag
6. that triggers new release workflow that checks out v7.0.0 tag, builds, and calls ...
7. ```lerna publish from-git ...``` which as I understand from [here](https://github.com/lerna/lerna/tree/main/libs/commands/publish#bump-from-git) should(?) figure out v7 has been tagged but yet to be published
8. once the release is out, merge relevant changes to releases/v7.0.0 back to master to continue development

Step 7 I'm currently the least sure about.