### PR TITLE
Change typescript to depend on source instead of built files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ packages/turf-directional-mean/test/in/bus_route_utm.json
 
 # is actually output
 packages/turf/turf.min.js
+packages/turf/test.example.js
 
 # Ignore test fixture json in case intentional line breaks help with coord
 # readability.

--- a/packages/turf/test.ts
+++ b/packages/turf/test.ts
@@ -331,7 +331,7 @@ const turfTypescriptPath = path.join(__dirname, "..", "turf-*", "index.d.ts");
 
 // Test Strings
 const requireString = `import test from 'tape';
-import * as turf from './dist/esm/index.js';
+import * as turf from './index.ts';
 `;
 
 /**

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -7,6 +7,10 @@
     "strict": true,
     "moduleResolution": "node16",
     "importHelpers": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@turf/turf": ["./packages/turf"],
+      "@turf/*": ["./packages/turf-*"]
+    }
   }
 }


### PR DESCRIPTION
Minimal version of #2682

There's an issue where it doesn't leave the imports in the built code.