### PR TITLE
Update @types/geojson to 7946.0.10 minimum

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -254,7 +254,7 @@ export default {
     requireDependency({
       options: {
         dependencies: {
-          "@types/geojson": "^7946.0.0",
+          "@types/geojson": "^7946.0.10",
         },
       },
       includePackages: [MAIN_PACKAGE, ...TS_PACKAGES, ...JS_PACKAGES],

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -68,7 +68,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -72,7 +72,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/rhumb-bearing": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -74,7 +74,7 @@
     "@turf/boolean-point-on-line": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -73,7 +73,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/line-intersect": "workspace:^",
     "@turf/polygon-to-line": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -72,7 +72,7 @@
     "@turf/line-intersect": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/polygon-to-line": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -74,7 +74,7 @@
     "@turf/clean-coords": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "geojson-equality-ts": "^1.0.2",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -71,7 +71,7 @@
     "@turf/boolean-disjoint": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -75,7 +75,7 @@
     "@turf/line-intersect": "workspace:^",
     "@turf/line-overlap": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "geojson-equality-ts": "^1.0.2",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -70,7 +70,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/line-segment": "workspace:^",
     "@turf/rhumb-bearing": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "point-in-polygon-hao": "^1.1.0",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -75,7 +75,7 @@
     "@turf/boolean-point-on-line": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -78,7 +78,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/line-intersect": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "geojson-polygon-self-intersections": "^1.2.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -76,7 +76,7 @@
     "@turf/boolean-point-on-line": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -78,7 +78,7 @@
     "@turf/jsts": "^2.7.1",
     "@turf/meta": "workspace:^",
     "@turf/projection": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "d3-geo": "1.7.1"
   }
 }

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -76,7 +76,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -73,7 +73,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -68,7 +68,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@turf/bbox": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@turf/destination": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -81,7 +81,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "rbush": "^3.0.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -81,7 +81,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "skmeans": "0.9.7",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -70,7 +70,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/boolean-point-in-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "rbush": "^3.0.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -82,7 +82,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/tin": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "topojson-client": "3.x",
     "topojson-server": "3.x",
     "tslib": "^2.6.2"

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "concaveman": "^1.2.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -71,7 +71,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/length": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -68,7 +68,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -68,7 +68,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -74,7 +74,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
     "@turf/transform-rotate": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -66,7 +66,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/bbox-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -67,7 +67,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-geojson-rbush/package.json
+++ b/packages/turf-geojson-rbush/package.json
@@ -75,7 +75,7 @@
     "@turf/bbox": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "rbush": "^3.0.1"
   }
 }

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -72,6 +72,6 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -68,7 +68,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -80,7 +80,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/intersect": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -78,6 +78,6 @@
     "@turf/point-grid": "workspace:^",
     "@turf/square-grid": "workspace:^",
     "@turf/triangle-grid": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -81,7 +81,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "marchingsquares": "^1.3.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -78,7 +78,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "marchingsquares": "^1.3.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "sweepline-intersections": "^1.5.0",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -72,7 +72,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -66,7 +66,7 @@
     "@turf/circle": "workspace:^",
     "@turf/destination": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -75,6 +75,6 @@
     "@turf/length": "workspace:^",
     "@turf/line-slice-along": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "sweepline-intersections": "^1.5.0",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -72,6 +72,6 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -75,7 +75,7 @@
     "@turf/line-segment": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/nearest-point-on-line": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -65,7 +65,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -66,6 +66,6 @@
     "@turf/destination": "workspace:^",
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -69,6 +69,6 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/nearest-point-on-line": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -76,6 +76,6 @@
     "@turf/nearest-point-on-line": "workspace:^",
     "@turf/square": "workspace:^",
     "@turf/truncate": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -72,7 +72,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -83,6 +83,6 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0"
