### PR TITLE
Update package.json for all turf packages

### DIFF
--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/along",
   "version": "7.2.0",
-  "description": "Calculates a point along a LineString at a specific distance",
+  "description": "Calculates a point along a line at a specific distance",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/along",
   "version": "7.2.0",
-  "description": "turf along module",
+  "description": "Calculates a point along a LineString at a specific distance",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/angle",
   "version": "7.2.0",
-  "description": "Finds the angle formed by two adjacent segments defined by 3 points. The result will be the (positive clockwise) angle with origin on the startPoint-midPoint segment, or its explementary angle if required.",
+  "description": "Finds the angle formed by two adjacent segments.",
   "author": "Turf Authors",
   "contributors": [
     "Denis <@DenisCarriere>"

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/angle",
   "version": "7.2.0",
-  "description": "turf angle module",
+  "description": "Finds the angle formed by two adjacent segments defined by 3 points. The result will be the (positive clockwise) angle with origin on the startPoint-midPoint segment, or its explementary angle if required.",
   "author": "Turf Authors",
   "contributors": [
     "Denis <@DenisCarriere>"

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/area",
   "version": "7.2.0",
-  "description": "turf area module",
+  "description": "Calculates the geodesic area in square meters of one or more polygons.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/bbox-clip",
   "version": "7.2.0",
-  "description": "turf bbox-clip module",
+  "description": "Takes a Feature and a bbox and clips the feature to the bbox using lineclip.",
   "author": "Turf Authors",
   "contributors": [
     "Tim Channell <@tcql>",

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/bbox-polygon",
   "version": "7.2.0",
-  "description": "turf bbox-polygon module",
+  "description": "Converts a bounding box to a GeoJSON polygon.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/bbox",
   "version": "7.2.0",
-  "description": "turf bbox module",
+  "description": "Generates a bounding box around a GeoJSON feature.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/bearing",
   "version": "7.2.0",
-  "description": "turf bearing module",
+  "description": "Takes two points and finds the geographic bearing between them.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/bezier-spline",
   "version": "7.2.0",
-  "description": "turf bezier-spline module",
+  "description": "Smooths a LineString into a curve using Bézier splines, great for visualizing routes.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/bezier-spline",
   "version": "7.2.0",
-  "description": "Smooths a LineString into a curve using Bézier splines, great for visualizing routes.",
+  "description": "Smooths a line into a curve using Bézier splines, great for visualizing routes.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-clockwise",
   "version": "7.2.0",
-  "description": "turf boolean-clockwise module",
+  "description": "Takes a ring and return true or false whether or not the ring is clockwise or counter-clockwise.",
   "author": "Turf Authors",
   "contributors": [
     "Morgan Herlocker <@morganherlocker>",

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-concave",
   "version": "7.2.0",
-  "description": "turf boolean-concave module",
+  "description": "Takes a polygon and return true or false as to whether it is concave or not.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>"

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-contains",
   "version": "7.2.0",
-  "description": "Checks if one geometry contains another.",
+  "description": "Determines whether the second geometry is completely within the first geometry.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-contains",
   "version": "7.2.0",
-  "description": "turf boolean-contains module",
+  "description": "Checks if one geometry contains another.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-crosses",
   "version": "7.2.0",
-  "description": "turf boolean-crosses module",
+  "description": "Checks if two geometries cross each other.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-disjoint",
   "version": "7.2.0",
-  "description": "turf boolean-disjoint module",
+  "description": "Checks if two geometries have no overlapping areas.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-equal",
   "version": "7.2.0",
-  "description": "turf boolean-equal module",
+  "description": "Determine whether two geometries of the same type have identical X,Y coordinate values",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-intersects",
   "version": "7.2.0",
-  "description": "turf boolean-intersects module",
+  "description": "Checks if two geometries overlap in any way.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-overlap",
   "version": "7.2.0",
-  "description": "turf boolean-overlap module",
+  "description": "Checks if two geometries have an area of overlap without one being completely contained inside the other.",
   "author": "Turf Authors",
   "contributors": [
     "Tim Channell <@tcql>",

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-parallel",
   "version": "7.2.0",
-  "description": "turf boolean-parallel module",
+  "description": "Determine whether each segment of a line is parallel to the correspondent segment of another line.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-point-in-polygon",
   "version": "7.2.0",
-  "description": "turf boolean-point-in-polygon module",
+  "description": "Checks if a point is inside an area, like a city boundary.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-point-on-line",
   "version": "7.2.0",
-  "description": "turf boolean-point-on-line module",
+  "description": "Checks if a point lies directly on a line, like a path or road.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>"

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-touches",
   "version": "7.2.0",
-  "description": "turf boolean-touches module",
+  "description": "Determine whether none of the points common to both geometries intersect the interiors of both geometries.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>"

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-valid",
   "version": "7.2.0",
-  "description": "turf boolean-valid module",
+  "description": "Checks if the geometry is a valid according to the OGC Simple Feature Specification.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/boolean-within",
   "version": "7.2.0",
-  "description": "turf boolean-within module",
+  "description": "Determines whether the first geometry is completely within the second geometry.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>"

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/buffer",
   "version": "7.2.0",
-  "description": "turf buffer module",
+  "description": "Creates a buffer around a GeoJSON feature.",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/center-mean",
   "version": "7.2.0",
-  "description": "turf center-mean module",
+  "description": "Takes a Feature or FeatureCollection and returns the mean center.",
   "author": "Turf Authors",
   "contributors": [
     "Moacir P. de Sá Pereira <@muziejus>"

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/center-median",
   "version": "7.2.0",
-  "description": "turf center-median module",
+  "description": "Takes a FeatureCollection of points and calculates the median center.",
   "author": "Turf Authors",
   "contributors": [
     "Moacir P. de Sá Pereira <@muziejus>"

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/center-of-mass",
   "version": "7.2.0",
-  "description": "turf center-of-mass module",
+  "description": "Finds the “balance point” of irregular shapes, like a country outline.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/center",
   "version": "7.2.0",
-  "description": "turf center module",
+  "description": "Finds the central point of a GeoJSON feature, like a city or a park. Ideal for placing labels or markers.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/centroid",
   "version": "7.2.0",
-  "description": "turf centroid module",
+  "description": "Determines the geometric center of a polygon or shape.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/circle",
   "version": "7.2.0",
-  "description": "Takes a Point and calculates the circle polygon given a radius in degrees, radians, miles, or kilometers; and steps for precision.",
+  "description": "Takes a point and calculates the circle polygon given a radius.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/circle",
   "version": "7.2.0",
-  "description": "turf circle module",
+  "description": "Takes a Point and calculates the circle polygon given a radius in degrees, radians, miles, or kilometers; and steps for precision.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/clean-coords",
   "version": "7.2.0",
-  "description": "turf clean-coords module",
+  "description": "Removes redundant coordinates from a GeoJSON Geometry.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/clone",
   "version": "7.2.0",
-  "description": "turf clone module",
+  "description": "Returns a cloned copy of the passed GeoJSON Object, including possible 'Foreign Members'.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/clusters-dbscan",
   "version": "7.2.0",
-  "description": "turf clusters-dbscan module",
+  "description": "Takes a set of points and partition them into clusters according to DBSCAN's data clustering algorithm.",
   "author": "Turf Authors",
   "contributors": [
     "Lukasz <@uhho>",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/clusters-kmeans",
   "version": "7.2.0",
-  "description": "turf clusters-kmeans module",
+  "description": "Takes a set of points and partition them into clusters using the k-means algorithm.",
   "author": "Turf Authors",
   "contributors": [
     "David Gómez Matarrodona <@solzimer>",

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/clusters",
   "version": "7.2.0",
-  "description": "turf clusters module",
+  "description": "Group points into clusters based on their spatial proximity or properties.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/collect",
   "version": "7.2.0",
-  "description": "turf collect module",
+  "description": "Merges a specified property from a FeatureCollection of points into a FeatureCollection of polygons.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>"

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/combine",
   "version": "7.2.0",
-  "description": "turf combine module",
+  "description": "Combines a FeatureCollection of Point, LineString, or Polygon features into MultiPoint, MultiLineString, or MultiPolygon features.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/concave",
   "version": "7.2.0",
-  "description": "turf concave module",
+  "description": "Creates a concave hull around points.",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/convex",
   "version": "7.2.0",
-  "description": "turf convex module",
+  "description": "Creates a convex hull around points",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/difference",
   "version": "7.2.0",
-  "description": "turf difference module",
+  "description": "Finds the difference between multiple polygons by clipping the subsequent polygon from the first.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/directional-mean",
   "version": "7.2.0",
-  "description": "turf directional-mean module",
+  "description": "Calculates the average angle of a set of lines, measuring the trend of it.",
   "author": "Turf Authors",
   "contributors": [
     "Haoming Zhuang <@zhuang-hao-ming>"

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/dissolve",
   "version": "7.2.0",
-  "description": "turf dissolve module",
+  "description": "Dissolves a FeatureCollection of Polygon features.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/distance-weight",
   "version": "7.2.0",
-  "description": "calculate the influence or weight of points over an area based on their distances.",
+  "description": "Calculate the influence or weight of points over an area based on their distances.",
   "author": "Turf Authors",
   "contributors": [
     "Haoming Zhuang <@zhuang-hao-ming>"

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/distance-weight",
   "version": "7.2.0",
-  "description": "turf distance-weight module",
+  "description": "calculate the influence or weight of points over an area based on their distances.",
   "author": "Turf Authors",
   "contributors": [
     "Haoming Zhuang <@zhuang-hao-ming>"

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/distance",
   "version": "7.2.0",
-  "description": "turf distance module",
+  "description": "Measures the straight-line distance between two points, like cities or landmarks.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/ellipse",
   "version": "7.2.0",
-  "description": "turf ellipse module",
+  "description": "Takes a Point and calculates the ellipse polygon given two semi-axes expressed in variable units and steps for precision.",
   "author": "Turf Authors",
   "contributors": [
     "Moacir P. de Sá Pereira <@muziejus>"

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/envelope",
   "version": "7.2.0",
-  "description": "turf envelope module",
+  "description": "Takes any number of features and returns a rectangular Polygon that encompasses all vertices.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/explode",
   "version": "7.2.0",
-  "description": "turf explode module",
+  "description": "Takes a feature or set of features and returns all positions as points.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/flatten",
   "version": "7.2.0",
-  "description": "turf flatten module",
+  "description": "Flattens any GeoJSON to a FeatureCollection",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/flip",
   "version": "7.2.0",
-  "description": "turf flip module",
+  "description": "Takes input features and flips all of their coordinates.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/great-circle",
   "version": "7.2.0",
-  "description": "turf great-circle module",
+  "description": "Calculate great circles routes as LineString or MultiLineString.",
   "author": "Turf Authors",
   "contributors": [
     "Dane Springmeyer <@springmeyer>",

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/helpers",
   "version": "7.2.0",
-  "description": "turf helpers module",
+  "description": "Provides helper functions to create GeoJSON features, like points, lines, or areas on a map.",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/hex-grid",
   "version": "7.2.0",
-  "description": "turf hex-grid module",
+  "description": "Creates a honeycomb-like grid of hexagons within a bounding box.",
   "author": "Turf Authors",
   "contributors": [
     "James Seppi <@jseppi>",

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/interpolate",
   "version": "7.2.0",
-  "description": "turf interpolate module",
+  "description": "Creates an interpolated grid of points using the Inverse Distance Weighting method.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/intersect",
   "version": "7.2.0",
-  "description": "turf intersect module",
+  "description": "Finds the shared area between two polygons.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/invariant",
   "version": "7.2.0",
-  "description": "turf invariant module",
+  "description": "Lightweight utility for input validation and data extraction in Turf.js. Ensures GeoJSON inputs are in the correct format and extracts specific components like coordinates or geometries.",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/isobands",
   "version": "7.2.0",
-  "description": "turf isobands module",
+  "description": "Takes a grid of values (GeoJSON format) and a set of threshold ranges. It outputs polygons that group areas within those ranges, effectively creating filled contour isobands.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/isolines",
   "version": "7.2.0",
-  "description": "turf isolines module",
+  "description": "Generate contour lines from a grid of data.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/kinks",
   "version": "7.2.0",
-  "description": "turf kinks module",
+  "description": "Takes a linestring, multi-linestring, multi-polygon or polygon and returns points at all self-intersections.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/kinks",
   "version": "7.2.0",
-  "description": "Takes a linestring, multi-linestring, multi-polygon or polygon and returns points at all self-intersections.",
+  "description": "Takes a GeoJSON feature and returns points at all self-intersections.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/length",
   "version": "7.2.0",
-  "description": " Calculates the length of a LineString or MultiLineString, perfect for paths or routes.",
+  "description": " Calculates the length of a line, perfect for paths or routes.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>",

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/length",
   "version": "7.2.0",
-  "description": "turf length module",
+  "description": " Calculates the length of a LineString or MultiLineString, perfect for paths or routes.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-arc",
   "version": "7.2.0",
-  "description": "turf line-arc module",
+  "description": "Creates a circular arc, of a circle of the given radius and center point, between two bearings.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-chunk",
   "version": "7.2.0",
-  "description": "turf line-chunk module",
+  "description": "Divides a LineString into chunks of a specified length. If the line is shorter than the segment length then the original line is returned.",
   "author": "Turf Authors",
   "contributors": [
     "Tim Channell <@tcql>",

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-chunk",
   "version": "7.2.0",
-  "description": "Divides a LineString into chunks of a specified length. If the line is shorter than the segment length then the original line is returned.",
+  "description": "Divides a LineString into chunks of a specified length.",
   "author": "Turf Authors",
   "contributors": [
     "Tim Channell <@tcql>",

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-intersect",
   "version": "7.2.0",
-  "description": "turf line-intersect module",
+  "description": "Takes any LineString or Polygon GeoJSON and returns the intersecting point(s).",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>",

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-offset",
   "version": "7.2.0",
-  "description": "turf line-offset module",
+  "description": "Takes a line and returns a line at offset by the specified distance.",
   "author": "Turf Authors",
   "contributors": [
     "David Wee <@rook2pawn>",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-overlap",
   "version": "7.2.0",
-  "description": "turf line-overlap module",
+  "description": "Takes any LineString or Polygon and returns the overlapping lines between both features.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-segment",
   "version": "7.2.0",
-  "description": "turf line-segment module",
+  "description": "Creates a FeatureCollection of 2-vertex LineString segments from a (Multi)LineString or (Multi)Polygon.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-segment",
   "version": "7.2.0",
-  "description": "Creates a FeatureCollection of 2-vertex LineString segments from a (Multi)LineString or (Multi)Polygon.",
+  "description": "Creates line segments from a GeoJSON feature.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-slice-along",
   "version": "7.2.0",
-  "description": "turf line-slice-along module",
+  "description": "Useful for extracting only the part of a route between two distances.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-slice",
   "version": "7.2.0",
-  "description": "turf line-slice module",
+  "description": "Useful for extracting only the part of a route between waypoints.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-split",
   "version": "7.2.0",
-  "description": "turf line-split module",
+  "description": "Split a LineString by another GeoJSON Feature.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-to-polygon",
   "version": "7.2.0",
-  "description": "Converts (Multi)LineString(s) to Polygon(s).",
+  "description": "Converts line(s) to polygon(s).",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/line-to-polygon",
   "version": "7.2.0",
-  "description": "turf line-to-polygon module",
+  "description": "Converts (Multi)LineString(s) to Polygon(s).",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/mask",
   "version": "7.2.0",
-  "description": "turf mask module",
+  "description": "Takes polygons or multipolygons and an optional mask, and returns an exterior ring polygon with holes.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/meta",
   "version": "7.2.0",
-  "description": "turf meta module",
+  "description": "Provides tools for iterating over and manipulating GeoJSON objects.",
   "author": "Turf Authors",
   "contributors": [
     "Tom MacWright <@tmcw>",

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/midpoint",
   "version": "7.2.0",
-  "description": "turf midpoint module",
+  "description": "Takes two points and calculates a point midway between them geodesically.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/moran-index",
   "version": "7.2.0",
-  "description": "turf moran-index module",
+  "description": "Measures patterns of attribute values associated with features. Reveals whether similar values tend to occur near each other, or whether high or low values are interspersed",
   "author": "Turf Authors",
   "contributors": [
     "Haoming Zhuang <@zhuang-hao-ming>"

--- a/packages/turf-nearest-neighbor-analysis/index.ts
+++ b/packages/turf-nearest-neighbor-analysis/index.ts
@@ -55,7 +55,7 @@ interface NearestNeighborStudyArea extends Feature<Polygon> {
 }
 
 /**
- * Nearest Neighbor Analysis calculates an index based the average distances
+ * Nearest Neighbor Analysis calculates an index based on the average distances
  * between points in the dataset, thereby providing inference as to whether the
  * data is clustered, dispersed, or randomly distributed within the study area.
  *

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/nearest-neighbor-analysis",
   "version": "7.2.0",
-  "description": "turf nearest-neighbor-analysis module",
+  "description": "Calculates an index based the average distances between points in the dataset, thereby providing inference as to whether the data is clustered, dispersed, or randomly distributed within the study area.",
   "author": "Turf Authors",
   "contributors": [
     "Moacir P. de Sá Pereira <@muziejus>"

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/nearest-point-on-line",
   "version": "7.2.0",
-  "description": "turf nearest-point-on-line module",
+  "description": "Finds the nearest point on a line to a given point",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/nearest-point-to-line",
   "version": "7.2.0",
-  "description": "turf nearest-point-to-line module",
+  "description": "Returns the closest point, of a collection of points, to a line.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/nearest-point",
   "version": "7.2.0",
-  "description": "turf nearest-point module",
+  "description": "Finds the nearest point from a FeatureCollection of Features with Point geometries to a given point.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/planepoint",
   "version": "7.2.0",
-  "description": "turf planepoint module",
+  "description": "Takes a triangular plane as a polygon and a point within that triangle, and returns the z-value at that point.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/point-grid",
   "version": "7.2.0",
-  "description": "turf point-grid module",
+  "description": "Creates a grid of points within a bounding box.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>",

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/point-on-feature",
   "version": "7.2.0",
-  "description": "turf point-on-feature module",
+  "description": "Takes a Feature or FeatureCollection and returns a Point guaranteed to be on the surface of the feature.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/point-to-line-distance",
   "version": "7.2.0",
-  "description": "turf point-to-line-distance module",
+  "description": "Calculates the distance between a given point and the nearest point on a line.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-point-to-polygon-distance/package.json
+++ b/packages/turf-point-to-polygon-distance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/point-to-polygon-distance",
   "version": "7.2.0",
-  "description": "turf point-to-polygon-distance module",
+  "description": "Calculates the distance from a point to the edges of a polygon or multi-polygon.",
   "author": "Turf Authors",
   "contributors": [
     "Marc <@pachacamac>"

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/points-within-polygon",
   "version": "7.2.0",
-  "description": "Finds Points or MultiPoint coordinate positions that fall within (Multi)Polygon(s).",
+  "description": "Finds points that fall within polygon(s).",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/points-within-polygon",
   "version": "7.2.0",
-  "description": "turf points-within-polygon module",
+  "description": "Finds Points or MultiPoint coordinate positions that fall within (Multi)Polygon(s).",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygon-smooth",
   "version": "7.2.0",
-  "description": "turf polygon smooth module",
+  "description": "Smooths a Polygon or MultiPolygon, based on Chaikin's algorithm.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>"

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygon-tangents",
   "version": "7.2.0",
-  "description": "turf polygon tangents module",
+  "description": "Finds the tangents of a (Multi)Polygon from a Point.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygon-tangents",
   "version": "7.2.0",
-  "description": "Finds the tangents of a (Multi)Polygon from a Point.",
+  "description": "Finds the tangents of a polygon from a point.",
   "author": "Turf Authors",
   "contributors": [
     "Rowan Winsemius <@rowanwins>",

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygon-to-line",
   "version": "7.2.0",
-  "description": "turf polygon-to-line module",
+  "description": "Converts a Polygon to (Multi)LineString or MultiPolygon to a FeatureCollection of (Multi)LineString.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygon-to-line",
   "version": "7.2.0",
-  "description": "Converts a polygon to a lineString.",
+  "description": "Converts a polygon to a line string.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygon-to-line",
   "version": "7.2.0",
-  "description": "Converts a Polygon to (Multi)LineString or MultiPolygon to a FeatureCollection of (Multi)LineString.",
+  "description": "Converts a polygon to a lineString.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/polygonize",
   "version": "7.2.0",
-  "description": "turf polygonize module",
+  "description": "Polygonizes a set of lines that represents edges in a planar graph.",
   "author": "Turf Authors",
   "contributors": [
     "Nicolas Cisco <@nickcis>",

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/projection",
   "version": "7.2.0",
-  "description": "turf projection module",
+  "description": "Provides tools for conversion between geographic coordinates and projected coordinates.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>"

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/quadrat-analysis",
   "version": "7.2.0",
-  "description": "turf quadrat-analysis module",
+  "description": "Quadrat analysis lays a set of equal-size areas(quadrat) over the study area and counts the number of features in each quadrat and creates a frequency table.",
   "author": "Turf Authors",
   "contributors": [
     "Haoming Zhuang <@zhuang-hao-ming>"

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/random",
   "version": "7.2.0",
-  "description": "turf random module",
+  "description": "Generates random points, lines, or polygons for testing.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rectangle-grid",
   "version": "7.2.0",
-  "description": "turf rectangle-grid module",
+  "description": "Creates a grid of rectangular polygons with width and height consistent in degrees.",
   "author": "Turf Authors",
   "contributors": [
     "Steve Bennett <@stevage>",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rewind",
   "version": "7.2.0",
-  "description": "turf rewind module",
+  "description": "Rewind (Multi)LineString or (Multi)Polygon outer ring counterclockwise and inner rings clockwise, using Shoelace Formula.",
   "author": "Turf Authors",
   "contributors": [
     "Abel Vázquez Montoro <@AbelVM>",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rewind",
   "version": "7.2.0",
-  "description": "Rewind (Multi)LineString or (Multi)Polygon outer ring counterclockwise and inner rings clockwise, using Shoelace Formula.",
+  "description": "Rewind using Shoelace Formula.",
   "author": "Turf Authors",
   "contributors": [
     "Abel Vázquez Montoro <@AbelVM>",

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rhumb-bearing",
   "version": "7.2.0",
-  "description": "turf rhumb-bearing module",
+  "description": "Takes two points and finds the bearing angle between them along a Rhumb line.",
   "author": "Turf Authors",
   "contributors": [
     "Chris Veness <@chrisveness>",

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rhumb-destination",
   "version": "7.2.0",
-  "description": "turf rhumb-destination module",
+  "description": "Returns the destination point having travelled the given distance along a Rhumb line from the origin point with the (varant) given bearing.",
   "author": "Turf Authors",
   "contributors": [
     "Chris Veness <@chrisveness>",

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rhumb-destination",
   "version": "7.2.0",
-  "description": "Returns the destination point having travelled the given distance along a Rhumb line from the origin point with the (varant) given bearing.",
+  "description": "Calculates the destination point having travelled the given distance along a Rhumb line.",
   "author": "Turf Authors",
   "contributors": [
     "Chris Veness <@chrisveness>",

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rhumb-distance",
   "version": "7.2.0",
-  "description": "turf rhumb-distance module",
+  "description": "Calculates the distance along a rhumb line between two points in degrees, radians, miles, or kilometers.",
   "author": "Turf Authors",
   "contributors": [
     "Chris Veness <@chrisveness>",

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/rhumb-distance",
   "version": "7.2.0",
-  "description": "Calculates the distance along a rhumb line between two points in degrees, radians, miles, or kilometers.",
+  "description": "Calculates the distance along a rhumb line between two points.",
   "author": "Turf Authors",
   "contributors": [
     "Chris Veness <@chrisveness>",

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/sample",
   "version": "7.2.0",
-  "description": "turf sample module",
+  "description": "Takes a FeatureCollection and returns a FeatureCollection with given number of features at random.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/sector",
   "version": "7.2.0",
-  "description": "Creates a circular sector of a circle of given radius and center Point, between two bearings.",
+  "description": "Creates a circular sector of a circle.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/sector",
   "version": "7.2.0",
-  "description": "turf sector module",
+  "description": "Creates a circular sector of a circle of given radius and center Point, between two bearings.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/shortest-path",
   "version": "7.2.0",
-  "description": "turf shortest-path module",
+  "description": "Returns the shortest path from start to end without colliding with any Feature in obstacles.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>",

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/simplify",
   "version": "7.2.0",
-  "description": "turf simplify module",
+  "description": "Reduces the number of points in a shape while keeping its overall look.",
   "author": "Turf Authors",
   "contributors": [
     "Vladimir Agafonkin <@mourner>",

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/square-grid",
   "version": "7.2.0",
-  "description": "turf square-grid module",
+  "description": "Creates a square grid within a bounding box.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/square",
   "version": "7.2.0",
-  "description": "turf square module",
+  "description": "Takes a bounding box and calculates the minimum square bounding box that would contain the input.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/standard-deviational-ellipse",
   "version": "7.2.0",
-  "description": "turf standard-deviational-ellipse module",
+  "description": "Takes a collection of features and returns a standard deviational ellipse.",
   "author": "Turf Authors",
   "contributors": [
     "Moacir P. de Sá Pereira <@muziejus>"

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/tag",
   "version": "7.2.0",
-  "description": "turf tag module",
+  "description": "Takes a set of points and a set of polygons and/or multipolygons and performs a spatial join.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/tesselate",
   "version": "7.2.0",
-  "description": "turf tesselate module",
+  "description": "Tesselates a polygon or multipolygon into a collection of triangle polygons using earcut.",
   "author": "Turf Authors",
   "contributors": [
     "Abel Vázquez <@AbelVM>",

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/tin",
   "version": "7.2.0",
-  "description": "turf tin module",
+  "description": "Takes a set of points and creates a Triangulated Irregular Network, returned as a collection of Polygons.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/tin",
   "version": "7.2.0",
-  "description": "Takes a set of points and creates a Triangulated Irregular Network, returned as a collection of Polygons.",
+  "description": "Takes a set of points and creates a Triangulated Irregular Network.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/transform-rotate",
   "version": "7.2.0",
-  "description": "turf transform-rotate module",
+  "description": "Rotates a geometry around its center or a given point.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>",

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/transform-scale",
   "version": "7.2.0",
-  "description": "turf transform-scale module",
+  "description": "Changes the size of a geometry by scaling it up or down.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>",

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/transform-translate",
   "version": "7.2.0",
-  "description": "turf transform-translate module",
+  "description": "Moves a shape or location in a specific direction.",
   "author": "Turf Authors",
   "contributors": [
     "Stefano Borghi <@stebogit>",

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/triangle-grid",
   "version": "7.2.0",
-  "description": "turf triangle-grid module",
+  "description": "Creates a triangular grid within a bounding box.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/truncate",
   "version": "7.2.0",
-  "description": "turf truncate module",
+  "description": "Truncates precision of GeoJSON coordinates.",
   "author": "Turf Authors",
   "contributors": [
     "Denis Carriere <@DenisCarriere>"

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/union",
   "version": "7.2.0",
-  "description": "turf union module",
+  "description": "Combines two or more polygons into a single polygon.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/unkink-polygon",
   "version": "7.2.0",
-  "description": "turf unkink-polygon module",
+  "description": "Takes a kinked polygon and returns a feature collection of polygons that have no kinks.",
   "author": "Turf Authors",
   "license": "MIT",
   "bugs": {

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turf/voronoi",
   "version": "7.2.0",
-  "description": "turf voronoi module",
+  "description": "Takes a collection of points and a bounding box, and returns a collection of Voronoi polygons.",
   "author": "Turf Authors",
   "contributors": [
     "Philippe Riviere <@Fil>",


### PR DESCRIPTION
This PR updates the description in package.json for all the turf packages. Almost all of the descriptions have been referenced from the API docs that can be found at https://turfjs.org. I could not find description for four packages in the API docs. These are turf-invariant, turf-projection, turf-meta, and turf-distance-weight.

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [ ] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [ ] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).

Resolves #2798
