### PR TITLE
Improve NearestPoint type for @turf/nearest-point so that it keeps the properties of the points in the FeatureCollection

### DIFF
--- a/packages/turf-nearest-point/index.ts
+++ b/packages/turf-nearest-point/index.ts
@@ -4,12 +4,11 @@ import { clone } from "@turf/clone";
 import { distance } from "@turf/distance";
 import { featureEach } from "@turf/meta";
 
-interface NearestPoint extends Feature<Point> {
+interface NearestPoint<P = GeoJsonProperties> extends Feature<Point> {
   properties: {
     featureIndex: number;
     distanceToPoint: number;
-    [key: string]: any;
-  };
+  } & P;
 }
 
 /**
@@ -38,13 +37,13 @@ interface NearestPoint extends Feature<Point> {
  * var addToMap = [targetPoint, points, nearest];
  * nearest.properties['marker-color'] = '#F00';
  */
-function nearestPoint(
+function nearestPoint<P = GeoJsonProperties>(
   targetPoint: Coord,
-  points: FeatureCollection<Point>,
+  points: FeatureCollection<Point, P>,
   options: {
     units?: Units;
   } = {}
-): NearestPoint {
+): NearestPoint<P> {
   // Input validation
   if (!targetPoint) throw new Error("targetPoint is required");
   if (!points) throw new Error("points is required");


### PR DESCRIPTION
Please provide the following when creating a PR:

- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).

This PR improves the `NearestPoint` type and the type definition for the `nearestPoint` function.

Consider the following example in TypeScript:

```ts
const coordinatesList = [[0, 0], [1, 1], [0, 1]];
const pointsList = coordinatesList.map((coordinate, i) => {
    return turf.point(coordinate, {
        name: `point${i}`
    });
});
const pointsCollection = turf.featureCollection(pointsList);
const myNearestPoint = turf.nearestPoint(turf.point([2, 2]), pointsCollection);
```

With the old behaviour `myNearestPoint.properties.name` is of type `any` according to TypeScript.

With the changes in this PR, the type of `myNearestPoint.properties.name` is correctly inferred as `string`.

This change should be non-breaking.