### PR TITLE
Inline last-checks into @turf/turf's test script

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,8 +31,8 @@
       "dependsOn": ["build"],
       "cache": true
     },
-    "last-checks": {
-      "inputs": ["default", "{projectRoot}/test.ts"],
+    "@turf/turf:test": {
+      "inputs": ["default", "{projectRoot}/test.ts", "{projectRoot}/index.ts"],
       "dependsOn": ["build", "^last-checks"],
       "cache": true
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:prettier": "prettier --check .",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky && lerna run build",
-    "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
+    "test": "pnpm run lint && lerna run test"
   },
   "lint-staged": {
     "package.json": [

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -55,7 +55,6 @@
     "@types/tape": "^4.2.32",
     "benchmark": "^2.1.4",
     "load-json-file": "^7.0.1",
-    "mkdirp": "^3.0.1",
     "npm-run-all": "^4.1.5",
     "tape": "^5.7.2",
     "tsup": "^8.0.1",

--- a/packages/turf/index.ts
+++ b/packages/turf/index.ts
@@ -46,6 +46,7 @@ export { concave } from "@turf/concave";
 export { convex } from "@turf/convex";
 export { destination } from "@turf/destination";
 export { difference } from "@turf/difference"; // JSTS Module
+export { directionalMean } from "@turf/directional-mean";
 export { dissolve } from "@turf/dissolve"; // JSTS Sub-Model
 export { distance } from "@turf/distance";
 export { distanceWeight } from "@turf/distance-weight";

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -68,10 +68,9 @@
   ],
   "scripts": {
     "build": "tsup --config ../../tsup.config.ts && rollup -c rollup.config.js",
-    "last-checks": "npm-run-all last-checks:testjs last-checks:example",
-    "last-checks:example": "tsx test.example.js",
-    "last-checks:testjs": "tsx test.ts",
-    "test": "echo '@turf/turf tests run in the last-checks step'"
+    "test": "npm-run-all test:testjs test:example",
+    "test:example": "tsx test.example.js",
+    "test:testjs": "tsx test.ts"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
@@ -132,6 +131,7 @@
     "@turf/convex": "workspace:^",
     "@turf/destination": "workspace:^",
     "@turf/difference": "workspace:^",
+    "@turf/directional-mean": "workspace:^",
     "@turf/dissolve": "workspace:^",
     "@turf/distance": "workspace:^",
     "@turf/distance-weight": "workspace:^",

--- a/packages/turf/test.ts
+++ b/packages/turf/test.ts
@@ -66,9 +66,7 @@ test("turf -- invalid dependencies", (t) => {
       t.fail(
         `${name} @turf/helpers should be located in Dependencies instead of DevDependencies`
       );
-    // if (devDependencies['mkdirp']) t.fail(`${name} tests should not have to create folders`);
   }
-  t.skip('remove "mkdirp" from testing');
   t.end();
 });
 
@@ -164,8 +162,6 @@ test("turf -- pre-defined attributes in package.json", (t) => {
   for (const { name, pckg } of modules) {
     if (pckg.author !== "Turf Authors")
       t.fail(name + ' (author) should be "Turf Authors"');
-    // if (pckg.main !== 'main.js') t.skip(`${name} (main) must be "main.js" in package.json`);
-    // if (pckg.module !== 'main.es.js') t.skip(`${name} (module) must be "main.es.js" in package.json`);
     if (pckg["jsnext:main"])
       t.fail(
         `${name} (jsnext:main) is no longer required in favor of using (module) in package.json`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@turf/difference':
         specifier: workspace:^
         version: link:../turf-difference
+      '@turf/directional-mean':
+        specifier: workspace:^
+        version: link:../turf-directional-mean
       '@turf/dissolve':
         specifier: workspace:^
         version: link:../turf-dissolve
@@ -4256,9 +4259,6 @@ importers:
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
-      mkdirp:
-        specifier: ^3.0.1
-        version: 3.0.1
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -13931,12 +13931,6 @@ packages:
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
-  /mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Instead of having this be its own step, we can just run it as part of the tests turf-mask had an unused mkdirp dependency that it looked like we wanted to get rid of at some point @turf/turf wasn't reexporting @turf/directional-mean so I added that
