### PR TITLE
turf-tessellate: Pass original coordinate elevations through the tesselate function.

### DIFF
--- a/packages/turf-tesselate/index.ts
+++ b/packages/turf-tesselate/index.ts
@@ -50,7 +50,7 @@ function tesselate(
 
 function processPolygon(coordinates: Position[][]) {
   const data = flattenCoords(coordinates);
-  const dim = 2;
+  const dim: number = coordinates[0][0].length;
   const result = earcut(data.vertices, data.holes, dim);
 
   const features: Feature<Polygon>[] = [];
@@ -58,7 +58,19 @@ function processPolygon(coordinates: Position[][]) {
 
   result.forEach(function (vert: any, i: number) {
     const index = result[i];
-    vertices.push([data.vertices[index * dim], data.vertices[index * dim + 1]]);
+    // if elevation component is included in the original coordinates, include it in the output coordinates
+    if (dim > 2) {
+      vertices.push([
+        data.vertices[index * dim],
+        data.vertices[index * dim + 1],
+        data.vertices[index * dim + 2],
+      ]);
+    } else {
+      vertices.push([
+        data.vertices[index * dim],
+        data.vertices[index * dim + 1],
+      ]);
+    }
   });
 
   for (var i = 0; i < vertices.length; i += 3) {

--- a/packages/turf-tesselate/index.ts
+++ b/packages/turf-tesselate/index.ts
@@ -50,7 +50,8 @@ function tesselate(
 
 function processPolygon(coordinates: Position[][]) {
   const data = flattenCoords(coordinates);
-  const dim: number = coordinates[0][0].length;
+  // coordinates are normalized to 3 dimensions by passing through original elevation value, or padding with undefined
+  const dim = 3;
   const result = earcut(data.vertices, data.holes, dim);
 
   const features: Feature<Polygon>[] = [];
@@ -58,8 +59,8 @@ function processPolygon(coordinates: Position[][]) {
 
   result.forEach(function (vert: any, i: number) {
     const index = result[i];
-    // if elevation component is included in the original coordinates, include it in the output coordinates
-    if (dim > 2) {
+    // if elevation component is included in the original coordinate, include it in the output coordinate
+    if (data.vertices[index * dim + 2] !== undefined) {
       vertices.push([
         data.vertices[index * dim],
         data.vertices[index * dim + 1],
@@ -83,7 +84,8 @@ function processPolygon(coordinates: Position[][]) {
 }
 
 function flattenCoords(data: Position[][]) {
-  const dim: number = data[0][0].length,
+  // coordinates are normalized to 3 dimensions by passing through original elevation value, or padding with undefined
+  const dim = 3,
     result: { vertices: number[]; holes: number[]; dimensions: number } = {
       vertices: [],
       holes: [],
@@ -93,6 +95,7 @@ function flattenCoords(data: Position[][]) {
 
   for (let i = 0; i < data.length; i++) {
     for (let j = 0; j < data[i].length; j++) {
+      // elevation member is either included, or undefined is put in its place
       for (let d = 0; d < dim; d++) result.vertices.push(data[i][j][d]);
     }
     if (i > 0) {

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -7,7 +7,8 @@
     "Abel Vázquez <@AbelVM>",
     "Morgan Herlocker <@morganherlocker>",
     "Tom MacWright <@tmcw>",
-    "Vladimir Agafonkin <@mourner>"
+    "Vladimir Agafonkin <@mourner>",
+    "Pavel Rozvora <@prozvora>"
   ],
   "license": "MIT",
   "bugs": {

--- a/packages/turf-tesselate/test.ts
+++ b/packages/turf-tesselate/test.ts
@@ -3499,5 +3499,44 @@ test("tesselate", function (t) {
     tesselate(featurecollection([]));
   }, /input must be a Polygon or MultiPolygon/);
 
+  var simplePolygonWithElevation = {
+    type: "Feature",
+    id: "CoordsWithElevation",
+    properties: { name: "CoordsWithElevation" },
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [-123.233256, 42.006186, 130],
+          [-114.634459, 35.00118, 130],
+          [-118.183517, 33.763391, 130],
+          [-124.213628, 42.000709, 130],
+          [-123.233256, 42.006186, 130],
+        ],
+      ],
+    },
+  };
+
+  var simpleTrianglesWithElevation = tesselate(simplePolygonWithElevation);
+  t.equal(
+    simpleTrianglesWithElevation.type,
+    "FeatureCollection",
+    "Polygon returns a FeatureCollection"
+  );
+  t.equal(
+    simpleTrianglesWithElevation.features[0].geometry.type,
+    "Polygon",
+    "contains at least 1 triangle"
+  );
+  t.equal(
+    simpleTrianglesWithElevation.features[0].geometry.coordinates[0].length,
+    4,
+    "triangle is valid"
+  );
+  t.equal(
+    simpleTrianglesWithElevation.features[0].geometry.coordinates[0][0][2],
+    130,
+    "triangle coordinates contain elevation"
+  );
   t.end();
 });

--- a/packages/turf-tesselate/test.ts
+++ b/packages/turf-tesselate/test.ts
@@ -3538,5 +3538,59 @@ test("tesselate", function (t) {
     130,
     "triangle coordinates contain elevation"
   );
+
+  var simpleSquareWithVariableElevation = {
+    type: "Feature",
+    id: "SquareWithVariableElevation",
+    properties: { name: "SquareWithVariableElevation" },
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [1, 1],
+          [1, 2, 50],
+          [2, 2, 75],
+          [2, 1],
+          [1, 1],
+        ],
+      ],
+    },
+  };
+
+  var simpleVariableElevationTriangles = tesselate(
+    simpleSquareWithVariableElevation
+  );
+
+  t.equal(
+    simpleVariableElevationTriangles.type,
+    "FeatureCollection",
+    "Polygon returns a FeatureCollection"
+  );
+
+  t.deepEqual(
+    simpleVariableElevationTriangles.features[0].geometry.coordinates,
+    [
+      [
+        [1, 2, 50],
+        [1, 1],
+        [2, 1],
+        [1, 2, 50],
+      ],
+    ],
+    "first triangle coordinates contain original elevations"
+  );
+  t.deepEqual(
+    simpleVariableElevationTriangles.features[1].geometry.coordinates,
+    [
+      [
+        [2, 1],
+        [2, 2, 75],
+        [1, 2, 50],
+        [2, 1],
+      ],
+    ],
+    "second triangle coordinates contain original elevations"
+  );
+
   t.end();
 });


### PR DESCRIPTION
### Summary of Changes

Pad elevation coordinate member with undefined for passing to `earcut`.
Strip off undefined elevations before returning result from `tessellate`.
Add test case for constant elevation in all coordinates.
Add test case for variable elevation in some coordinates.

> [!NOTE]
> This is a non-breaking change.

### Resolves

- #2672 

### Test Output
<img width="567" alt="turf-all-tests" src="https://github.com/user-attachments/assets/e673fb5c-fd6e-426b-951a-37f1949d0105" />

#### Tessellate
```
# tesselate
ok 1 Polygon returns a FeatureCollection
ok 2 contains at least 1 triangle
ok 3 triangle is valid
ok 4 MultiPolygon returns a FeatureCollection
ok 5 contains at least 1 triangle
ok 6 triangle is valid
ok 7 should throw
ok 8 should throw
ok 9 Polygon returns a FeatureCollection
ok 10 contains at least 1 triangle
ok 11 triangle is valid
ok 12 triangle coordinates contain elevation
ok 13 Polygon returns a FeatureCollection
ok 14 first triangle coordinates contain original elevations
ok 15 second triangle coordinates contain original elevations

1..15
# tests 15
# pass  15

# ok
```

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [x] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
