### PR TITLE
Update link to Chaikin's algorithm - access forbidden for the old link.

### DIFF
--- a/packages/turf-polygon-smooth/README.md
+++ b/packages/turf-polygon-smooth/README.md
@@ -31,7 +31,7 @@ Returns **[FeatureCollection][4]<([Polygon][1] | [MultiPolygon][2])>** FeatureCo
 
 [2]: https://tools.ietf.org/html/rfc7946#section-3.1.7
 
-[3]: http://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html
+[3]: https://www.cs.unc.edu/~dm/UNC/COMP258/LECTURES/Chaikins-Algorithm.pdf
 
 [4]: https://tools.ietf.org/html/rfc7946#section-3.3
 

--- a/packages/turf-polygon-smooth/index.ts
+++ b/packages/turf-polygon-smooth/index.ts
@@ -9,7 +9,7 @@ import { featureCollection, multiPolygon, polygon } from "@turf/helpers";
 import { coordEach, geomEach } from "@turf/meta";
 
 /**
- * Smooths a {@link Polygon} or {@link MultiPolygon}. Based on [Chaikin's algorithm](http://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html).
+ * Smooths a {@link Polygon} or {@link MultiPolygon}. Based on [Chaikin's algorithm](https://www.cs.unc.edu/~dm/UNC/COMP258/LECTURES/Chaikins-Algorithm.pdf).
  * Warning: may create degenerate polygons.
  *
  * @function


### PR DESCRIPTION
This pull request includes updates to the `turf-polygon-smooth` package, specifically to update the URL references for Chaikin's algorithm in the documentation and code comments.

Documentation updates:

* [`packages/turf-polygon-smooth/README.md`](diffhunk://#diff-25dc8d9d663fe6cb0e238414941927e62a97489f65e134cb79c1fe9bb7975975L34-R34): Updated the URL reference for Chaikin's algorithm to a new link.


* [`packages/turf-polygon-smooth/index.ts`](diffhunk://#diff-2ed7e493c7af51a55577035ec3ba1afb18744aa21cbbea17c158956e888dbcd6L12-R12): Updated the URL reference for Chaikin's algorithm in the code comments to the same new link.


- [ ] Meaningful title, including the name of the package being modified.
- [ ] Summary of the changes.
- [ ] Heads up if this is a breaking change.
- [ ] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [ ] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [ ] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
