### PR TITLE
fix(polygonize): deduplicate segments in planar graph

### DIFF
--- a/packages/turf-polygonize/lib/Graph.ts
+++ b/packages/turf-polygonize/lib/Graph.ts
@@ -44,6 +44,7 @@ function validateGeoJson(geoJson: AllGeoJSON) {
 class Graph {
   private nodes: { [id: string]: Node };
   private edges: Edge[];
+  private edgeIds: { [id: string]: true };
 
   /**
    * Creates a graph from a GeoJSON.
@@ -102,15 +103,21 @@ class Graph {
    * @param {Node} to - Node which ends the Edge
    */
   addEdge(from: Node, to: Node) {
-    const edge = new Edge(from, to),
-      symetricEdge = edge.getSymetric();
+    const edgeId = `${from.id}->${to.id}`;
+    if (this.edgeIds[edgeId]) return;
 
+    const edge = new Edge(from, to);
+    const symetricEdge = edge.getSymetric();
+
+    this.edgeIds[`${edge.from.id}->${edge.to.id}`] = true;
+    this.edgeIds[`${symetricEdge.from.id}->${symetricEdge.to.id}`] = true;
     this.edges.push(edge);
     this.edges.push(symetricEdge);
   }
 
   constructor() {
     this.edges = []; //< {Edge[]} dirEdges
+    this.edgeIds = {};
 
     // The key is the `id` of the Node (ie: coordinates.join(','))
     this.nodes = {};
@@ -348,6 +355,7 @@ class Graph {
   removeEdge(edge: Edge) {
     this.edges = this.edges.filter((e) => !e.isEqual(edge));
     edge.deleteEdge();
+    delete this.edgeIds[`${edge.from.id}->${edge.to.id}`];
   }
 }
 

--- a/packages/turf-polygonize/test.ts
+++ b/packages/turf-polygonize/test.ts
@@ -81,6 +81,40 @@ test("turf-polygonize -- input mutation", (t) => {
   t.end();
 });
 
+test("turf-polygonize -- duplicate segment", (t) => {
+  const lines = featureCollection([
+    lineString([
+      [0, 0],
+      [1, 0],
+    ]),
+    lineString([
+      [1, 0],
+      [1, 1],
+    ]),
+    lineString([
+      [1, 1],
+      [0, 1],
+    ]),
+    lineString([
+      [0, 1],
+      [0, 0],
+    ]),
+    // Duplicate boundary segment should not prevent polygonization.
+    lineString([
+      [0, 0],
+      [1, 0],
+    ]),
+  ]);
+
+  const polygonized = polygonize(lines);
+  t.equal(
+    polygonized.features.length,
+    1,
+    "returns one polygon for closed ring with duplicate edge"
+  );
+  t.end();
+});
+
 function colorize(feature, color = "#F00", width = 6) {
   feature.properties["fill"] = color;
   feature.properties["fill-opacity"] = 0.3;


### PR DESCRIPTION
- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [ ] Heads up if this is a breaking change.
- [ ] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [ ] Inclusion of your details in the `contributors` field of `package.json` - you've earned it!
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).

## Summary

When input geometry contains duplicate line segments (the same segment appearing more than once), `@turf/polygonize` silently returns 0 polygons instead of the expected result.

**Root cause:** `Graph.addEdge()` creates a new pair of directed edges for every segment, including duplicates. The duplicate edges corrupt the planar graph topology, causing the edge-ring traversal to fail.

**Fix:** Track edge IDs in `Graph` and skip segments that have already been added. This is a one-line guard in `addEdge()` plus cleanup in `removeEdge()`.

**Test:** Added a regression test with a simple square whose closing segment is duplicated — confirms polygonize now correctly returns 1 polygon.

This is not a breaking change. Inputs that previously worked continue to produce the same output. Only the failure case (duplicate segments -> 0 polygons) is fixed.
