### PR TITLE
Upgrade pnpm/action-setup in github actions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,9 +21,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.4.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.4.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
The release builds are failing because the existing version no longer works.

https://github.com/Turfjs/turf/actions/runs/10323298223/job/28580462018
https://github.com/pnpm/action-setup?tab=readme-ov-file#warning-upgrade-from-v2

Copy/pasted the block from our `turf.yml` into these two configs.