### PR TITLE
Improve type inference in @turf/helpers' geometry and geometryCollection

### DIFF
--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -231,7 +231,7 @@ export function geometry<
     case "Point":
       return point(coordinates).geometry as any;
     case "LineString":
-      return lineString(coordinates).geometry satisfies LineString as any;
+      return lineString(coordinates).geometry as any;
     case "Polygon":
       return polygon(coordinates).geometry as any;
     case "MultiPoint":


### PR DESCRIPTION
Cherry-picking some of the work from https://github.com/Turfjs/turf/pull/2970 so that we can merge it today instead of waiting for a major release.

Specifically we can further narrow the return types of `geometry` and `geometryCollection` based on what the user sends in the arguments.