### PR TITLE
Add explicit geojson types dependency

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -250,5 +250,14 @@ export default {
       },
       includePackages: [MAIN_PACKAGE],
     }),
+
+    requireDependency({
+      options: {
+        dependencies: {
+          "@types/geojson": "^7946.0.0",
+        },
+      },
+      includePackages: [MAIN_PACKAGE, ...TS_PACKAGES, ...JS_PACKAGES],
+    }),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@monorepolint/config": "0.5.0-alpha.132",
     "@monorepolint/core": "0.5.0-alpha.132",
     "@monorepolint/rules": "0.5.0-alpha.132",
-    "@types/geojson": "7946.0.8",
     "@types/node": "18.11.9",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -68,6 +68,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -72,6 +72,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/rhumb-bearing": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -74,6 +74,7 @@
     "@turf/boolean-point-on-line": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -73,6 +73,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/line-intersect": "workspace:^",
     "@turf/polygon-to-line": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -72,6 +72,7 @@
     "@turf/line-intersect": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/polygon-to-line": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -74,6 +74,7 @@
     "@turf/clean-coords": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "geojson-equality-ts": "^1.0.2",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -71,6 +71,7 @@
     "@turf/boolean-disjoint": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -75,6 +75,7 @@
     "@turf/line-intersect": "workspace:^",
     "@turf/line-overlap": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "geojson-equality-ts": "^1.0.2",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -70,6 +70,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/line-segment": "workspace:^",
     "@turf/rhumb-bearing": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "point-in-polygon-hao": "^1.1.0",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -75,6 +75,7 @@
     "@turf/boolean-point-on-line": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -78,6 +78,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/line-intersect": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "geojson-polygon-self-intersections": "^1.2.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -76,6 +76,7 @@
     "@turf/boolean-point-on-line": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -78,6 +78,7 @@
     "@turf/jsts": "^2.7.1",
     "@turf/meta": "workspace:^",
     "@turf/projection": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "d3-geo": "1.7.1"
   }
 }

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -76,6 +76,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -73,6 +73,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -68,6 +68,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@turf/bbox": "workspace:^",
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@turf/destination": "workspace:^",
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -81,6 +81,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "rbush": "^3.0.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -81,6 +81,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "skmeans": "0.9.7",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -70,6 +70,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/boolean-point-in-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "rbush": "^3.0.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -82,6 +82,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/tin": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "topojson-client": "3.x",
     "topojson-server": "3.x",
     "tslib": "^2.6.2"

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "concaveman": "^1.2.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -71,6 +71,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/length": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -68,6 +68,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -68,6 +68,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -74,6 +74,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
     "@turf/transform-rotate": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -66,6 +66,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/bbox-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -67,6 +67,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-geojson-rbush/package.json
+++ b/packages/turf-geojson-rbush/package.json
@@ -75,7 +75,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "rbush": "^3.0.1"
   }
 }

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@turf/invariant": "workspace:^"
+    "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -68,6 +68,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -80,6 +80,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/intersect": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -77,6 +77,7 @@
     "@turf/meta": "workspace:^",
     "@turf/point-grid": "workspace:^",
     "@turf/square-grid": "workspace:^",
-    "@turf/triangle-grid": "workspace:^"
+    "@turf/triangle-grid": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -81,6 +81,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "marchingsquares": "^1.3.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -78,6 +78,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "marchingsquares": "^1.3.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "sweepline-intersections": "^1.5.0",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -72,6 +72,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -66,6 +66,7 @@
     "@turf/circle": "workspace:^",
     "@turf/destination": "workspace:^",
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -74,6 +74,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/length": "workspace:^",
     "@turf/line-slice-along": "workspace:^",
-    "@turf/meta": "workspace:^"
+    "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "sweepline-intersections": "^1.5.0",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@turf/meta": "workspace:^"
+    "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -75,6 +75,7 @@
     "@turf/line-segment": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/nearest-point-on-line": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -65,6 +65,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -65,6 +65,7 @@
     "@turf/bearing": "workspace:^",
     "@turf/destination": "workspace:^",
     "@turf/distance": "workspace:^",
