### PR TITLE
Move to pnpm catalogs

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -238,11 +238,11 @@ export default {
     requireDependency({
       options: {
         devDependencies: {
-          benchmark: "^2.1.4",
+          benchmark: "catalog:",
           glob: REMOVE,
-          tape: "^5.9.0",
-          tsup: "^8.4.0",
-          tsx: "^4.19.4",
+          tape: "catalog:",
+          tsup: "catalog:",
+          tsx: "catalog:",
         },
       },
       includePackages: [...TS_PACKAGES, ...JS_PACKAGES],
@@ -251,12 +251,12 @@ export default {
     requireDependency({
       options: {
         dependencies: {
-          tslib: "^2.8.1",
+          tslib: "catalog:",
         },
         devDependencies: {
-          "@types/benchmark": "^2.1.5",
-          "@types/tape": "^5.8.1",
-          typescript: "^5.8.3",
+          "@types/benchmark": "catalog:",
+          "@types/tape": "catalog:",
+          typescript: "catalog:",
         },
       },
       includePackages: TS_PACKAGES,
@@ -265,7 +265,7 @@ export default {
     requireDependency({
       options: {
         devDependencies: {
-          tstyche: "^6.2.0",
+          tstyche: "catalog:",
         },
       },
       includePackages: TSTYCHE_PACKAGES,
@@ -274,7 +274,7 @@ export default {
     requireDependency({
       options: {
         dependencies: {
-          "@types/geojson": "^7946.0.10",
+          "@types/geojson": "catalog:",
         },
       },
       includePackages: [MAIN_PACKAGE, ...TS_PACKAGES, ...JS_PACKAGES],

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -51,14 +51,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bearing": "workspace:*",
@@ -66,7 +66,7 @@
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -54,14 +54,14 @@
     "@turf/distance": "workspace:*",
     "@turf/sector": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -69,7 +69,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/rhumb-bearing": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -50,20 +50,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -57,20 +57,20 @@
   },
   "devDependencies": {
     "@turf/bbox": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -51,17 +51,17 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -52,18 +52,18 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -49,19 +49,19 @@
   },
   "devDependencies": {
     "@turf/destination": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -51,20 +51,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -55,19 +55,19 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -54,19 +54,19 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -55,16 +55,16 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-jsts": "*",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
@@ -73,7 +73,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/line-split": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -55,15 +55,15 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-equal": "workspace:*",
@@ -72,7 +72,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/line-intersect": "workspace:*",
     "@turf/polygon-to-line": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -54,15 +54,15 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",
@@ -70,7 +70,7 @@
     "@turf/line-intersect": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/polygon-to-line": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -57,22 +57,22 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/clean-coords": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "geojson-equality-ts": "^1.0.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -55,21 +55,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-disjoint": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -56,15 +56,15 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
@@ -72,8 +72,8 @@
     "@turf/line-intersect": "workspace:*",
     "@turf/line-overlap": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "geojson-equality-ts": "^1.0.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -53,14 +53,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -68,7 +68,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/line-segment": "workspace:*",
     "@turf/rhumb-bearing": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -52,19 +52,19 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "point-in-polygon-hao": "^1.1.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -51,20 +51,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -56,23 +56,23 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-jsts": "*",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",
     "@turf/boolean-point-on-line": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -54,16 +54,16 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-jsts": "*",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
@@ -75,8 +75,8 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/line-intersect": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "geojson-polygon-self-intersections": "^1.2.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -57,16 +57,16 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "boolean-jsts": "*",
     "boolean-shapely": "*",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
@@ -75,7 +75,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/line-split": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -60,16 +60,16 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/d3-geo": "^3.1.0",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tstyche": "^6.2.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tstyche": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -79,8 +79,8 @@
     "@turf/jsts": "^2.7.1",
     "@turf/meta": "workspace:*",
     "@turf/projection": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "d3-geo": "^3.1.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -59,21 +59,21 @@
   "devDependencies": {
     "@turf/center": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -55,14 +55,14 @@
     "@turf/center-of-mass": "workspace:*",
     "@turf/random": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -49,14 +49,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -65,7 +65,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -55,20 +55,20 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -51,20 +51,20 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -55,20 +55,20 @@
   "devDependencies": {
     "@placemarkio/check-geojson": "^0.1.12",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/destination": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -55,22 +55,22 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "geojson-equality-ts": "^1.0.2",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/boolean-point-on-line": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -53,17 +53,17 @@
   },
   "devDependencies": {
     "@turf/meta": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -61,17 +61,17 @@
   "devDependencies": {
     "@turf/centroid": "workspace:*",
     "@turf/clusters": "workspace:*",
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/rbush": "^3.0.4",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "chromatism": "^3.0.0",
     "concaveman": "^1.2.1",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -79,8 +79,8 @@
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "rbush": "^3.0.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -61,17 +61,17 @@
     "@turf/centroid": "workspace:*",
     "@turf/clusters": "workspace:*",
     "@turf/random": "workspace:*",
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/skmeans": "^0.11.7",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "chromatism": "^3.0.0",
     "concaveman": "^1.2.1",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -79,8 +79,8 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "skmeans": "0.9.7",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -55,18 +55,18 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -55,21 +55,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/rbush": "^3.0.4",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
     "@turf/boolean-point-in-polygon": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "rbush": "^3.0.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -51,18 +51,18 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -61,16 +61,16 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
     "@types/topojson-client": "3.1.3",
     "@types/topojson-server": "3.0.3",
-    "benchmark": "^2.1.4",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -80,9 +80,9 @@
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/tin": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "topojson-client": "3.x",
     "topojson-server": "3.x",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -48,22 +48,22 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/concaveman": "^1.1.6",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "concaveman": "^1.2.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -56,20 +56,20 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -48,21 +48,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "polyclip-ts": "^0.16.8",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -51,14 +51,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -69,7 +69,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/length": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -51,14 +51,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -66,8 +66,8 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "polyclip-ts": "^0.16.8",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -51,14 +51,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -66,7 +66,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -50,20 +50,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -58,14 +58,14 @@
     "@turf/circle": "workspace:*",
     "@turf/intersect": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -74,7 +74,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/transform-rotate": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -51,20 +51,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
     "@turf/bbox-polygon": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -50,20 +50,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -56,20 +56,20 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -51,21 +51,21 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-geojson-rbush/package.json
+++ b/packages/turf-geojson-rbush/package.json
@@ -59,23 +59,23 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/random": "workspace:*",
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/rbush": "^3.0.4",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "rbush": "^3.0.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -59,21 +59,21 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "arc": "^0.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -57,16 +57,16 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -63,14 +63,14 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -78,7 +78,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/intersect": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -54,15 +54,15 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "chromatism": "^3.0.0",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -77,7 +77,7 @@
     "@turf/point-grid": "workspace:*",
     "@turf/square-grid": "workspace:*",
     "@turf/triangle-grid": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -50,21 +50,21 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "polyclip-ts": "^0.16.8",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -54,17 +54,17 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -62,14 +62,14 @@
     "@turf/random": "workspace:*",
     "@turf/rhumb-destination": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -80,7 +80,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -62,14 +62,14 @@
     "@turf/random": "workspace:*",
     "@turf/rhumb-destination": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -77,7 +77,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -51,19 +51,19 @@
   },
   "devDependencies": {
     "@turf/meta": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -56,21 +56,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -50,21 +50,21 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/circle": "workspace:*",
     "@turf/destination": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -59,14 +59,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -74,7 +74,7 @@
     "@turf/length": "workspace:*",
     "@turf/line-slice-along": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -56,20 +56,20 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "sweepline-intersections": "^1.5.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -57,22 +57,22 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tstyche": "^6.2.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tstyche": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -55,14 +55,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -73,8 +73,8 @@
     "@turf/line-segment": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/nearest-point-on-line": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "fast-deep-equal": "^3.1.3",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -49,21 +49,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -51,21 +51,21 @@
   "devDependencies": {
     "@turf/along": "workspace:*",
     "@turf/length": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bearing": "workspace:*",
     "@turf/destination": "workspace:*",
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -54,21 +54,21 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/nearest-point-on-line": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -54,14 +54,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -74,7 +74,7 @@
     "@turf/meta": "workspace:*",
     "@turf/nearest-point-on-line": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -55,14 +55,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -70,7 +70,7 @@
     "@turf/clone": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -50,22 +50,22 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
     "mkdirp": "^3.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "polyclip-ts": "^0.16.8",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -73,17 +73,17 @@
   },
   "devDependencies": {
     "@turf/random": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -51,20 +51,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/bearing": "workspace:*",
     "@turf/destination": "workspace:*",
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -51,21 +51,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/distance-weight": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -52,14 +52,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/nearest-point": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -54,14 +54,14 @@
     "@turf/along": "workspace:*",
     "@turf/length": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -69,7 +69,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -57,15 +57,15 @@
   "devDependencies": {
     "@turf/circle": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/object-assign": "^4.0.33",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/point-to-line-distance": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -53,14 +53,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -68,7 +68,7 @@
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -52,18 +52,18 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -57,14 +57,14 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -72,7 +72,7 @@
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -54,13 +54,13 @@
   "devDependencies": {
     "@turf/meta": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -69,7 +69,7 @@
     "@turf/explode": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/nearest-point": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -54,14 +54,14 @@
   },
   "devDependencies": {
     "@turf/circle": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -74,7 +74,7 @@
     "@turf/projection": "workspace:*",
     "@turf/rhumb-bearing": "workspace:*",
     "@turf/rhumb-distance": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-point-to-polygon-distance/package.json
+++ b/packages/turf-point-to-polygon-distance/package.json
@@ -54,14 +54,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "@turf/meta": "workspace:*",
     "@turf/point-to-line-distance": "workspace:*",
     "@turf/polygon-to-line": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -52,19 +52,19 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -53,20 +53,20 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -56,14 +56,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/nearest-point": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -51,20 +51,20 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -55,14 +55,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -64,22 +64,22 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
     "proj4": "^2.9.2",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -52,14 +52,14 @@
   },
   "devDependencies": {
     "@turf/nearest-neighbor-analysis": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -72,7 +72,7 @@
     "@turf/point-grid": "workspace:*",
     "@turf/random": "workspace:*",
     "@turf/square-grid": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -48,17 +48,17 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -56,21 +56,21 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/boolean-intersects": "workspace:*",
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -57,14 +57,14 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -57,19 +57,19 @@
   },
   "devDependencies": {
     "@turf/destination": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -61,20 +61,20 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -59,20 +59,20 @@
   },
   "devDependencies": {
     "@turf/distance": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -50,17 +50,17 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -50,14 +50,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -66,7 +66,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/line-arc": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -56,14 +56,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -76,7 +76,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/transform-scale": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -58,14 +58,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "@turf/clone": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -53,19 +53,19 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/rectangle-grid": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -50,18 +50,18 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -56,14 +56,14 @@
   "devDependencies": {
     "@turf/random": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/points-within-polygon": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -54,21 +54,21 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",
     "@turf/clone": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -59,18 +59,18 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "earcut": "^2.2.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -50,17 +50,17 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -56,14 +56,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -75,7 +75,7 @@
     "@turf/rhumb-bearing": "workspace:*",
     "@turf/rhumb-destination": "workspace:*",
     "@turf/rhumb-distance": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -62,14 +62,14 @@
     "@turf/bbox-polygon": "workspace:*",
     "@turf/hex-grid": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -83,7 +83,7 @@
     "@turf/rhumb-bearing": "workspace:*",
     "@turf/rhumb-destination": "workspace:*",
     "@turf/rhumb-distance": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -58,14 +58,14 @@
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -74,7 +74,7 @@
     "@turf/invariant": "workspace:*",
     "@turf/meta": "workspace:*",
     "@turf/rhumb-destination": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -55,21 +55,21 @@
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",
     "@turf/truncate": "workspace:*",
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/intersect": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -54,20 +54,20 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
-    "tslib": "^2.8.1"
+    "@types/geojson": "catalog:",
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -49,21 +49,21 @@
     "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "polyclip-ts": "^0.16.8",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -53,15 +53,15 @@
   },
   "devDependencies": {
     "@turf/kinks": "workspace:*",
-    "@types/benchmark": "^2.1.5",
+    "@types/benchmark": "catalog:",
     "@types/rbush": "^3.0.4",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -69,8 +69,8 @@
     "@turf/boolean-point-in-polygon": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "rbush": "^3.0.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -57,14 +57,14 @@
     "test:tape": "tsx test.ts"
   },
   "devDependencies": {
-    "@types/benchmark": "^2.1.5",
-    "@types/tape": "^5.8.1",
-    "benchmark": "^2.1.4",
+    "@types/benchmark": "catalog:",
+    "@types/tape": "catalog:",
+    "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
-    "tape": "^5.9.0",
-    "tsup": "^8.4.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "tape": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
     "write-json-file": "^6.0.0"
   },
   "dependencies": {
@@ -72,8 +72,8 @@
     "@turf/helpers": "workspace:*",
     "@turf/invariant": "workspace:*",
     "@types/d3-voronoi": "^1.1.12",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "d3-voronoi": "1.1.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   }
 }

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -206,7 +206,7 @@
     "@turf/union": "workspace:*",
     "@turf/unkink-polygon": "workspace:*",
     "@turf/voronoi": "workspace:*",
-    "@types/geojson": "^7946.0.10",
+    "@types/geojson": "catalog:",
     "@types/kdbush": "^3.0.5",
     "tslib": "^2.8.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,39 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/benchmark':
+      specifier: ^2.1.5
+      version: 2.1.5
+    '@types/geojson':
+      specifier: ^7946.0.10
+      version: 7946.0.14
+    '@types/tape':
+      specifier: ^5.8.1
+      version: 5.8.1
+    benchmark:
+      specifier: ^2.1.4
+      version: 2.1.4
+    tape:
+      specifier: ^5.9.0
+      version: 5.9.0
+    tslib:
+      specifier: ^2.8.1
+      version: 2.8.1
+    tstyche:
+      specifier: ^6.2.0
+      version: 6.2.0
+    tsup:
+      specifier: ^8.4.0
+      version: 8.4.0
+    tsx:
+      specifier: ^4.19.4
+      version: 4.19.4
+    typescript:
+      specifier: ^5.8.3
+      version: 5.8.3
+
 importers:
 
   .:
@@ -447,7 +480,7 @@ importers:
         specifier: workspace:*
         version: link:../turf-voronoi
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       '@types/kdbush':
         specifier: ^3.0.5
@@ -523,35 +556,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-angle:
@@ -569,10 +602,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-rhumb-bearing
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/distance':
@@ -585,28 +618,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -621,35 +654,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -664,32 +697,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-bbox-clip:
@@ -701,38 +734,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox':
         specifier: workspace:*
         version: link:../turf-bbox
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -744,32 +777,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-bearing:
@@ -781,35 +814,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/destination':
         specifier: workspace:*
         version: link:../turf-destination
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -824,35 +857,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -867,35 +900,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-concave:
@@ -907,35 +940,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-contains:
@@ -959,20 +992,20 @@ importers:
         specifier: workspace:*
         version: link:../turf-line-split
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-jsts:
         specifier: '*'
@@ -984,16 +1017,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-crosses:
@@ -1017,20 +1050,20 @@ importers:
         specifier: workspace:*
         version: link:../turf-polygon-to-line
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-shapely:
         specifier: '*'
@@ -1039,16 +1072,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-disjoint:
@@ -1069,20 +1102,20 @@ importers:
         specifier: workspace:*
         version: link:../turf-polygon-to-line
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-shapely:
         specifier: '*'
@@ -1091,16 +1124,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-equal:
@@ -1115,23 +1148,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       geojson-equality-ts:
         specifier: ^1.0.2
         version: 1.0.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-shapely:
         specifier: '*'
@@ -1140,16 +1173,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-intersects:
@@ -1164,20 +1197,20 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-shapely:
         specifier: '*'
@@ -1186,16 +1219,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-overlap:
@@ -1216,23 +1249,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       geojson-equality-ts:
         specifier: ^1.0.2
         version: 1.0.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-shapely:
         specifier: '*'
@@ -1241,16 +1274,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-parallel:
@@ -1268,35 +1301,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-rhumb-bearing
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1311,35 +1344,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       point-in-polygon-hao:
         specifier: ^1.1.0
         version: 1.1.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-point-on-line:
@@ -1351,35 +1384,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1400,20 +1433,20 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-jsts:
         specifier: '*'
@@ -1425,16 +1458,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-valid:
@@ -1467,23 +1500,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-line-intersect
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       geojson-polygon-self-intersections:
         specifier: ^1.2.1
         version: 1.2.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-jsts:
         specifier: '*'
@@ -1495,16 +1528,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-boolean-within:
@@ -1528,20 +1561,20 @@ importers:
         specifier: workspace:*
         version: link:../turf-line-split
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       boolean-jsts:
         specifier: '*'
@@ -1553,16 +1586,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-buffer:
@@ -1586,47 +1619,47 @@ importers:
         specifier: workspace:*
         version: link:../turf-projection
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       d3-geo:
         specifier: ^3.1.1
         version: 3.1.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/d3-geo':
         specifier: ^3.1.0
         version: 3.1.0
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tstyche:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0(typescript@5.8.3)
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1641,10 +1674,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -1654,28 +1687,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1693,10 +1726,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/center':
@@ -1706,28 +1739,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1751,10 +1784,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/center':
@@ -1770,28 +1803,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1815,35 +1848,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1858,35 +1891,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1901,10 +1934,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@placemarkio/check-geojson':
@@ -1914,28 +1947,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1953,23 +1986,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       geojson-equality-ts:
         specifier: ^1.0.2
@@ -1978,16 +2011,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -1999,35 +2032,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/meta':
         specifier: workspace:*
         version: link:../turf-meta
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-clusters:
@@ -2039,32 +2072,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-clusters-dbscan:
@@ -2082,13 +2115,13 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/centroid':
@@ -2098,16 +2131,16 @@ importers:
         specifier: workspace:*
         version: link:../turf-clusters
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/rbush':
         specifier: ^3.0.4
         version: 3.0.4
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       chromatism:
         specifier: ^3.0.0
@@ -2119,16 +2152,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2149,13 +2182,13 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       skmeans:
         specifier: 0.9.7
         version: 0.9.7
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/centroid':
@@ -2168,16 +2201,16 @@ importers:
         specifier: workspace:*
         version: link:../turf-random
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/skmeans':
         specifier: ^0.11.7
         version: 0.11.7
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       chromatism:
         specifier: ^3.0.0
@@ -2189,16 +2222,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2216,38 +2249,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/rbush':
         specifier: ^3.0.4
         version: 3.0.4
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-combine:
@@ -2259,32 +2292,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-concave:
@@ -2308,7 +2341,7 @@ importers:
         specifier: workspace:*
         version: link:../turf-tin
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       topojson-client:
         specifier: 3.x
@@ -2317,14 +2350,14 @@ importers:
         specifier: 3.x
         version: 3.0.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       '@types/topojson-client':
         specifier: 3.1.3
@@ -2333,22 +2366,22 @@ importers:
         specifier: 3.0.3
         version: 3.0.3
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2363,41 +2396,41 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       concaveman:
         specifier: ^1.2.1
         version: 1.2.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/concaveman':
         specifier: ^1.1.6
         version: 1.1.6
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2412,38 +2445,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2458,38 +2491,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       polyclip-ts:
         specifier: ^0.16.8
         version: 0.16.8
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2519,35 +2552,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2568,38 +2601,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       polyclip-ts:
         specifier: ^0.16.8
         version: 0.16.8
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2614,35 +2647,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2663,35 +2696,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2715,10 +2748,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-transform-rotate
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@placemarkio/check-geojson':
@@ -2740,28 +2773,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2779,35 +2812,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-explode:
@@ -2819,35 +2852,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2862,35 +2895,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2908,35 +2941,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -2954,13 +2987,13 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -2970,31 +3003,31 @@ importers:
         specifier: workspace:*
         version: link:../turf-random
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/rbush':
         specifier: ^3.0.4
         version: 3.0.4
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3009,41 +3042,41 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       arc:
         specifier: ^0.2.0
         version: 0.2.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3052,32 +3085,32 @@ importers:
   packages/turf-helpers:
     dependencies:
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-hex-grid:
@@ -3095,10 +3128,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -3108,28 +3141,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3171,23 +3204,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-triangle-grid
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       chromatism:
         specifier: ^3.0.0
@@ -3196,16 +3229,16 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3220,38 +3253,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       polyclip-ts:
         specifier: ^0.16.8
         version: 0.16.8
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3263,32 +3296,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-isobands:
@@ -3315,10 +3348,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/envelope':
@@ -3337,28 +3370,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3379,10 +3412,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/envelope':
@@ -3401,28 +3434,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3434,38 +3467,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/meta':
         specifier: workspace:*
         version: link:../turf-meta
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3483,35 +3516,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3529,38 +3562,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3581,38 +3614,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3624,41 +3657,41 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       sweepline-intersections:
         specifier: ^1.5.0
         version: 1.5.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3676,41 +3709,41 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tstyche:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0(typescript@5.8.3)
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3740,38 +3773,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-nearest-point-on-line
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3789,35 +3822,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3835,38 +3868,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-nearest-point-on-line
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -3887,10 +3920,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/along':
@@ -3900,28 +3933,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-length
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-line-split:
@@ -3954,35 +3987,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4003,35 +4036,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4046,23 +4079,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       polyclip-ts:
         specifier: ^0.16.8
         version: 0.16.8
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
@@ -4071,16 +4104,16 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4092,35 +4125,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/random':
         specifier: workspace:*
         version: link:../turf-random
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-midpoint:
@@ -4138,32 +4171,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-moran-index:
@@ -4178,35 +4211,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4239,38 +4272,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-nearest-point
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4291,35 +4324,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4340,10 +4373,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/along':
@@ -4356,28 +4389,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4398,10 +4431,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-point-to-line-distance
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/circle':
@@ -4411,31 +4444,31 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/object-assign':
         specifier: ^4.0.33
         version: 4.0.33
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4450,32 +4483,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-point-grid:
@@ -4493,10 +4526,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -4506,28 +4539,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4551,10 +4584,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-nearest-point
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/meta':
@@ -4564,25 +4597,25 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4618,38 +4651,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/circle':
         specifier: workspace:*
         version: link:../turf-circle
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4676,35 +4709,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-polygon-to-line
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4722,32 +4755,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-polygon-smooth:
@@ -4759,35 +4792,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4814,35 +4847,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-nearest-point
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4857,35 +4890,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4909,35 +4942,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -4955,23 +4988,23 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
@@ -4980,16 +5013,16 @@ importers:
         specifier: ^2.9.2
         version: 2.9.2
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5025,38 +5058,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-square-grid
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/nearest-neighbor-analysis':
         specifier: workspace:*
         version: link:../turf-nearest-neighbor-analysis
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5068,32 +5101,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-rectangle-grid:
@@ -5108,10 +5141,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -5121,28 +5154,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5166,35 +5199,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5209,35 +5242,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/destination':
         specifier: workspace:*
         version: link:../turf-destination
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5252,38 +5285,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5298,38 +5331,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-invariant
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/distance':
         specifier: workspace:*
         version: link:../turf-distance
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5341,32 +5374,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-sector:
@@ -5387,38 +5420,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5454,38 +5487,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-transform-scale
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5506,38 +5539,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5552,32 +5585,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-square-grid:
@@ -5589,10 +5622,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-rectangle-grid
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -5602,25 +5635,25 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5647,10 +5680,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-points-within-polygon
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/random':
@@ -5660,28 +5693,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5702,35 +5735,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-tesselate:
@@ -5739,35 +5772,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       earcut:
         specifier: ^2.2.4
         version: 2.2.4
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-tin:
@@ -5776,32 +5809,32 @@ importers:
         specifier: workspace:*
         version: link:../turf-helpers
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   packages/turf-transform-rotate:
@@ -5831,38 +5864,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5901,10 +5934,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-rhumb-distance
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -5917,28 +5950,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -5962,38 +5995,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-rhumb-destination
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/truncate':
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -6011,10 +6044,10 @@ importers:
         specifier: workspace:*
         version: link:../turf-intersect
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/bbox-polygon':
@@ -6024,28 +6057,28 @@ importers:
         specifier: workspace:*
         version: link:../turf-truncate
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -6060,35 +6093,35 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -6103,38 +6136,38 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       polyclip-ts:
         specifier: ^0.16.8
         version: 0.16.8
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -6155,44 +6188,44 @@ importers:
         specifier: workspace:*
         version: link:../turf-meta
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       rbush:
         specifier: ^3.0.1
         version: 3.0.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@turf/kinks':
         specifier: workspace:*
         version: link:../turf-kinks
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/rbush':
         specifier: ^3.0.4
         version: 3.0.4
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0
@@ -6213,38 +6246,38 @@ importers:
         specifier: ^1.1.12
         version: 1.1.12
       '@types/geojson':
-        specifier: ^7946.0.10
+        specifier: 'catalog:'
         version: 7946.0.14
       d3-voronoi:
         specifier: 1.1.2
         version: 1.1.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@types/benchmark':
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5
       '@types/tape':
-        specifier: ^5.8.1
+        specifier: 'catalog:'
         version: 5.8.1
       benchmark:
-        specifier: ^2.1.4
+        specifier: 'catalog:'
         version: 2.1.4
       load-json-file:
         specifier: ^7.0.1
         version: 7.0.1
       tape:
-        specifier: ^5.9.0
+        specifier: 'catalog:'
         version: 5.9.0
       tsup:
-        specifier: ^8.4.0
+        specifier: 'catalog:'
         version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.4
+        specifier: 'catalog:'
         version: 4.19.4
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       write-json-file:
         specifier: ^6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,14 @@
 packages:
   - "packages/*"
+
+catalog:
+  "@types/benchmark": ^2.1.5
+  "@types/geojson": ^7946.0.10
+  "@types/tape": ^5.8.1
+  benchmark: ^2.1.4
+  tape: ^5.9.0
+  tslib: ^2.8.1
+  tstyche: ^6.2.0
+  tsup: ^8.4.0
+  tsx: ^4.19.4
+  typescript: ^5.8.3


### PR DESCRIPTION
[pnpm catalogs](https://pnpm.io/catalogs) were built to exactly solve the problem of wanting a single version of a given dependency across the workspace. We've been getting along ok with monorepolint enforcing the versions, but if we move these things into the catalog as well, it will make version bumps much simpler (just bump in 1 place, run pnpm install) and result in less churn (package.json files will no longer need updating).

Note that these will be replaced by the actual versions [when publishing](https://pnpm.io/catalogs#publishing).

First commit is the manual changes, second is just the churn from `pnpm mrl check --fix` and then `pnpm i`