### PR TITLE
fix nearestPointOnLine for points far away from the segment endpoints

### DIFF
--- a/packages/turf-nearest-point-on-line/index.ts
+++ b/packages/turf-nearest-point-on-line/index.ts
@@ -250,13 +250,10 @@ function nearestPointOnSegment(
   // If angle AI or BI is greater than angleAB, I lies on the circle *beyond* A
   // and B so use the closest of A or B as the intersection
   if (angle(A, I) > angleAB || angle(B, I) > angleAB) {
-    if (
-      distance(vectorToLngLat(I), vectorToLngLat(A)) <=
-      distance(vectorToLngLat(I), vectorToLngLat(B))
-    ) {
-      return [vectorToLngLat(A), true, false];
+    if (distance(posC, posA) <= distance(posC, posB)) {
+      return [posA, true, false];
     } else {
-      return [vectorToLngLat(B), false, true];
+      return [posB, false, true];
     }
   }
 

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -3,6 +3,9 @@
   "version": "7.2.0",
   "description": "Finds the nearest point on a line to a given point",
   "author": "Turf Authors",
+  "contributors": [
+    "mike castleman <@mlc>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"

--- a/packages/turf-nearest-point-on-line/test.ts
+++ b/packages/turf-nearest-point-on-line/test.ts
@@ -517,3 +517,20 @@ test("turf-nearest-point-on-line -- issue 2808 redundant point support", (t) => 
 
   t.end();
 });
+
+test("turf-nearest-point-on-line -- issue 2870 faraway point", (t) => {
+  const line1 = lineString([
+    [-96.80974, -58.32062],
+    [-50.2464, 38.36643],
+  ]);
+  const thePoint = point([13.6023, 46.50646]);
+
+  const nearest = nearestPointOnLine(line1, thePoint);
+  t.deepEqual(
+    truncate(nearest, { precision: 8 }).geometry.coordinates,
+    [-50.2464, 38.36643],
+    "nearest point should be [-50.2464, 38.36643]"
+  );
+
+  t.end();
+});


### PR DESCRIPTION
Fixes #2870; see that ticket for a description of the observed bug.

This patch fixes the described bug by adjusting how `nearestPointOnSegment` picks an endpoint when it determines that the nearest intersection of the great circles is not on the segment. Rather than doing work with angles, it just computes the distance to the two endpoints and picks the closer one.

I think this is safe—it does not break any existing tests—and should not lead to a performance reduction (there are just as many calls to `distance` as there were before, and some vector math has been removed), but the algorithms here are a little bit outside of my wheelhouse, so I would certainly appreciate any feedback if there is something wrong. A more natural way of fixing the issue might be to correctly choose the right value of `I` in the section above the one I modified, but I can not quite figure out how to make that work.

Thanks so much for turf and for your attention to this!

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [ ] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [x] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
