### PR TITLE
Fixed simplify to not get stuck in an infinite loop on certain geometries

### DIFF
--- a/packages/turf-nearest-neighbor-analysis/README.md
+++ b/packages/turf-nearest-neighbor-analysis/README.md
@@ -30,7 +30,7 @@ Type: [object][1]
 
 ## nearestNeighborAnalysis
 
-Nearest Neighbor Analysis calculates an index based the average distances
+Nearest Neighbor Analysis calculates an index based on the average distances
 between points in the dataset, thereby providing inference as to whether the
 data is clustered, dispersed, or randomly distributed within the study area.
 

--- a/packages/turf-simplify/README.md
+++ b/packages/turf-simplify/README.md
@@ -4,22 +4,22 @@
 
 ## simplify
 
-Takes a [GeoJSON][1] object and returns a simplified version. Internally uses the 2d version of
-[simplify-js][2] to perform simplification using the Ramer-Douglas-Peucker algorithm.
+Simplifies the geometries in a GeoJSON object. Uses the 2d version of
+[simplify-js][1].
 
 ### Parameters
 
-*   `geojson` **[GeoJSON][1]** object to be simplified
+*   `geojson` **[GeoJSON][2]** GeoJSON object to be simplified
 *   `options` **[Object][3]** Optional parameters (optional, default `{}`)
 
-    *   `options.tolerance` **[number][4]** simplification tolerance (optional, default `1`)
-    *   `options.highQuality` **[boolean][5]** whether or not to spend more time to create a higher-quality simplification with a different algorithm (optional, default `false`)
-    *   `options.mutate` **[boolean][5]** allows GeoJSON input to be mutated (significant performance increase if true) (optional, default `false`)
+    *   `options.tolerance` **[number][4]** Simplification tolerance (optional, default `1`)
+    *   `options.highQuality` **[boolean][5]** Produce a higher-quality simplification using a slower algorithm (optional, default `false`)
+    *   `options.mutate` **[boolean][5]** Allow GeoJSON input to be mutated (significant performance improvement if true) (optional, default `false`)
 
 ### Examples
 
 ```javascript
-var geojson = turf.polygon([[
+const geojson = turf.polygon([[
   [-70.603637, -33.399918],
   [-70.614624, -33.395332],
   [-70.639343, -33.392466],
@@ -41,18 +41,18 @@ var geojson = turf.polygon([[
   [-70.594711, -33.406224],
   [-70.603637, -33.399918]
 ]]);
-var options = {tolerance: 0.01, highQuality: false};
-var simplified = turf.simplify(geojson, options);
+const result0_01 = turf.simplify(geojson, {tolerance: 0.01 });
+const result0_005 = turf.simplify(geojson, {tolerance: 0.005 });
 
 //addToMap
-var addToMap = [geojson, simplified]
+const addToMap = [geojson, result0_01, result0_005]
 ```
 
-Returns **[GeoJSON][1]** a simplified GeoJSON
+Returns **[GeoJSON][2]** Simplified GeoJSON
 
-[1]: https://tools.ietf.org/html/rfc7946#section-3
+[1]: https://mourner.github.io/simplify-js/
 
-[2]: http://mourner.github.io/simplify-js/
+[2]: https://tools.ietf.org/html/rfc7946#section-3
 
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 

--- a/packages/turf-simplify/test.ts
+++ b/packages/turf-simplify/test.ts
@@ -214,3 +214,60 @@ test("simplify -- issue #918", (t) => {
   );
   t.end();
 });
+
+test("simplify - issue 1788 - infinite loop", (t) => {
+  // For particularly small polygons simplify was getting stuck in an
+  // infinite loop.
+
+  // https://github.com/Turfjs/turf/issues/1788#issue-521052548
+  const poly1 = polygon([
+    [
+      [11.662180661499999, 50.1081498005],
+      [11.662192661499999, 50.108041800500004],
+      [11.6621866615, 50.1080958005],
+      [11.662180661499999, 50.1081498005],
+    ],
+  ]);
+  simplify(poly1, {
+    tolerance: 0.000001,
+    highQuality: true,
+    mutate: false,
+  });
+  t.pass("issue 1788 test 1 didn't hang");
+
+  // https://github.com/Turfjs/turf/issues/1788#issuecomment-951109683
+  const poly2 = polygon([
+    [
+      [4.0881641, 6.8121605],
+      [4.0881639, 6.8121607],
+      [4.0881638, 6.8121608],
+      [4.0881641, 6.8121605],
+    ],
+  ]);
+  simplify(poly2);
+  t.pass("issue 1788 test 2 didn't hang");
+
+  // https://github.com/Turfjs/turf/issues/1788#issuecomment-1362073785
+  const poly3 = multiPolygon([
+    [
+      [
+        [-10.06762725, -17.428977611],
+        [-10.067626613, -17.428977323],
+        [-10.067625943, -17.428976957],
+        [-10.06762725, -17.428977611],
+      ],
+    ],
+    [
+      [
+        [-10.067625943, -17.428976957],
+        [-10.067599027, -17.428963499],
+        [-10.067625941, -17.428976956],
+        [-10.067625943, -17.428976957],
+      ],
+    ],
+  ]);
+  simplify(poly3, { tolerance: 0.00001, highQuality: true });
+  t.pass("issue 1788 test 3 didn't hang");
+
+  t.end();
+});


### PR DESCRIPTION
simplify was getting stuck in an infinite loop when it couldn't reduce the tolerance far enough to generate a valid polygon. This often happened with very small rings e.g. couple of centimetres to a side.

Resolves #1788 

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [ ] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
