### PR TITLE
Reverted performance related improvement to clusters-dbscan that broke builds

### DIFF
--- a/packages/turf-clusters-dbscan/index.ts
+++ b/packages/turf-clusters-dbscan/index.ts
@@ -1,8 +1,8 @@
 import { GeoJsonProperties, FeatureCollection, Point } from "geojson";
 import { clone } from "@turf/clone";
-import { Units } from "@turf/helpers";
-import KDBush from "kdbush";
-import * as geokdbush from "geokdbush";
+import { distance } from "@turf/distance";
+import { degreesToRadians, lengthToDegrees, Units } from "@turf/helpers";
+import RBush from "rbush";
 
 /**
  * Point classification within the cluster.
@@ -80,13 +80,11 @@ function clustersDbscan(
   // Defaults
   const minPoints = options.minPoints || 3;
 
+  // Calculate the distance in degrees for region queries
+  const latDistanceInDegrees = lengthToDegrees(maxDistance, options.units);
+
   // Create a spatial index
-  const kdIndex = new KDBush(points.features.length);
-  // Index each point for spatial queries
-  for (const point of points.features) {
-    kdIndex.add(point.geometry.coordinates[0], point.geometry.coordinates[1]);
-  }
-  kdIndex.finish();
+  var tree = new RBush(points.features.length);
 
   // Keeps track of whether a point has been visited or not.
   var visited = points.features.map((_) => false);
@@ -100,22 +98,54 @@ function clustersDbscan(
   // Keeps track of the clusterId for each point
   var clusterIds: number[] = points.features.map((_) => -1);
 
+  // Index each point for spatial queries
+  tree.load(
+    points.features.map((point, index) => {
+      var [x, y] = point.geometry.coordinates;
+      return {
+        minX: x,
+        minY: y,
+        maxX: x,
+        maxY: y,
+        index: index,
+      } as IndexedPoint;
+    })
+  );
+
   // Function to find neighbors of a point within a given distance
   const regionQuery = (index: number): IndexedPoint[] => {
     const point = points.features[index];
     const [x, y] = point.geometry.coordinates;
 
-    return (
-      geokdbush
-        // @ts-expect-error 2345 until https://github.com/mourner/geokdbush/issues/20 is resolved
-        .around<number>(kdIndex, x, y, undefined, maxDistance)
-        .map((id) => ({
-          minX: points.features[id].geometry.coordinates[0],
-          minY: points.features[id].geometry.coordinates[1],
-          maxX: points.features[id].geometry.coordinates[0],
-          maxY: points.features[id].geometry.coordinates[1],
-          index: id,
-        }))
+    const minY = Math.max(y - latDistanceInDegrees, -90.0);
+    const maxY = Math.min(y + latDistanceInDegrees, 90.0);
+
+    const lonDistanceInDegrees = (function () {
+      // Handle the case where the bounding box crosses the poles
+      if (minY < 0 && maxY > 0) {
+        return latDistanceInDegrees;
+      }
+      if (Math.abs(minY) < Math.abs(maxY)) {
+        return latDistanceInDegrees / Math.cos(degreesToRadians(maxY));
+      } else {
+        return latDistanceInDegrees / Math.cos(degreesToRadians(minY));
+      }
+    })();
+
+    const minX = Math.max(x - lonDistanceInDegrees, -360.0);
+    const maxX = Math.min(x + lonDistanceInDegrees, 360.0);
+
+    // Calculate the bounding box for the region query
+    const bbox = { minX, minY, maxX, maxY };
+    return (tree.search(bbox) as ReadonlyArray<IndexedPoint>).filter(
+      (neighbor) => {
+        const neighborIndex = neighbor.index;
+        const neighborPoint = points.features[neighborIndex];
+        const distanceInKm = distance(point, neighborPoint, {
+          units: "kilometers",
+        });
+        return distanceInKm <= maxDistance;
+      }
     );
   };
 

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -62,6 +62,7 @@
     "@turf/centroid": "workspace:*",
     "@turf/clusters": "workspace:*",
     "@types/benchmark": "^2.1.5",
+    "@types/rbush": "^3.0.4",
     "@types/tape": "^5.8.1",
     "benchmark": "^2.1.4",
     "chromatism": "^3.0.0",
@@ -75,12 +76,11 @@
   },
   "dependencies": {
     "@turf/clone": "workspace:*",
+    "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
     "@types/geojson": "^7946.0.10",
-    "@types/geokdbush": "^1.1.5",
-    "geokdbush": "^2.0.1",
-    "kdbush": "^4.0.2",
+    "rbush": "^3.0.1",
     "tslib": "^2.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2060,6 +2060,9 @@ importers:
       '@turf/clone':
         specifier: workspace:*
         version: link:../turf-clone
+      '@turf/distance':
+        specifier: workspace:*
+        version: link:../turf-distance
       '@turf/helpers':
         specifier: workspace:*
         version: link:../turf-helpers
@@ -2069,15 +2072,9 @@ importers:
       '@types/geojson':
         specifier: ^7946.0.10
         version: 7946.0.14
-      '@types/geokdbush':
-        specifier: ^1.1.5
-        version: 1.1.5
-      geokdbush:
-        specifier: ^2.0.1
-        version: 2.0.1
-      kdbush:
-        specifier: ^4.0.2
-        version: 4.0.2
+      rbush:
+        specifier: ^3.0.1
+        version: 3.0.1
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -2091,6 +2088,9 @@ importers:
       '@types/benchmark':
         specifier: ^2.1.5
         version: 2.1.5
+      '@types/rbush':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/tape':
         specifier: ^5.8.1
         version: 5.8.1
@@ -7711,17 +7711,11 @@ packages:
   '@types/geojson@7946.0.14':
     resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
 
-  '@types/geokdbush@1.1.5':
-    resolution: {integrity: sha512-jIsYnXY+RQ/YCyBqeEHxYN9mh+7PqKJUJUp84wLfZ7T2kqyVPNaXwZuvf1A2uQUkrvVqEbsG94ff8jH32AlLvA==}
-
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/kdbush@1.0.7':
-    resolution: {integrity: sha512-QM5iB8m/0mnGOjUKshErIZQ0LseyTieRSYc3yaOpmrRM0xbWiOuJUWlduJx+TPNK7/VFMWphUGwx3nus7eT1Wg==}
 
   '@types/kdbush@3.0.5':
     resolution: {integrity: sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==}
@@ -8993,9 +8987,6 @@ packages:
   geojson-polygon-self-intersections@1.2.1:
     resolution: {integrity: sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==}
 
-  geokdbush@2.0.1:
-    resolution: {integrity: sha512-0M8so1Qx6+jJ1xpirpCNrgUsWAzIcQ3LrLmh0KJPBYI3gH7vy70nY5zEEjSp9Tn0nBt6Q2Fh922oL08lfib4Zg==}
-
   get-amd-module-type@6.0.1:
     resolution: {integrity: sha512-MtjsmYiCXcYDDrGqtNbeIYdAl85n+5mSv2r3FbzER/YV3ZILw4HNNIw34HuV5pyl0jzs6GFYU1VHVEefhgcNHQ==}
     engines: {node: '>=18'}
@@ -9703,9 +9694,6 @@ packages:
 
   just-diff@6.0.2:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
-
-  kdbush@4.0.2:
-    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -13489,17 +13477,11 @@ snapshots:
 
   '@types/geojson@7946.0.14': {}
 
-  '@types/geokdbush@1.1.5':
-    dependencies:
-      '@types/kdbush': 1.0.7
-
   '@types/hast@2.3.10':
     dependencies:
       '@types/unist': 2.0.10
 
   '@types/json-schema@7.0.15': {}
-
-  '@types/kdbush@1.0.7': {}
 
   '@types/kdbush@3.0.5': {}
 
@@ -14994,10 +14976,6 @@ snapshots:
     dependencies:
       rbush: 2.0.2
 
-  geokdbush@2.0.1:
-    dependencies:
-      tinyqueue: 2.0.3
-
   get-amd-module-type@6.0.1:
     dependencies:
       ast-module-types: 6.0.1
@@ -15691,8 +15669,6 @@ snapshots:
   just-diff-apply@5.5.0: {}
 
   just-diff@6.0.2: {}
-
-  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
Reverted performance related improvement that was breaking builds. While faster, kdbush isn't released with a CJS variant and that caused dependency problems for users. Removes kdbush dependency and rolls back to using CJS compatible rbush 3.0.1.

Reverts #2885

Resolves #3018 

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [ ] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
