### PR TITLE
Compute multiFeatureLocation in addition to location property in @turf/nearest-point-on-line

### DIFF
--- a/packages/turf-nearest-point-on-line/test.ts
+++ b/packages/turf-nearest-point-on-line/test.ts
@@ -398,6 +398,37 @@ test("turf-nearest-point-on-line -- multifeature index", (t) => {
   t.end();
 });
 
+test("turf-nearest-point-on-line -- issue 2753 multifeature location", (t) => {
+  const multiLine = multiLineString([
+    [
+      [-122.3125, 47.6632],
+      [-122.3102, 47.6646],
+    ],
+    [
+      [-122.3116, 47.6623],
+      [-122.3091, 47.6636],
+    ],
+  ]);
+
+  const ptA = point([-122.3106, 47.6638], { name: "A" });
+  const ptB = point([-122.3102, 47.6634], { name: "B" });
+
+  const nearestToA = nearestPointOnLine(multiLine, ptA, { units: "meters" });
+  const nearestToB = nearestPointOnLine(multiLine, ptB, { units: "meters" });
+
+  t.equal(
+    Number(nearestToA.properties.multiFeatureLocation.toFixed(6)),
+    150.293316,
+    "nearestToA multiFeatureLocation"
+  );
+  t.equal(
+    Number(nearestToB.properties.multiFeatureLocation.toFixed(6)),
+    157.736676,
+    "nearestToB multiFeatureLocation"
+  );
+  t.end();
+});
+
 test("turf-nearest-point-on-line -- issue 1514", (t) => {
   const pt = point([-40.01, 56]);
   const line = lineString([


### PR DESCRIPTION
This adds a `multiFeatureLocation` property to the points returned by the `nearestPointOnLine` function. If there is just one LineString, then this will be the same as the existing `location` property. But if you pass a MultiLineString, this will tell you the distance along the line between the start of the MultiLineString where the closest point was found and the closest point itself. See #2753 for an example why this is useful.

Closes #2753.

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
