### PR TITLE
Added support/6.x branch to CI config

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -2,9 +2,13 @@ name: CI build
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - support/6.x
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - support/6.x
 
 permissions:
   contents: read


### PR DESCRIPTION
Add support/6.x branch to CI config so related activity prompts a build and test cycle.

Not directly related to any release, just housekeeping.