### PR TITLE
Publish without NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,21 +36,14 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4.3.0
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
-
-      - run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test
 
       - name: run publish
-        run: lerna publish from-package --ignore-scripts true --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --no-git-checks --provenance --access public
 
       - name: Create Github Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # 2.2.1


### PR DESCRIPTION
I thought this was done correctly before, but we actually just quietly used a token last time we published.

Skip the whoami step entirely, I'm not sure that will work with oauth publishing.
Move from Lerna to pnpm native publishing, just in case Lerna did any kind of access checks. Also one less Lerna dependency.