### PR TITLE
Add test.example.js to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ node_modules
 
 # is actually output
 packages/turf/turf.min.js
+packages/turf/test.example.js
 
 pnpm-lock.yaml
 


### PR DESCRIPTION
This file gets generated as part of the overall build and ignoring it should help with rerunning build steps locally several times in a row without cleaning up generated files.