### PR TITLE
Remove deprecated properties `multiFeatureIndex`, `index`, `location` and `dist` from nearest-point-on-line

### DIFF
--- a/packages/turf-nearest-point-on-line/README.md
+++ b/packages/turf-nearest-point-on-line/README.md
@@ -10,18 +10,13 @@ If any of the segments in the input line string are antipodal and therefore
 have an undefined arc, this function will instead return that the point lies
 on the line.
 
-⚠️ We have begun the process of migrating to different return properties for
-this function. The new properties we recommend using as of v7.4 are:
+⚠️ We have migrated to different return properties for this function in v8.0.
+To upgrade from v7.x, please make the following changes in your code:
 
-*   lineStringIndex - point was found on the nth LineString of an input MultiLineString. Previously `multiFeatureIndex`
-*   segmentIndex - point was found on the nth segment of the above LineString. Previously `index`
-*   totalDistance - distance from the start of the overall MultiLineString. Previously `location`
-*   lineDistance - distance from the start of the relevant LineString
-*   segmentDistance - distance from the start of the relevant segment
-*   pointDistance - distance between found point is from input reference point. Previously `dist`
-
-multiFeatureIndex, index, location, and dist continue to work as previously
-until at least the next major release.
+*   use `lineStringIndex` instead of `multiFeatureIndex`
+*   use `segmentIndex` instead of `index`
+*   use `totalDistance` instead of `location`
+*   use `pointDistance` instead of `dist`
 
 ### Parameters
 

--- a/packages/turf-nearest-point-on-line/index.ts
+++ b/packages/turf-nearest-point-on-line/index.ts
@@ -17,17 +17,12 @@ import { getCoord, getCoords } from "@turf/invariant";
  * have an undefined arc, this function will instead return that the point lies
  * on the line.
  *
- * ⚠️ We have begun the process of migrating to different return properties for
- * this function. The new properties we recommend using as of v7.4 are:
- * - lineStringIndex - point was found on the nth LineString of an input MultiLineString. Previously `multiFeatureIndex`
- * - segmentIndex - point was found on the nth segment of the above LineString. Previously `index`
- * - totalDistance - distance from the start of the overall MultiLineString. Previously `location`
- * - lineDistance - distance from the start of the relevant LineString
- * - segmentDistance - distance from the start of the relevant segment
- * - pointDistance - distance between found point is from input reference point. Previously `dist`
- *
- * multiFeatureIndex, index, location, and dist continue to work as previously
- * until at least the next major release.
+ * ⚠️ We have migrated to different return properties for this function in v8.0.
+ * To upgrade from v7.x, please make the following changes in your code:
+ * - use `lineStringIndex` instead of `multiFeatureIndex`
+ * - use `segmentIndex` instead of `index`
+ * - use `totalDistance` instead of `location`
+ * - use `pointDistance` instead of `dist`
  *
  * @function
  * @param {Geometry|Feature<LineString|MultiLineString>} lines Lines to snap to
@@ -65,16 +60,6 @@ function nearestPointOnLine<G extends LineString | MultiLineString>(
     lineDistance: number;
     segmentDistance: number;
     pointDistance: number;
-    // deprecated properties START
-    /** @deprecated use `lineStringIndex` instead */
-    multiFeatureIndex: number;
-    /** @deprecated use `segmentIndex` instead */
-    index: number;
-    /** @deprecated use `totalDistance` instead */
-    location: number;
-    /** @deprecated use `pointDistance` instead */
-    dist: number;
-    // deprecated properties END
     [key: string]: any;
   }
 > {
@@ -91,12 +76,6 @@ function nearestPointOnLine<G extends LineString | MultiLineString>(
     lineDistance: -1,
     segmentDistance: -1,
     pointDistance: Infinity,
-    // deprecated properties START
-    multiFeatureIndex: -1,
-    index: -1,
-    location: -1,
-    dist: Infinity,
-    // deprecated properties END
   });
 
   let totalDistance = 0.0;
@@ -156,21 +135,7 @@ function nearestPointOnLine<G extends LineString | MultiLineString>(
             lineDistance: lineDistance + segmentDistance,
             segmentDistance: segmentDistance,
             pointDistance: pointDistance,
-            // deprecated properties START
-            multiFeatureIndex: -1,
-            index: -1,
-            location: -1,
-            dist: Infinity,
-            // deprecated properties END
           });
