### PR TITLE
@turf/invariant getTypes cleanup

### DIFF
--- a/packages/turf-invariant/README.md
+++ b/packages/turf-invariant/README.md
@@ -132,8 +132,6 @@ Get GeoJSON object's type, Geometry type is prioritize.
 ### Parameters
 
 *   `geojson` **[GeoJSON][7]** GeoJSON object
-*   `_name` **[string][8]?**&#x20;
-*   `name` **[string][8]** name of the variable to display in error message (unused) (optional, default `"geojson"`)
 
 ### Examples
 

--- a/packages/turf-invariant/index.ts
+++ b/packages/turf-invariant/index.ts
@@ -250,7 +250,6 @@ function getGeom<G extends Geometry>(geojson: Feature<G> | G): G {
  * Get GeoJSON object's type, Geometry type is prioritize.
  *
  * @param {GeoJSON} geojson GeoJSON object
- * @param {string} [name="geojson"] name of the variable to display in error message (unused)
  * @returns {string} GeoJSON type
  * @example
  * var point = {
@@ -264,20 +263,19 @@ function getGeom<G extends Geometry>(geojson: Feature<G> | G): G {
  * var geom = turf.getType(point)
  * //="Point"
  */
-function getType(
-  geojson: Feature<any> | FeatureCollection<any> | Geometry,
-  _name?: string
-): string {
-  if (geojson.type === "FeatureCollection") {
-    return "FeatureCollection";
-  }
-  if (geojson.type === "GeometryCollection") {
-    return "GeometryCollection";
-  }
+function getType<
+  T extends Geometry | Feature<Geometry | null> | FeatureCollection,
+>(
+  geojson: T
+): T extends Feature<infer G>
+  ? G extends Geometry
+    ? G["type"]
+    : "Feature"
+  : T["type"] {
   if (geojson.type === "Feature" && geojson.geometry !== null) {
-    return geojson.geometry.type;
+    return geojson.geometry.type as any;
   }
-  return geojson.type;
+  return geojson.type as any;
 }
 
 export {

--- a/packages/turf-invariant/test.ts
+++ b/packages/turf-invariant/test.ts
@@ -5,8 +5,10 @@ import {
   polygon,
   featureCollection,
   geometryCollection,
+  feature,
 } from "@turf/helpers";
 import * as invariant from "./index.js";
+import { LineString, Point } from "geojson";
 
 test("invariant -- containsNumber", (t) => {
   t.equals(invariant.containsNumber([1, 1]), true);
@@ -367,13 +369,15 @@ test("invariant -- getType", (t) => {
     [0, 1],
     [1, 1],
   ]);
-  const collection = featureCollection([pt, line]);
+  const collection = featureCollection<Point | LineString>([pt, line]);
   const geomCollection = geometryCollection([pt.geometry, line.geometry]);
+  const nullFeature = feature(null);
 
   t.deepEqual(invariant.getType(pt), "Point");
   t.deepEqual(invariant.getType(line.geometry), "LineString");
   t.deepEqual(invariant.getType(geomCollection), "GeometryCollection");
   t.deepEqual(invariant.getType(collection), "FeatureCollection");
+  t.deepEqual(invariant.getType(nullFeature), "Feature");
   // t.throws(() => invariant.getType(null), /geojson is required/, 'geojson is required');
   t.end();
 });


### PR DESCRIPTION
Ran into some issues when [typing @turf/line-split](https://github.com/Turfjs/turf/pull/2985) that warranted a small cleanup PR.

- Make type inference work a lot better
- Simplify logic
- Add a test for Feature<null> behavior, which is surprising and I don't like it
- Remove an unused parameter

I'm kind of unsure how much of a breaking change this is. Removing a parameter that was never used breaks the signature, but also I'm not sure how anyone would've been passing in anything for this parameter that appears to have been unused since we started shipping types.

We're also narrowing the return type from `string` to a specific string (or string union, depending on input). This could cause a new break with something like the (very contrived) snippet below:

```
let t = getType(pointFeature); // t is of type `"Point"` now, previously it would have been `string`
t = "foo"; // previously that's fine, but now it would error with "foo" isn't "Point"
```

Overall I think I'd push for merging this in 7.x, but happy for pushback there if others feel strongly against.