### PR TITLE
Fix @turf/mask benchmarks to exclude test fixtures that are not usable

### DIFF
--- a/packages/turf-mask/bench.ts
+++ b/packages/turf-mask/bench.ts
@@ -14,7 +14,10 @@ const isPolygonFeature = (
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const SKIP = [];
+// these test fixtures are not used for benchmarking because they contain a
+// FeatureCollection with a single MultiPolygon, instead of a FeatureCollection
+// with two Polygons, where the first one is the polygon and the second is the mask.
+const SKIP = ["multi-polygon.geojson", "overlapping.geojson"];
 
 const suite = new Benchmark.Suite("turf-mask");
 


### PR DESCRIPTION
I gambled and lost with #2635. This re-adds the SKIP entries and adds a comment explaining why they were skipped.