### PR TITLE
Revert self intersection behavior: `boolean-disjoint`

### DIFF
--- a/packages/turf-boolean-disjoint/README.md
+++ b/packages/turf-boolean-disjoint/README.md
@@ -12,7 +12,7 @@ Boolean-disjoint returns (TRUE) if the intersection of the two geometries is an 
 *   `feature2` **([Geometry][1] | [Feature][2]\<any>)** GeoJSON Feature or Geometry
 *   `options` **[Object][3]** Optional parameters (optional, default `{}`)
 
-    *   `options.ignoreSelfIntersections` **[boolean][4]** ignores self-intersections on input features (optional, default `false`)
+    *   `options.ignoreSelfIntersections` **[boolean][4]** ignores self-intersections on input features (optional, default `true`)
 
 ### Examples
 

--- a/packages/turf-boolean-disjoint/index.ts
+++ b/packages/turf-boolean-disjoint/index.ts
@@ -18,7 +18,7 @@ import { polygonToLine } from "@turf/polygon-to-line";
  * @param {Geometry|Feature<any>} feature1 GeoJSON Feature or Geometry
  * @param {Geometry|Feature<any>} feature2 GeoJSON Feature or Geometry
  * @param {Object} [options={}] Optional parameters
- * @param {boolean} [options.ignoreSelfIntersections=false] ignores self-intersections on input features
+ * @param {boolean} [options.ignoreSelfIntersections=true] ignores self-intersections on input features
  * @returns {boolean} true if the intersection is an empty set, false otherwise
  * @example
  * var point = turf.point([2, 2]);
@@ -35,7 +35,7 @@ function booleanDisjoint(
   } = {}
 ): boolean {
   const ignoreSelfIntersections: boolean =
-    options.ignoreSelfIntersections ?? false;
+    options.ignoreSelfIntersections ?? true;
 
   let bool = true;
   flattenEach(feature1, (flatten1) => {

--- a/packages/turf-boolean-disjoint/test.ts
+++ b/packages/turf-boolean-disjoint/test.ts
@@ -117,64 +117,95 @@ test("turf-boolean-disjoin with ignoreSelfIntersections option", (t) => {
     },
   };
 
-  // Test without ignoringSelfIntersections option (default behavior)
+  const selfIntersectingPolygon: GeoJSON.Feature<GeoJSON.Polygon> = {
+    type: "Feature",
+    properties: {},
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [1.5, 1],
+          [2, 1.5],
+
+          [3, 0.5],
+          [-1, 3],
+          [1.5, 1],
+        ],
+      ],
+    },
+  };
+
+  // Test with ignoringSelfIntersections = true (default behavior)
   let result = disjoint(selfIntersectingLineString, nonIntersectingLineString);