-    "@turf/helpers": "workspace:^"
+    "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@turf/nearest-point-on-line": "workspace:^"
+    "@turf/nearest-point-on-line": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -75,6 +75,7 @@
     "@turf/meta": "workspace:^",
     "@turf/nearest-point-on-line": "workspace:^",
     "@turf/square": "workspace:^",
-    "@turf/truncate": "workspace:^"
+    "@turf/truncate": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -72,6 +72,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -82,6 +82,7 @@
     "tsx": "^4.6.2"
   },
   "dependencies": {
-    "@turf/helpers": "workspace:^"
+    "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0"
   }
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -66,7 +66,7 @@
     "@turf/destination": "workspace:^",
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -67,6 +67,7 @@
     "@turf/distance-weight": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -73,6 +73,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/nearest-point": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -68,6 +68,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/line-intersect": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -75,6 +75,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/point-to-line-distance": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -70,6 +70,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -74,6 +74,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -71,6 +71,7 @@
     "@turf/explode": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/nearest-point": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -75,6 +75,7 @@
     "@turf/projection": "workspace:^",
     "@turf/rhumb-bearing": "workspace:^",
     "@turf/rhumb-distance": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -66,6 +66,7 @@
     "@turf/boolean-point-in-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -75,6 +75,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/nearest-point": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -73,6 +73,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -81,6 +81,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -74,6 +74,7 @@
     "@turf/point-grid": "workspace:^",
     "@turf/random": "workspace:^",
     "@turf/square-grid": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -72,6 +72,7 @@
     "@turf/boolean-intersects": "workspace:^",
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -75,6 +75,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -68,6 +68,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/line-arc": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -77,6 +77,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/transform-scale": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -75,6 +75,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/rectangle-grid": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -75,7 +75,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/points-within-polygon": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -70,6 +70,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "earcut": "^2.2.4",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -77,7 +77,7 @@
     "@turf/rhumb-bearing": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
     "@turf/rhumb-distance": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -85,7 +85,7 @@
     "@turf/rhumb-bearing": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
     "@turf/rhumb-distance": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -76,7 +76,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -71,6 +71,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/intersect": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -70,7 +70,7 @@
     "@turf/boolean-point-in-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "rbush": "^3.0.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -75,7 +75,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@types/d3-voronoi": "^1.1.12",
-    "@types/geojson": "7946.0.8",
+    "@types/geojson": "^7946.0.0",
     "d3-voronoi": "1.1.2",
     "tslib": "^2.6.2"
   }

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -204,6 +204,7 @@
     "@turf/union": "workspace:^",
     "@turf/unkink-polygon": "workspace:^",
     "@turf/voronoi": "workspace:^",
+    "@types/geojson": "^7946.0.0",
     "tslib": "^2.6.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@monorepolint/rules':
         specifier: 0.5.0-alpha.132
         version: 0.5.0-alpha.132
-      '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
       '@types/node':
         specifier: 18.11.9
         version: 18.11.9
@@ -449,6 +446,9 @@ importers:
       '@turf/voronoi':
         specifier: workspace:^
         version: link:../turf-voronoi
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -519,6 +519,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -565,6 +568,9 @@ importers:
       '@turf/rhumb-bearing':
         specifier: workspace:^
         version: link:../turf-rhumb-bearing
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -620,6 +626,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -663,6 +672,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -700,6 +712,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -743,6 +758,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -780,6 +798,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -823,6 +844,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -866,6 +890,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -909,6 +936,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -961,6 +991,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1019,6 +1052,9 @@ importers:
       '@turf/polygon-to-line':
         specifier: workspace:^
         version: link:../turf-polygon-to-line
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1074,6 +1110,9 @@ importers:
       '@turf/polygon-to-line':
         specifier: workspace:^
         version: link:../turf-polygon-to-line
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1120,6 +1159,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       geojson-equality-ts:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1172,6 +1214,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1224,6 +1269,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       geojson-equality-ts:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1279,6 +1327,9 @@ importers:
       '@turf/rhumb-bearing':
         specifier: workspace:^
         version: link:../turf-rhumb-bearing
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1322,6 +1373,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       point-in-polygon-hao:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1362,6 +1416,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1414,6 +1471,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1484,6 +1544,9 @@ importers:
       '@turf/line-intersect':
         specifier: workspace:^
         version: link:../turf-line-intersect
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       geojson-polygon-self-intersections:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1545,6 +1608,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1606,6 +1672,9 @@ importers:
       '@turf/projection':
         specifier: workspace:^
         version: link:../turf-projection
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       d3-geo:
         specifier: 1.7.1
         version: 1.7.1