-          closestPt.properties = {
-            ...closestPt.properties,
-            multiFeatureIndex: closestPt.properties.lineStringIndex,
-            index: closestPt.properties.segmentIndex,
-            location: closestPt.properties.totalDistance,
-            dist: closestPt.properties.pointDistance,
-            // deprecated properties END
-          };
         }
 
         // update totalDistance and lineDistance

--- a/packages/turf-nearest-point-on-line/test.ts
+++ b/packages/turf-nearest-point-on-line/test.ts
@@ -46,10 +46,6 @@ test("turf-nearest-point-on-line", (t) => {
       6
     );
     onLine.properties.pointDistance = round(onLine.properties.pointDistance, 6);
-    // deprecated properties START
-    onLine.properties.dist = round(onLine.properties.dist, 6);
-    onLine.properties.location = round(onLine.properties.location, 6);
-    // deprecated properties END
     onLine.properties["marker-color"] = "#F0F";
     const between = lineString(
       [onLine.geometry.coordinates, point.geometry.coordinates],

--- a/packages/turf-nearest-point-on-line/test/out/line-northern-latitude-#344.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/line-northern-latitude-#344.geojson
@@ -45,10 +45,6 @@
         "lineDistance": 19.748879,
         "segmentDistance": 1.771897,
         "pointDistance": 5.959562,
-        "dist": 5.959562,
-        "multiFeatureIndex": 0,
-        "location": 19.748879,
-        "index": 1,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/test/out/line1.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/line1.geojson
@@ -45,10 +45,6 @@
         "lineDistance": 22.137494,
         "segmentDistance": 3.445915,
         "pointDistance": 2.556271,
-        "dist": 2.556271,
-        "multiFeatureIndex": 0,
-        "location": 22.137494,
-        "index": 1,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/test/out/multiLine1.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/multiLine1.geojson
@@ -73,10 +73,6 @@
         "lineDistance": 4800.716022,
         "segmentDistance": 173.221741,
         "pointDistance": 114.725451,
-        "dist": 114.725451,
-        "multiFeatureIndex": 1,
-        "location": 9479.011715,
-        "index": 21,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/test/out/multiLine2.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/multiLine2.geojson
@@ -54,10 +54,6 @@
         "lineDistance": 0,
         "segmentDistance": 0,
         "pointDistance": 390.942725,
-        "dist": 390.942725,
-        "multiFeatureIndex": 1,
-        "location": 1656.139708,
-        "index": 0,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/test/out/multiLine3.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/multiLine3.geojson
@@ -63,10 +63,6 @@
         "lineDistance": 214.735285,
         "segmentDistance": 214.735285,
         "pointDistance": 121.937841,
-        "dist": 121.937841,
-        "multiFeatureIndex": 0,
-        "location": 214.735285,
-        "index": 0,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/test/out/route1.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/route1.geojson
@@ -4798,10 +4798,6 @@
         "lineDistance": 183.46844,
         "segmentDistance": 0.044741,
         "pointDistance": 7.876557,
-        "dist": 7.876557,
-        "multiFeatureIndex": 0,
-        "location": 183.46844,
-        "index": 3104,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/test/out/route2.geojson
+++ b/packages/turf-nearest-point-on-line/test/out/route2.geojson
@@ -3802,10 +3802,6 @@
         "lineDistance": 303.639629,
         "segmentDistance": 0.867249,
         "pointDistance": 19.22738,
-        "dist": 19.22738,
-        "multiFeatureIndex": 0,
-        "location": 303.639629,
-        "index": 1185,
         "marker-color": "#F0F"
       },
       "geometry": {

--- a/packages/turf-nearest-point-on-line/types.ts
+++ b/packages/turf-nearest-point-on-line/types.ts
@@ -25,9 +25,3 @@ nearestPointOnLine(line, pt, { units: "miles" });
 // Output can be used as Input
 const output = nearestPointOnLine(line, pt);
 nearestPointOnLine(line, output);
-
-// Extra properties being generated from module
-output.properties.dist;
-output.properties.multiFeatureIndex;
-output.properties.index;
-output.properties.location;


### PR DESCRIPTION
This PR is a follow-up to #2867 and removes the deprecated properties `multiFeatureIndex`, `index`, `location` and `dist` from the points returned by the nearestPointOnLine function.

As previously agreed, the properties are being removed in favor of the new ones with clearer names:

- `multiFeatureIndex` -> `lineStringIndex`
- `index` -> `segmentIndex`
- `location` -> `totalDistance`
- `dist` -> `pointDistance`

This is, of course, a breaking change. Therefore, this PR should only be merged when the next major release is due.

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [x] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
