### PR TITLE
@turf/nearest-point-on-line TESTS: add test for duplicated points on line string affecting v7.2.0

### DIFF
--- a/packages/turf-nearest-point-on-line/test.ts
+++ b/packages/turf-nearest-point-on-line/test.ts
@@ -517,3 +517,17 @@ test("turf-nearest-point-on-line -- issue 2808 redundant point support", (t) => 
 
   t.end();
 });
+
+test("turf-nearest-point-on-line -- duplicate points on line string shouldn't break the function.", (t) => {
+  // @jonmiles
+  const line = lineString([
+    [-80.191793, 25.885611],
+    [-80.191793, 25.885611],
+    [-80.191543, 25.885874],
+  ]);
+  const userPoint = point([-80.191762, 25.885587]);
+  const nearest = nearestPointOnLine(line, userPoint, { units: "meters" });
+  t.equal(nearest.properties.dist > 4, true, "dist should be greater than 4");
+  t.equal(nearest.properties.location, 0, "location should be 0");
+  t.end();
+});


### PR DESCRIPTION
### Summary of Changes

- Adding unit tests that fail on version 7.2.0
- This test will prevent regressions affecting this package

### Issues related:

- https://github.com/Turfjs/turf/issues/2809
- https://github.com/Turfjs/turf/issues/2807

