### PR TITLE
Revert d3-geo to 2.x to fix Node CJS consumers

### DIFF
--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@turf/truncate": "workspace:*",
     "@types/benchmark": "catalog:",
-    "@types/d3-geo": "^3.1.0",
+    "@types/d3-geo": "^2.0.7",
     "@types/tape": "catalog:",
     "benchmark": "catalog:",
     "load-json-file": "^7.0.1",
@@ -80,7 +80,7 @@
     "@turf/meta": "workspace:*",
     "@turf/projection": "workspace:*",
     "@types/geojson": "catalog:",
-    "d3-geo": "^3.1.1",
+    "d3-geo": "^2.0.2",
     "tslib": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,8 +1622,8 @@ importers:
         specifier: 'catalog:'
         version: 7946.0.14
       d3-geo:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^2.0.2
+        version: 2.0.2
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
@@ -1635,8 +1635,8 @@ importers:
         specifier: 'catalog:'
         version: 2.1.5
       '@types/d3-geo':
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^2.0.7
+        version: 2.0.7
       '@types/tape':
         specifier: 'catalog:'
         version: 5.8.1
@@ -7738,8 +7738,8 @@ packages:
   '@types/concaveman@1.1.6':
     resolution: {integrity: sha512-3shTHRmSStvc+91qrFlQv2UmrOB0sZ6biDQo7YzY+9tV1mNLpdzuZal4D3hTYXYWig49K01lCvYDpnh+txToXw==}
 
-  '@types/d3-geo@3.1.0':
-    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+  '@types/d3-geo@2.0.7':
+    resolution: {integrity: sha512-RIXlxPdxvX+LAZFv+t78CuYpxYag4zuw9mZc+AwfB8tZpKU90rMEn2il2ADncmeZlb7nER9dDsJpRisA3lRvjA==}
 
   '@types/d3-voronoi@1.1.12':
     resolution: {integrity: sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==}
@@ -8433,13 +8433,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
 
-  d3-geo@3.1.1:
-    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
-    engines: {node: '>=12'}
+  d3-geo@2.0.2:
+    resolution: {integrity: sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==}
 
   d3-queue@3.0.7:
     resolution: {integrity: sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw==}
@@ -9402,9 +9400,8 @@ packages:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
 
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   ip@2.0.1:
     resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
@@ -13517,7 +13514,7 @@ snapshots:
 
   '@types/concaveman@1.1.6': {}
 
-  '@types/d3-geo@3.1.0':
+  '@types/d3-geo@2.0.7':
     dependencies:
       '@types/geojson': 7946.0.14
 
@@ -14289,13 +14286,13 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  d3-array@3.2.4:
+  d3-array@2.12.1:
     dependencies:
-      internmap: 2.0.3
+      internmap: 1.0.1
 
-  d3-geo@3.1.1:
+  d3-geo@2.0.2:
     dependencies:
-      d3-array: 3.2.4
+      d3-array: 2.12.1
 
   d3-queue@3.0.7: {}
 
@@ -15453,7 +15450,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.0.6
 
-  internmap@2.0.3: {}
+  internmap@1.0.1: {}
 
   ip@2.0.1: {}
 


### PR DESCRIPTION
While building [testing for the various consumer scenarios](https://github.com/Turfjs/turf/pull/3065), it caught that the d3-geo upgrade from the [@turf/buffer migration to TypeScript](https://github.com/Turfjs/turf/pull/2994) actually caused failures in node@18 from CJS. I believe this is because `d3-geo` incorrectly points to an ESM file when it is expecting a CJS one. See [arethetypeswrong](https://arethetypeswrong.github.io/?p=d3-geo%403.1.1) with node16+cjs.

The original upgrade was from d3-geo@1 to d3-geo@3, but d3-geo@2 hadn't yet been moved to ESM and so we can take that instead.

---

The failure that was caught by the consumer testing:

```
❌ > node-cjs:test
  
  
  > node-cjs@1.0.0 test /home/runner/work/turf/turf/test/node-cjs
  > pnpm run /test:.*/
  
  
  > node-cjs@1.0.0 test:node /home/runner/work/turf/turf/test/node-cjs
  > node index.cjs
  
  /home/runner/work/turf/turf/packages/turf-buffer/dist/cjs/index.cjs:5
  var _d3geo = require('d3-geo');
               ^
  
  Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/turf/turf/node_modules/.pnpm/d3-geo@3.1.1/node_modules/d3-geo/src/index.js from /home/runner/work/turf/turf/packages/turf-buffer/dist/cjs/index.cjs not supported.
  Instead change the require of index.js in /home/runner/work/turf/turf/packages/turf-buffer/dist/cjs/index.cjs to a dynamic import() which is available in all CommonJS modules.
      at Object.<anonymous> (/home/runner/work/turf/turf/packages/turf-buffer/dist/cjs/index.cjs:5:14)
      at Object.<anonymous> (/home/runner/work/turf/turf/packages/turf/dist/cjs/index.cjs:24:15)
      at Object.<anonymous> (/home/runner/work/turf/turf/test/node-cjs/index.cjs:3:14) {
    code: 'ERR_REQUIRE_ESM'
  }
  ```