### PR TITLE
turf-great-circle: Fix antipodal error message

### DIFF
--- a/packages/turf-great-circle/lib/arc.js
+++ b/packages/turf-great-circle/lib/arc.js
@@ -135,9 +135,9 @@ var GreatCircle = function (start, end, properties) {
   if (this.g === Math.PI) {
     throw new Error(
       "it appears " +
-        start.view() +
+        this.start.view() +
         " and " +
-        end.view() +
+        this.end.view() +
         " are 'antipodal', e.g diametrically opposite, thus there is no single route but rather infinite"
     );
   } else if (isNaN(this.g)) {

--- a/packages/turf-great-circle/test.ts
+++ b/packages/turf-great-circle/test.ts
@@ -59,3 +59,16 @@ test("turf-great-circle with same input and output", (t) => {
 
   t.end();
 });
+
+test("turf-great-circle with antipodal start and end", (t) => {
+  const start = point([0, 90]);
+  const end = point([0, -90]);
+
+  t.throws(() => {
+    greatCircle(start, end, {
+      npoints: 4,
+    });
+  }, "it appears 0,90 and 0,-90 are 'antipodal', e.g diametrically opposite, thus there is no single route but rather infinite");
+
+  t.end();
+});


### PR DESCRIPTION
`start.view()` and `end.view()` should have been `this.start.view()` and `this.end.view()` to correctly give the desired error message.

No breaking change

Fixes #2883 

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [x] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
