### PR TITLE
Example PR to migrate from featureEach to iterFeatures

### DIFF
--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -18,6 +18,23 @@ import {
 import { Id } from "./lib/geojson.js";
 export * from "./lib/geojson.js";
 
+// I'd normally put this in @turf/meta but it isn't full-TypeScript yet
+export function* iterFeatures<
+  G extends GeometryObject,
+  P extends GeoJsonProperties,
+>(
+  geojson: Feature<G, P> | FeatureCollection<G, P>
+): Generator<{ feature: Feature<G, P>; featureIndex: number }, void, unknown> {
+  if (geojson.type === "Feature") {
+    yield { feature: geojson, featureIndex: 0 };
+  } else {
+    const features = geojson.features;
+    for (let i = 0; i < features.length; i++) {
+      yield { feature: features[i], featureIndex: i };
+    }
+  }
+}
+
 /**
  * @module helpers
  */

--- a/packages/turf-moran-index/index.ts
+++ b/packages/turf-moran-index/index.ts
@@ -1,6 +1,6 @@
 import { FeatureCollection } from "geojson";
 import { distanceWeight as spatialWeight } from "@turf/distance-weight";
-import { featureEach } from "@turf/meta";
+import { iterFeatures } from "@turf/helpers";
 
 /**
  * @typedef {object} MoranIndex
@@ -86,11 +86,11 @@ function moranIndex(
   });
 
   const y: number[] = [];
-  featureEach(fc, (feature) => {
+  for (const { feature } of iterFeatures(fc)) {
     const feaProperties = feature.properties || {};
     // validate inputField exists
     y.push(feaProperties[inputField]);
-  });
+  }
 
   const yMean = mean(y);
   const yVar = variance(y);

--- a/packages/turf-nearest-point/index.ts
+++ b/packages/turf-nearest-point/index.ts
@@ -1,8 +1,7 @@
 import { Feature, FeatureCollection, GeoJsonProperties, Point } from "geojson";
-import { Coord, Units } from "@turf/helpers";
+import { Coord, iterFeatures, Units } from "@turf/helpers";
 import { clone } from "@turf/clone";
 import { distance } from "@turf/distance";
-import { featureEach } from "@turf/meta";
 
 interface NearestPoint<P extends GeoJsonProperties = GeoJsonProperties>
   extends Feature<Point> {
@@ -51,13 +50,14 @@ function nearestPoint<P extends GeoJsonProperties = GeoJsonProperties>(
 
   let minDist = Infinity;
   let bestFeatureIndex = 0;
-  featureEach(points, (pt, featureIndex) => {
+  for (const { feature: pt, featureIndex } of iterFeatures(points)) {
     const distanceToPoint = distance(targetPoint, pt, options);
     if (distanceToPoint < minDist) {
       bestFeatureIndex = featureIndex;
       minDist = distanceToPoint;
     }
-  });
+  }
+
   const nearestPoint = clone(points.features[bestFeatureIndex]);
 
   return {


### PR DESCRIPTION
How do people feel about moving towards iterators for some of the @turf/meta functions? They were actually introduced in ES6 so we are definitely safe syntax to use. I made an example PR and migrated a few instances of `featureEach` to make a little demo.

Upsides:

We can introduce new iterator methods today and leave the existing methods alone (and potentially deprecate them). Relatedly, they can be written TypeScript-native from the start so we can be mindful of public API signatures and ease-of-typing issues which we're hitting in @turf/meta now.

We no longer have to check return types and break our loops, the caller can control exactly what they want.

```
function featureEach(geojson, callback) {
  if (geojson.type === "Feature") {
    callback(geojson, 0);
  } else if (geojson.type === "FeatureCollection") {
    for (var i = 0; i < geojson.features.length; i++) {
      if (callback(geojson.features[i], i) === false) break;
    }
  }
}
```

We can stop creating any (potentially large) intermediate arrays when they aren't needed

```
function coordAll(geojson) {
  var coords = [];
  coordEach(geojson, function (coord) {
    coords.push(coord);
  });
  return coords;
}
```

Downsides:

I'm not sure if generators have perf parity with the existing callback situation.

It seems like we only use a small set of iterator methods really frequently: featureEach, coordEach, flattenEach, segmentEach, geomEach. The reducers are mostly just wrappers of these each methods, and could be inlined in a few places instead.