### PR TITLE
Fix convex function ignoring given properties

### DIFF
--- a/packages/turf-convex/index.ts
+++ b/packages/turf-convex/index.ts
@@ -56,7 +56,7 @@ function convex<P extends GeoJsonProperties = GeoJsonProperties>(
 
   // Convex hull should have at least 3 different vertices in order to create a valid polygon
   if (convexHull.length > 3) {
-    return polygon([convexHull]);
+    return polygon<P>([convexHull], options.properties);
   }
   return null;
 }

--- a/packages/turf-convex/test.ts
+++ b/packages/turf-convex/test.ts
@@ -6,6 +6,7 @@ import { writeJsonFileSync } from "write-json-file";
 import { loadJsonFileSync } from "load-json-file";
 import { featureCollection } from "@turf/helpers";
 import { convex } from "./index.js";
+import { type FeatureCollection } from "geojson";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -30,5 +31,19 @@ test("convex hull", (t) => {
 
 test("turf-convex -- empty", (t) => {
   t.deepEqual(convex(featureCollection([])), null, "corner case: null hull");
+  t.end();
+});
+
+test("turf-convex -- properties are transferred to result polygon", (t) => {
+  const geoJson = loadJsonFileSync<FeatureCollection>(
+    "./test/in/elevation2.geojson"
+  );
+  const expectedProperties = { cadastralData: [1220, 1290, 1440, 1943] };
+  const actualPolygon = convex(geoJson, { properties: expectedProperties });
+  t.deepEqual(
+    actualPolygon?.properties,
+    expectedProperties,
+    "properties do not match"
+  );
   t.end();
 });


### PR DESCRIPTION
# Background

Using the `convex` function to combine a feature collection returns a newly constructed polygon with missing properties. This is crucial if the caller of the function attempts to pass additional properties to the end polygon.

PR includes a test to test this scenario and improved typing

### Resolve #2762

- [x] Is this a bug fix, new functionality, or a breaking change?
This change fixes a bug where the convex function ignores given properties. I came across this problem, as I was working on a project for one of our clients 
- [x] Have read and followed the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/CONTRIBUTING.md#preparing-a-pull-request).