-  t.false(
+  t.true(
     result,
-    "[false] " +
-      "selfIntersectingLineString-LineString (ignoreSelfIntersections=false)"
+    "[true] " +
+      "selfIntersectingLineString-LineString (ignoreSelfIntersections=true)"
   );
   result = disjoint(selfIntersectingLineString, intersectingLineString);
   t.false(
     result,
     "[false] " +
-      "selfIntersectingLineString-LineString (ignoreSelfIntersections=false)"
+      "selfIntersectingLineString-LineString (ignoreSelfIntersections=true)"
   );
   result = disjoint(selfIntersectingLineString, intersectingPolygon);
   t.false(
     result,
     "[false] " +
-      "selfIntersectingLineString-Polygon (ignoreSelfIntersections=false)"
+      "selfIntersectingLineString-Polygon (ignoreSelfIntersections=true)"
   );
   result = disjoint(selfIntersectingLineString, nonIntersectingPolygon);
+  t.true(
+    result,
+    "[true] " +
+      "selfIntersectingLineString-Polygon (ignoreSelfIntersections=true)"
+  );
+  result = disjoint(selfIntersectingPolygon, nonIntersectingPolygon);
+  t.true(
+    result,
+    "[true] " + "selfIntersectingPolygon-Polygon (ignoreSelfIntersections=true)"
+  );
+
+  // Test with ignoringSelfIntersections option set to false
+  result = disjoint(selfIntersectingLineString, nonIntersectingLineString, {
+    ignoreSelfIntersections: false,
+  });
+  t.false(
+    result,
+    "[false] " +
+      "selfIntersectingLineString-LineString (ignoreSelfIntersections=false)"
+  );
+  result = disjoint(selfIntersectingLineString, intersectingLineString, {
+    ignoreSelfIntersections: false,
+  });
+  t.false(
+    result,
+    "[false] " +
+      "selfIntersectingLineString-LineString (ignoreSelfIntersections=false)"
+  );
+  result = disjoint(selfIntersectingLineString, intersectingPolygon, {
+    ignoreSelfIntersections: false,
+  });
   t.false(
     result,
     "[false] " +
       "selfIntersectingLineString-Polygon (ignoreSelfIntersections=false)"
   );
-
-  // Test with ignoringSelfIntersections option
-  result = disjoint(selfIntersectingLineString, nonIntersectingLineString, {
-    ignoreSelfIntersections: true,
-  });
-  t.true(
-    result,
-    "[true] " +
-      "selfIntersectingLineString-LineString (ignoreSelfIntersections=true)"
-  );
-  result = disjoint(selfIntersectingLineString, intersectingLineString, {
-    ignoreSelfIntersections: true,
-  });
-  t.false(
-    result,
-    "[false] " +
-      "selfIntersectingLineString-LineString (ignoreSelfIntersections=true)"
-  );
-  result = disjoint(selfIntersectingLineString, intersectingPolygon, {
-    ignoreSelfIntersections: true,
-  });
-  t.false(
-    result,
-    "[false] " +
-      "selfIntersectingLineString-Polygon (ignoreSelfIntersections=true)"
-  );
   result = disjoint(selfIntersectingLineString, nonIntersectingPolygon, {
-    ignoreSelfIntersections: true,
+    ignoreSelfIntersections: false,
   });
-  t.true(
+  t.false(
     result,
-    "[true] " +
-      "selfIntersectingLineString-Polygon (ignoreSelfIntersections=true)"
+    "[false] " +
+      "selfIntersectingLineString-Polygon (ignoreSelfIntersections=false)"
+  );
+  result = disjoint(selfIntersectingPolygon, nonIntersectingPolygon, {
+    ignoreSelfIntersections: false,
+  });
+  t.false(
+    result,
+    "[false] " +
+      "selfIntersectingPolygon-Polygon (ignoreSelfIntersections=false)"
   );
 
   t.end();

--- a/packages/turf-boolean-disjoint/test.ts
+++ b/packages/turf-boolean-disjoint/test.ts
@@ -14,7 +14,7 @@ test("turf-boolean-disjoint", (t) => {
     .sync(path.join(__dirname, "test", "true", "**", "*.geojson"))
     .forEach((filepath) => {
       const name = path.parse(filepath).name;
-      const geojson = loadJsonFileSync(filepath);
+      const geojson: GeoJSON.FeatureCollection = loadJsonFileSync(filepath);
       const feature1 = geojson.features[0];
       const feature2 = geojson.features[1];
       const result = disjoint(feature1, feature2);
@@ -30,7 +30,7 @@ test("turf-boolean-disjoint", (t) => {
     .sync(path.join(__dirname, "test", "false", "**", "*.geojson"))
     .forEach((filepath) => {
       const name = path.parse(filepath).name;
-      const geojson = loadJsonFileSync(filepath);
+      const geojson: GeoJSON.FeatureCollection = loadJsonFileSync(filepath);
       const feature1 = geojson.features[0];
       const feature2 = geojson.features[1];
       const result = disjoint(feature1, feature2);


### PR DESCRIPTION
Purpose: Bug fix

Partially Addresses: 
https://github.com/Turfjs/turf/discussions/2728
https://github.com/Turfjs/turf/issues/2722

`boolean-disjoint`
- Sets `ignoreSelfIntersection` option to default to `true`
- Adds minimal types to geojson in test files to correct TS errors
- Adds a self intersecting polygon to test cases
- Updates test cases for expected values based on the flip of "default"
- Adds test cases for the self intersecting polygon