+    "@types/geojson": "^7946.0.10"
   }
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -66,7 +66,7 @@
     "@turf/destination": "workspace:^",
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -67,7 +67,7 @@
     "@turf/distance-weight": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -73,7 +73,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/nearest-point": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -68,7 +68,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/line-intersect": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -75,7 +75,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/point-to-line-distance": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -70,7 +70,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -74,7 +74,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -71,7 +71,7 @@
     "@turf/explode": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/nearest-point": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -75,7 +75,7 @@
     "@turf/projection": "workspace:^",
     "@turf/rhumb-bearing": "workspace:^",
     "@turf/rhumb-distance": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -66,7 +66,7 @@
     "@turf/boolean-point-in-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -75,7 +75,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/nearest-point": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -73,7 +73,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -81,7 +81,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -74,7 +74,7 @@
     "@turf/point-grid": "workspace:^",
     "@turf/random": "workspace:^",
     "@turf/square-grid": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -72,7 +72,7 @@
     "@turf/boolean-intersects": "workspace:^",
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -75,7 +75,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -68,7 +68,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/line-arc": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -77,7 +77,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/transform-scale": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -75,7 +75,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/rectangle-grid": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -75,7 +75,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/points-within-polygon": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -70,7 +70,7 @@
     "@turf/clone": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "earcut": "^2.2.4",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@turf/helpers": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -77,7 +77,7 @@
     "@turf/rhumb-bearing": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
     "@turf/rhumb-distance": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -85,7 +85,7 @@
     "@turf/rhumb-bearing": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
     "@turf/rhumb-distance": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -76,7 +76,7 @@
     "@turf/invariant": "workspace:^",
     "@turf/meta": "workspace:^",
     "@turf/rhumb-destination": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -71,7 +71,7 @@
     "@turf/distance": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/intersect": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "polygon-clipping": "^0.15.3",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -70,7 +70,7 @@
     "@turf/boolean-point-in-polygon": "workspace:^",
     "@turf/helpers": "workspace:^",
     "@turf/meta": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "rbush": "^3.0.1",
     "tslib": "^2.6.2"
   }

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -75,7 +75,7 @@
     "@turf/helpers": "workspace:^",
     "@turf/invariant": "workspace:^",
     "@types/d3-voronoi": "^1.1.12",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "d3-voronoi": "1.1.2",
     "tslib": "^2.6.2"
   }

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -204,7 +204,7 @@
     "@turf/union": "workspace:^",
     "@turf/unkink-polygon": "workspace:^",
     "@turf/voronoi": "workspace:^",
-    "@types/geojson": "^7946.0.0",
+    "@types/geojson": "^7946.0.10",
     "tslib": "^2.6.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,7 +447,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-voronoi
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -520,7 +520,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -569,7 +569,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-bearing
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -627,7 +627,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -673,7 +673,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -713,7 +713,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -759,7 +759,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -799,7 +799,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -845,7 +845,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -891,7 +891,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -937,7 +937,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -992,7 +992,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1053,7 +1053,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-polygon-to-line
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1111,7 +1111,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-polygon-to-line
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1160,7 +1160,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       geojson-equality-ts:
         specifier: ^1.0.2
@@ -1215,7 +1215,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1270,7 +1270,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       geojson-equality-ts:
         specifier: ^1.0.2
@@ -1328,7 +1328,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-bearing
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1374,7 +1374,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       point-in-polygon-hao:
         specifier: ^1.1.0
@@ -1417,7 +1417,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1472,7 +1472,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1545,7 +1545,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-line-intersect
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       geojson-polygon-self-intersections:
         specifier: ^1.2.1
@@ -1609,7 +1609,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1673,7 +1673,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-projection
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       d3-geo:
         specifier: 1.7.1
@@ -1719,7 +1719,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1777,7 +1777,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1841,7 +1841,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1908,7 +1908,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -1957,7 +1957,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2006,7 +2006,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2058,7 +2058,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2104,7 +2104,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2147,7 +2147,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2193,7 +2193,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
@@ -2263,7 +2263,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       skmeans:
         specifier: 0.9.7
@@ -2333,7 +2333,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
@@ -2379,7 +2379,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2431,7 +2431,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-tin
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       topojson-client:
         specifier: 3.x
@@ -2489,7 +2489,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       concaveman:
         specifier: ^1.2.1
