### PR TITLE
Fix - Documented unit used for Earth's radius

### DIFF
--- a/packages/turf-helpers/README.md
+++ b/packages/turf-helpers/README.md
@@ -49,7 +49,7 @@ Type: ([Feature][7] | [FeatureCollection][8] | [Geometry][9] | [GeometryCollecti
 
 ## earthRadius
 
-The Earth radius in kilometers. Used by Turf modules that model the Earth as a sphere. The [mean radius][11] was selected because it is [recommended ][12] by the Haversine formula (used by turf/distance) to reduce error.
+The Earth radius in meters. Used by Turf modules that model the Earth as a sphere. The [mean radius][11] was selected because it is [recommended ][12] by the Haversine formula (used by turf/distance) to reduce error.
 
 Type: [number][13]
 

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -97,7 +97,7 @@ export type AllGeoJSON =
   | GeometryCollection;
 
 /**
- * The Earth radius in kilometers. Used by Turf modules that model the Earth as a sphere. The {@link https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius mean radius} was selected because it is {@link https://rosettacode.org/wiki/Haversine_formula#:~:text=This%20value%20is%20recommended recommended } by the Haversine formula (used by turf/distance) to reduce error.
+ * The Earth radius in meters. Used by Turf modules that model the Earth as a sphere. The {@link https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius mean radius} was selected because it is {@link https://rosettacode.org/wiki/Haversine_formula#:~:text=This%20value%20is%20recommended recommended } by the Haversine formula (used by turf/distance) to reduce error.
  *
  * @constant
  */


### PR DESCRIPTION
Corrected the "unit" that is documented as the one being used for the Earth's radius, from "kilometers" to "meters".

The constant value is: `6371008.8`, which is + 6 million, that would be meters. 
As mentioned in the Wikipedia that is referenced in the documentation https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius 

> For Earth, the arithmetic mean radius is 6,371.0088 km (3,958.7613 mi).

6371 km are 6.371.000 meters.

---

This change should not bring any errors, since only changes the documentation, instead of changing the constant value to kilometers.

I took a quick look, and the code seems to have been done using the correct "meters" unit, for example when checking out the factors constant:

```
export const factors: Record<Units, number> = {
  centimeters: earthRadius * 100,
  centimetres: earthRadius * 100,
  degrees: 360 / (2 * Math.PI),
  feet: earthRadius * 3.28084,
  inches: earthRadius * 39.37,
  kilometers: earthRadius / 1000,  // <------
  kilometres: earthRadius / 1000,  // <------
  meters: earthRadius,  // <------
  metres: earthRadius,  // <------
  miles: earthRadius / 1609.344,
  millimeters: earthRadius * 1000,
  millimetres: earthRadius * 1000,
  nauticalmiles: earthRadius / 1852,
  radians: 1,
  yards: earthRadius * 1.0936,
};

```