### PR TITLE
Specify release environment for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    environment: release
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
The @turf/turf 7.3.2 publish correctly did the trusted publish step 🎉 .

This forces releases to use the `release` GitHub environment for release jobs. `release` environment is currently a basic unrestricted environment at the moment. I'd rather have this specified now, rather than going back to add it later on 115 packages. That lets us restrict `release` further later without needing to go back through NPM for all 115 packages 😩 .