@@ -2544,7 +2544,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2596,7 +2596,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
@@ -2663,7 +2663,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2715,7 +2715,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
@@ -2764,7 +2764,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2816,7 +2816,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2868,7 +2868,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-transform-rotate
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2935,7 +2935,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -2978,7 +2978,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3024,7 +3024,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3073,7 +3073,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3122,7 +3122,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
@@ -3174,7 +3174,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/truncate':
@@ -3211,7 +3211,7 @@ importers:
   packages/turf-helpers:
     dependencies:
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3257,7 +3257,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3336,7 +3336,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-triangle-grid
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/truncate':
@@ -3382,7 +3382,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
@@ -3431,7 +3431,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3486,7 +3486,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       marchingsquares:
         specifier: ^1.3.3
@@ -3556,7 +3556,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       marchingsquares:
         specifier: ^1.3.3
@@ -3617,7 +3617,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       sweepline-intersections:
         specifier: ^1.5.0
@@ -3672,7 +3672,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3721,7 +3721,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -3776,7 +3776,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/truncate':
@@ -3816,7 +3816,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       sweepline-intersections:
         specifier: ^1.5.0
@@ -3871,7 +3871,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/truncate':
@@ -3929,7 +3929,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-nearest-point-on-line
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       fast-deep-equal:
         specifier: ^3.1.3
@@ -3981,7 +3981,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4030,7 +4030,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-nearest-point-on-line
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/truncate':
@@ -4079,7 +4079,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/along':
@@ -4146,7 +4146,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-truncate
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@types/benchmark':
@@ -4192,7 +4192,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4235,7 +4235,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
@@ -4284,7 +4284,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
     devDependencies:
       '@turf/random':
@@ -4324,7 +4324,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4367,7 +4367,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4431,7 +4431,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-nearest-point
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4486,7 +4486,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4547,7 +4547,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4608,7 +4608,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-point-to-line-distance
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4663,7 +4663,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4709,7 +4709,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4770,7 +4770,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-nearest-point
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4837,7 +4837,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4889,7 +4889,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4929,7 +4929,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -4990,7 +4990,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-nearest-point
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5036,7 +5036,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5091,7 +5091,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5140,7 +5140,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5213,7 +5213,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-square-grid
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5259,7 +5259,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5305,7 +5305,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5366,7 +5366,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5412,7 +5412,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5458,7 +5458,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5507,7 +5507,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5553,7 +5553,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5602,7 +5602,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5672,7 +5672,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-transform-scale
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5727,7 +5727,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5776,7 +5776,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5816,7 +5816,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rectangle-grid
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5877,7 +5877,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-points-within-polygon
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5935,7 +5935,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -5975,7 +5975,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       earcut:
         specifier: ^2.2.4
@@ -6015,7 +6015,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -6073,7 +6073,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -6146,7 +6146,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -6210,7 +6210,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-rhumb-destination
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -6262,7 +6262,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-intersect
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -6314,7 +6314,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       tslib:
         specifier: ^2.6.2
@@ -6360,7 +6360,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       polygon-clipping:
         specifier: ^0.15.3
@@ -6418,7 +6418,7 @@ importers:
         specifier: workspace:^
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
@@ -6476,7 +6476,7 @@ importers:
         specifier: ^1.1.12
         version: 1.1.12
       '@types/geojson':
-        specifier: ^7946.0.0
+        specifier: ^7946.0.10
         version: 7946.0.14
       d3-voronoi:
         specifier: 1.1.2
@@ -6763,6 +6763,7 @@ packages:
   /@babel/helper-string-parser@7.24.8:
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dev: true
 
   /@babel/helper-validator-identifier@7.22.20:
@@ -6773,6 +6774,7 @@ packages:
   /@babel/helper-validator-identifier@7.24.7:
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dev: true
 
   /@babel/helper-validator-option@7.23.5:


### PR DESCRIPTION
Apparently the @types/geojson package has had some relatively breaking changes around allowing nulls between 7946.0.0 and .14. This PR raises the minimum version to .10 which is only different from .14 because of formatting changes, but was released over 2 years ago and has dist-tags saying that is supported all the way back to typescript 4.0.

Hopefully this strikes a reasonable balance between limiting our exposure to the weirdness of the early types, and being relatively easy to adopt downstream because the minimum version is already quite old.