### PR TITLE
Increase strictness of @turf/line-chunk input

### DIFF
--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -598,15 +598,20 @@ export function multiPolygon<P extends GeoJsonProperties = GeoJsonProperties>(
  * // => collection
  */
 export function geometryCollection<
+  T extends
+    | Point
+    | LineString
+    | Polygon
+    | MultiPoint
+    | MultiLineString
+    | MultiPolygon,
   P extends GeoJsonProperties = GeoJsonProperties,
 >(
-  geometries: Array<
-    Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon
-  >,
+  geometries: Array<T>,
   properties?: P,
   options: { bbox?: BBox; id?: Id } = {}
-): Feature<GeometryCollection, P> {
-  const geom: GeometryCollection = {
+): Feature<GeometryCollection<T>, P> {
+  const geom: GeometryCollection<T> = {
     type: "GeometryCollection",
     geometries,
   };

--- a/packages/turf-line-chunk/index.ts
+++ b/packages/turf-line-chunk/index.ts
@@ -15,7 +15,7 @@ import {
  * If the line is shorter than the segment length then the original line is returned.
  *
  * @function
- * @param {FeatureCollection|Geometry|Feature<LineString|MultiLineString>} geojson the lines to split
+ * @param {FeatureCollection|Geometry|Feature<LineString|MultiLineString>} geojson the LineString or MultiLineStrings to split
  * @param {number} segmentLength how long to make each segment
  * @param {Object} [options={}] Optional parameters
  * @param {Units} [options.units='kilometers'] Supports all valid Turf {@link https://turfjs.org/docs/api/types/Units Units}
@@ -34,8 +34,8 @@ function lineChunk<T extends LineString | MultiLineString>(
     | Feature<T>
     | FeatureCollection<T>
     | T
-    | GeometryCollection
-    | Feature<GeometryCollection>,
+    | GeometryCollection<T>
+    | Feature<GeometryCollection<T>>,
   segmentLength: number,
   options: {
     units?: Units;
@@ -57,6 +57,12 @@ function lineChunk<T extends LineString | MultiLineString>(
 
   // Flatten each feature to simple LineString
   flattenEach(geojson, (feature: Feature<T>) => {
+    if (feature.geometry.type !== "LineString") {
+      throw new Error(
+        "Only LineString and MultiLineString geometry types are supported"
+      );
+    }
+
     // reverses coordinates to start the first chunked segment at the end
     if (reverse) {
       feature.geometry.coordinates = feature.geometry.coordinates.reverse();

--- a/packages/turf-line-chunk/test.ts
+++ b/packages/turf-line-chunk/test.ts
@@ -106,6 +106,57 @@ test("turf-line-chunk: Prevent input mutation", (t) => {
   t.end();
 });
 
+test("turf-line-chunk: Validate behavior on unsupported geometry types", (t) => {
+  // Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | GeometryCollection;
+
+  // each of these `as any` casts are required to bypass the TypeScript rejection and actually test the validation underneath
+  t.throws(() => {
+    lineChunk({ type: "Point", geometry: [0, 0] } as any, 10);
+  }, "Point geometries are rejected");
+
+  t.throws(() => {
+    lineChunk({ type: "MultiPoint", geometry: [[0, 0]] } as any, 10);
+  }, "MultiPoint geometries are rejected");
+
+  t.throws(() => {
+    lineChunk(
+      {
+        type: "Polygon",
+        geometry: [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 0],
+          ],
+        ],
+      } as any,
+      10
+    );
+  }, "Polygon geometries are rejected");
+
+  t.throws(() => {
+    lineChunk(
+      {
+        type: "MultiPolygon",
+        geometry: [
+          [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 0],
+            ],
+          ],
+        ],
+      } as any,
+      10
+    );
+  }, "MultiPolygons geometries are rejected");
+
+  t.end();
+});
+
 /**
  * Colorize FeatureCollection
  *


### PR DESCRIPTION
The method only works correctly for LineString and MultiLineString shaped geometries (with any containing Features, Collections, etc. This makes the strictness more explicit in the docs, the TypeScript types, and runtime checking.

Follow up to #2969