### PR TITLE
Clean up the .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,38 +1,16 @@
-.rpt2_cache
+# our build directories
 packages/*/dist
-main.js
-main.es.js
-main.mjs
-main.min.js
-index.mjs
-*.min.js
-*.es5.js
-.esm-cache
-package-lock.json
-env
-.nyc_output
-lib-cov
-*.seed
-*.log
-*.csv
-*.dat
-*.out
-*.pid
-.idea/*
-types.js
-.DS_Store
-types.d.ts
 
-pids
-logs
-results
-
-npm-debug.log*
-
+# pnpm-specific
 node_modules
+pnpm-debug.log*
 
+# build caches
+.nx
+
+# editor-specific
 .vscode
+.idea
 
-.nx/
-.cursor/rules/nx-rules.mdc
-.github/instructions/nx.instructions.md
+# os-specific
+.DS_Store

--- a/packages/turf/.gitignore
+++ b/packages/turf/.gitignore
@@ -1,1 +1,2 @@
 test.example.js
+turf.min.js


### PR DESCRIPTION
Moved the turf.min.js gitignore into packages/turf/.gitignore, as that is the only place that creates that file.

Removed a bunch of the old ignores which did not appear on my computer, but I'm happy to re-add anything that is still relevant today and causing noise for others. It seems like a lot of these are related to tools that no longer exist or weird early TypeScript migration oddities that are no longer relevant.

(I ran into this when [adding consumer-style testing](https://github.com/Turfjs/turf/pull/3065), where index.mjs had been ignored, and so I didn't add it originally)