@@ -1649,6 +1718,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1704,6 +1776,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1765,6 +1840,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1829,6 +1907,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1875,6 +1956,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1921,6 +2005,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1970,6 +2057,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2013,6 +2103,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2053,6 +2146,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2096,6 +2192,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
@@ -2163,6 +2262,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       skmeans:
         specifier: 0.9.7
         version: 0.9.7
@@ -2230,6 +2332,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
@@ -2273,6 +2378,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2322,6 +2430,9 @@ importers:
       '@turf/tin':
         specifier: workspace:^
         version: link:../turf-tin
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       topojson-client:
         specifier: 3.x
         version: 3.1.0
@@ -2377,6 +2488,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       concaveman:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2429,6 +2543,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2478,6 +2595,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
         version: 0.15.3
@@ -2542,6 +2662,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2591,6 +2714,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
         version: 0.15.3
@@ -2637,6 +2763,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2686,6 +2815,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2735,6 +2867,9 @@ importers:
       '@turf/transform-rotate':
         specifier: workspace:^
         version: link:../turf-transform-rotate
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2799,6 +2934,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2839,6 +2977,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2882,6 +3023,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2928,6 +3072,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2975,8 +3122,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
@@ -3026,6 +3173,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/truncate':
         specifier: workspace:^
@@ -3060,6 +3210,9 @@ importers:
 
   packages/turf-helpers:
     dependencies:
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3103,6 +3256,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3179,6 +3335,9 @@ importers:
       '@turf/triangle-grid':
         specifier: workspace:^
         version: link:../turf-triangle-grid
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/truncate':
         specifier: workspace:^
@@ -3222,6 +3381,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
         version: 0.15.3
@@ -3268,6 +3430,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3320,6 +3485,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       marchingsquares:
         specifier: ^1.3.3
         version: 1.3.3
@@ -3387,6 +3555,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       marchingsquares:
         specifier: ^1.3.3
         version: 1.3.3
@@ -3445,6 +3616,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       sweepline-intersections:
         specifier: ^1.5.0
         version: 1.5.0
@@ -3497,6 +3671,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3543,6 +3720,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3595,6 +3775,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/truncate':
         specifier: workspace:^
@@ -3632,6 +3815,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       sweepline-intersections:
         specifier: ^1.5.0
         version: 1.5.0
@@ -3684,6 +3870,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/truncate':
         specifier: workspace:^
@@ -3739,6 +3928,9 @@ importers:
       '@turf/nearest-point-on-line':
         specifier: workspace:^
         version: link:../turf-nearest-point-on-line
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -3788,6 +3980,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3834,6 +4029,9 @@ importers:
       '@turf/nearest-point-on-line':
         specifier: workspace:^
         version: link:../turf-nearest-point-on-line
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/truncate':
         specifier: workspace:^
@@ -3880,6 +4078,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/along':
         specifier: workspace:^
@@ -3944,6 +4145,9 @@ importers:
       '@turf/truncate':
         specifier: workspace:^
         version: link:../turf-truncate
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@types/benchmark':
         specifier: ^2.1.5
@@ -3987,6 +4191,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4028,8 +4235,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
         version: 0.15.3
@@ -4076,6 +4283,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
     devDependencies:
       '@turf/random':
         specifier: workspace:^
