### PR TITLE
fix(clusters-dbscan): honor non-kilometer units in neighbor distance check

### DIFF
--- a/packages/turf-clusters-dbscan/index.ts
+++ b/packages/turf-clusters-dbscan/index.ts
@@ -141,10 +141,10 @@ function clustersDbscan(
       (neighbor) => {
         const neighborIndex = neighbor.index;
         const neighborPoint = points.features[neighborIndex];
-        const distanceInKm = distance(point, neighborPoint, {
-          units: "kilometers",
+        const neighborDistance = distance(point, neighborPoint, {
+          units: options.units,
         });
-        return distanceInKm <= maxDistance;
+        return neighborDistance <= maxDistance;
       }
     );
   };

--- a/packages/turf-clusters-dbscan/test.ts
+++ b/packages/turf-clusters-dbscan/test.ts
@@ -7,7 +7,12 @@ import { writeJsonFileSync } from "write-json-file";
 import { centroid } from "@turf/centroid";
 import chromatism from "chromatism";
 import concaveman from "concaveman";
-import { point, polygon, featureCollection } from "@turf/helpers";
+import {
+  point,
+  polygon,
+  featureCollection,
+  lengthToDegrees,
+} from "@turf/helpers";
 import { clusterReduce, clusterEach } from "@turf/clusters";
 import { coordAll, featureEach } from "@turf/meta";
 import { clustersDbscan } from "./index.js";
@@ -152,5 +157,19 @@ test("clusters-dbscan -- allow input mutation", (t) => {
   // Allow mutation
   clustersDbscan(oldPoints, 2, { minPoints: 1, mutate: true });
   t.equal(oldPoints.features[1].properties.cluster, 1, "cluster is 1");
+  t.end();
+});
+
+test("clusters-dbscan -- maxDistance honors non-kilometer units", (t) => {
+  // 400 m east + 400 m north of the origin is ~566 m away — outside a 400 m
+  // radius — so with a 400 m maxDistance the two points must be noise.
+  const offset = lengthToDegrees(400, "meters"); // at the equator, east == north
+  const fc = featureCollection([point([0, 0]), point([offset, offset])]);
+
+  const clustered = clustersDbscan(fc, 400, { units: "meters", minPoints: 2 });
+  t.true(
+    clustered.features.every((f) => f.properties.dbscan === "noise"),
+    "points ~566 m apart are noise when maxDistance is 400 meters"
+  );
   t.end();
 });


### PR DESCRIPTION
## Issue
`clustersDbscan` ignores a non-kilometer `units` option. The bbox pre-filter honors `options.units` via `lengthToDegrees(maxDistance, options.units)`, but the final neighbor predicate computes the distance in kilometers and compares it directly against `maxDistance`:

```ts
const distanceInKm = distance(point, neighborPoint, { units: "kilometers" });
return distanceInKm <= maxDistance;
```

So `maxDistance` is treated as kilometers in the predicate regardless of `options.units`. For any unit smaller than a kilometer this makes the check effectively always true, and the neighborhood is no longer clipped to a `maxDistance`-radius circle — it collapses to the square bounding box, clustering points that are farther apart than `maxDistance`.

Example: with `{ units: "meters" }` and `maxDistance: 400`, two points ~566 m apart (400 m east + 400 m north) are clustered even though they are well beyond 400 m.

## Fix
Measure the neighbor distance in `options.units` so it matches the unit used by both `maxDistance` and the bbox pre-filter. When `units` is omitted, both still default to kilometers, so existing behavior is unchanged.

## Tests
Added a regression test covering a non-kilometer unit. All existing fixture tests still pass.
