### PR TITLE
Rework actions for faster PR CI

### DIFF
--- a/.github/workflows/turf.yml
+++ b/.github/workflows/turf.yml
@@ -1,14 +1,9 @@
 name: CI build
 
 on:
-  push:
-    branches:
-      - master
-      - support/6.x
   pull_request:
     branches:
       - master
-      - support/6.x
 
 permissions:
   contents: read
@@ -24,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -37,5 +34,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm lerna run build --since origin/master --ignore @turf/turf
       - run: git diff --exit-code
-      - run: pnpm test
+      - run: pnpm lerna run test --since origin/master
+      # note: does not run linting
+      # note: does not run last-checks

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,7 @@
         "{projectRoot}/test/**",
         "{projectRoot}/types.ts"
       ],
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "cache": true
     },
     "last-checks": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:mrl": "mrl check",
     "lint:prettier": "prettier --check .",
     "preinstall": "npx only-allow pnpm",
-    "prepare": "husky && lerna run build",
+    "prepare": "husky",
     "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
   },
   "lint-staged": {

--- a/packages/turf-difference/index.ts
+++ b/packages/turf-difference/index.ts
@@ -52,6 +52,7 @@ function difference(
   const properties = features.features[0].properties || {};
 
   const differenced = polygonClipping.difference(geoms[0], ...geoms.slice(1));
+
   if (differenced.length === 0) return null;
   if (differenced.length === 1) return polygon(differenced[0], properties);
   return multiPolygon(differenced, properties);


### PR DESCRIPTION
Exploratory PR to investigate lerna's `--since` mode.

This breaks the merge builds, and it breaks the support/6.5 branch as well, but we can experiment with PR timings and the overall approach.

Example build https://github.com/Turfjs/turf/actions/runs/10324602220 (took less than a minute)