@@ -4114,8 +4324,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4156,6 +4366,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4217,6 +4430,9 @@ importers:
       '@turf/nearest-point':
         specifier: workspace:^
         version: link:../turf-nearest-point
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4269,6 +4485,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4327,6 +4546,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4385,6 +4607,9 @@ importers:
       '@turf/point-to-line-distance':
         specifier: workspace:^
         version: link:../turf-point-to-line-distance
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4438,8 +4663,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4483,6 +4708,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4541,6 +4769,9 @@ importers:
       '@turf/nearest-point':
         specifier: workspace:^
         version: link:../turf-nearest-point
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4605,6 +4836,9 @@ importers:
       '@turf/rhumb-distance':
         specifier: workspace:^
         version: link:../turf-rhumb-distance
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4654,6 +4888,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4691,6 +4928,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4749,6 +4989,9 @@ importers:
       '@turf/nearest-point':
         specifier: workspace:^
         version: link:../turf-nearest-point
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4792,6 +5035,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4844,6 +5090,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4890,6 +5139,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -4960,6 +5212,9 @@ importers:
       '@turf/square-grid':
         specifier: workspace:^
         version: link:../turf-square-grid
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5003,6 +5258,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5046,6 +5304,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5104,6 +5365,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5147,6 +5411,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5190,6 +5457,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5236,6 +5506,9 @@ importers:
       '@turf/invariant':
         specifier: workspace:^
         version: link:../turf-invariant
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5279,6 +5552,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5325,6 +5601,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5392,6 +5671,9 @@ importers:
       '@turf/transform-scale':
         specifier: workspace:^
         version: link:../turf-transform-scale
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5444,6 +5726,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5491,8 +5776,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5530,6 +5815,9 @@ importers:
       '@turf/rectangle-grid':
         specifier: workspace:^
         version: link:../turf-rectangle-grid
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5589,8 +5877,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-points-within-polygon
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5646,6 +5934,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5684,8 +5975,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       earcut:
         specifier: ^2.2.4
         version: 2.2.4
@@ -5723,6 +6014,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:^
         version: link:../turf-helpers
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5779,8 +6073,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5852,8 +6146,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5916,8 +6210,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-destination
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -5967,6 +6261,9 @@ importers:
       '@turf/intersect':
         specifier: workspace:^
         version: link:../turf-intersect
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -6016,6 +6313,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -6059,6 +6359,9 @@ importers:
       '@turf/meta':
         specifier: workspace:^
         version: link:../turf-meta
+      '@types/geojson':
+        specifier: ^7946.0.0
+        version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
         version: 0.15.3
@@ -6115,8 +6418,8 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
@@ -6173,8 +6476,8 @@ importers:
         specifier: ^1.1.12
         version: 1.1.12
       '@types/geojson':
-        specifier: 7946.0.8
-        version: 7946.0.8
+        specifier: ^7946.0.0
+        version: 7946.0.14
       d3-voronoi:
         specifier: 1.1.2
         version: 1.1.2
@@ -9005,10 +9308,6 @@ packages:
 
   /@types/geojson@7946.0.14:
     resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
-    dev: false
-
-  /@types/geojson@7946.0.8:
-    resolution: {integrity: sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==}
 
   /@types/hast@2.3.10:
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -9094,21 +9393,21 @@ packages:
   /@types/topojson-client@3.1.3:
     resolution: {integrity: sha512-liC+dHCxoqQy5bbJMsF59Cx1WZZwbcT084v/5bdp3NWSFUuzQpsm4gbLQh+wlv58Mng4jCsO4p8hWelqGlb7rg==}
     dependencies:
-      '@types/geojson': 7946.0.8
+      '@types/geojson': 7946.0.14
       '@types/topojson-specification': 1.0.5
     dev: true
 
   /@types/topojson-server@3.0.3:
     resolution: {integrity: sha512-Xi903I5D0pu9il0xXRNxugj5MuIAUalZzciGS0FTLbiW4jLyd2jkoVN2g80RavHw39Z8YTFaSdRgp8f8WHbyxg==}
     dependencies:
-      '@types/geojson': 7946.0.8
+      '@types/geojson': 7946.0.14
       '@types/topojson-specification': 1.0.5
     dev: true
 
   /@types/topojson-specification@1.0.5:
     resolution: {integrity: sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==}
     dependencies:
-      '@types/geojson': 7946.0.8
+      '@types/geojson': 7946.0.14
     dev: true
 
   /@types/triple-beam@1.3.5:


### PR DESCRIPTION
Fixes https://github.com/Turfjs/turf/issues/2617

I struggled a bit trying to figure out what type of dependency this actually represents. I considered defining it as a peer dependency, but in the end it seems like several other packages declare it as a normal dependency (including `maplibre-gl`).

PR done in two commits, the first one is the manual changes and the second is just running monorepolint and pnpm to get everything in sync with the new spec.