### PR TITLE
Add consumer-style testing for Turf

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6283,6 +6283,58 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
 
+  test/node-cjs:
+    dependencies:
+      '@turf/turf':
+        specifier: workspace:*
+        version: link:../../packages/turf
+
+  test/node-esm:
+    dependencies:
+      '@turf/turf':
+        specifier: workspace:*
+        version: link:../../packages/turf
+
+  test/ts-bundler-cjs:
+    dependencies:
+      '@turf/turf':
+        specifier: workspace:*
+        version: link:../../packages/turf
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  test/ts-bundler-esm:
+    dependencies:
+      '@turf/turf':
+        specifier: workspace:*
+        version: link:../../packages/turf
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  test/ts-node-cjs:
+    dependencies:
+      '@turf/turf':
+        specifier: workspace:*
+        version: link:../../packages/turf
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  test/ts-node-esm:
+    dependencies:
+      '@turf/turf':
+        specifier: workspace:*
+        version: link:../../packages/turf
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/*"
+  - "test/*"
 
 catalog:
   "@types/benchmark": ^2.1.5

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,7 @@
+# Consumer test harnesses
+
+Each directory is an example configuration that we may expect a Turf consumer to depend on. It allows us to test various configurations in CI and avoid shipping breaking changes unintentionally across a variety of different user groups.
+
+Note that the CI runs include a matrix of Node versions, so each of these scenarios is tested across those as well.
+
+The TypeScript settings were inspired by the [Choosing Compiler Options](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html) documentation on the recommended configurations in May 2026.

--- a/test/node-cjs/index.cjs
+++ b/test/node-cjs/index.cjs
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const turf = require("@turf/turf");
+
+const polygon = turf.polygon([
+  [
+    [125, -15],
+    [113, -22],
+    [154, -27],
+    [144, -15],
+    [125, -15],
+  ],
+]);
+
+const area = turf.area(polygon);
+
+console.log(area);

--- a/test/node-cjs/package.json
+++ b/test/node-cjs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-cjs",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "funding": "https://opencollective.com/turf",
+  "scripts": {
+    "test": "pnpm run /test:.*/",
+    "test:node": "node index.cjs"
+  },
+  "dependencies": {
+    "@turf/turf": "workspace:*"
+  }
+}

--- a/test/node-esm/index.mjs
+++ b/test/node-esm/index.mjs
@@ -1,0 +1,15 @@
+import * as turf from "@turf/turf";
+
+const polygon = turf.polygon([
+  [
+    [125, -15],
+    [113, -22],
+    [154, -27],
+    [144, -15],
+    [125, -15],
+  ],
+]);
+
+const area = turf.area(polygon);
+
+console.log(area);

--- a/test/node-esm/package.json
+++ b/test/node-esm/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-esm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "funding": "https://opencollective.com/turf",
+  "keywords": [],
+  "scripts": {
+    "test": "pnpm run /test:.*/",
+    "test:node": "node index.mjs"
+  },
+  "dependencies": {
+    "@turf/turf": "workspace:*"
+  }
+}

--- a/test/ts-bundler-cjs/package.json
+++ b/test/ts-bundler-cjs/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ts-bundler-cjs",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "funding": "https://opencollective.com/turf",
+  "keywords": [],
+  "scripts": {
+    "test": "pnpm run /test:.*/",
+    "test:ts": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@turf/turf": "workspace:*"
+  }
+}

--- a/test/ts-bundler-cjs/ts-bundler-cjs.ts
+++ b/test/ts-bundler-cjs/ts-bundler-cjs.ts
@@ -1,0 +1,16 @@
+/* eslint-disable-next-line @typescript-eslint/no-require-imports */
+const turf = require("@turf/turf");
+
+const polygon = turf.polygon([
+  [
+    [125, -15],
+    [113, -22],
+    [154, -27],
+    [144, -15],
+    [125, -15],
+  ],
+]);
+
+const area = turf.area(polygon);
+
+console.log(area);

--- a/test/ts-bundler-cjs/tsconfig.json
+++ b/test/ts-bundler-cjs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": ["ts-bundler-cjs.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": false,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": false
+  }
+}

--- a/test/ts-bundler-esm/package.json
+++ b/test/ts-bundler-esm/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ts-bundler-esm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "funding": "https://opencollective.com/turf",
+  "keywords": [],
+  "type": "module",
+  "scripts": {
+    "test": "pnpm run /test:.*/",
+    "test:ts": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@turf/turf": "workspace:*"
+  }
+}

--- a/test/ts-bundler-esm/ts-bundler-esm.ts
+++ b/test/ts-bundler-esm/ts-bundler-esm.ts
@@ -1,0 +1,15 @@
+import * as turf from "@turf/turf";
+
+const polygon = turf.polygon([
+  [
+    [125, -15],
+    [113, -22],
+    [154, -27],
+    [144, -15],
+    [125, -15],
+  ],
+]);
+
+const area = turf.area(polygon);
+
+console.log(area);

--- a/test/ts-bundler-esm/tsconfig.json
+++ b/test/ts-bundler-esm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": ["ts-bundler-esm.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": false,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": false
+  }
+}

--- a/test/ts-node-cjs/package.json
+++ b/test/ts-node-cjs/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ts-node-cjs",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "funding": "https://opencollective.com/turf",
+  "keywords": [],
+  "scripts": {
+    "test": "pnpm run /test:.*/",
+    "test:ts": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@turf/turf": "workspace:*"
+  }
+}

--- a/test/ts-node-cjs/ts-node-cjs.ts
+++ b/test/ts-node-cjs/ts-node-cjs.ts
@@ -1,0 +1,16 @@
+/* eslint-disable-next-line @typescript-eslint/no-require-imports */
+const turf = require("@turf/turf");
+
+const polygon = turf.polygon([
+  [
+    [125, -15],
+    [113, -22],
+    [154, -27],
+    [144, -15],
+    [125, -15],
+  ],
+]);
+
+const area = turf.area(polygon);
+
+console.log(area);

--- a/test/ts-node-cjs/tsconfig.json
+++ b/test/ts-node-cjs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["ts-node-cjs.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": false
+  }
+}

--- a/test/ts-node-esm/package.json
+++ b/test/ts-node-esm/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ts-node-esm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "funding": "https://opencollective.com/turf",
+  "keywords": [],
+  "type": "module",
+  "scripts": {
+    "test": "pnpm run /test:.*/",
+    "test:ts": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@turf/turf": "workspace:*"
+  }
+}

--- a/test/ts-node-esm/ts-node-esm.ts
+++ b/test/ts-node-esm/ts-node-esm.ts
@@ -1,0 +1,15 @@
+import * as turf from "@turf/turf";
+
+const polygon = turf.polygon([
+  [
+    [125, -15],
+    [113, -22],
+    [154, -27],
+    [144, -15],
+    [125, -15],
+  ],
+]);
+
+const area = turf.area(polygon);
+
+console.log(area);

--- a/test/ts-node-esm/tsconfig.json
+++ b/test/ts-node-esm/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["ts-node-esm.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": false
+  }
+}


### PR DESCRIPTION
We add a handful of packages to test using Turf in ways that we might expect a consumer to have. Specifically we test from CommonJS and ESM module types, and we test Node native consuming as well as TypeScript targeted towards NodeJS and bundler consumers.

This should hopefully give us more assurance that the package.json entries are actually working as expected and we aren't accidentally breaking compatibility.

Note: some of the other changes originally pushed to this branch were rebased out into the other linked PRs #3066 and #3067.