### PR TITLE
@turf/line-arc: always reach bearing2 (fix dropped final vertex)

### DIFF
--- a/packages/turf-line-arc/index.ts
+++ b/packages/turf-line-arc/index.ts
@@ -57,19 +57,21 @@ function lineArc(
   const arcStartDegree = angle1;
   const arcEndDegree = angle1 < angle2 ? angle2 : angle2 + 360;
 
-  let alpha = arcStartDegree;
   const coordinates = [];
-  let i = 0;
   // How many degrees we'll swing around between each step.
   const arcStep = (arcEndDegree - arcStartDegree) / steps;
-  // Add coords to the list, increasing the angle from our start bearing
-  // (alpha) by arcStep degrees until we reach the end bearing.
-  while (alpha <= arcEndDegree) {
+  // Add coords to the list, increasing the angle from our start bearing by
+  // arcStep degrees until we reach the end bearing. Iterate a fixed number of
+  // times (steps + 1 vertices) rather than comparing an accumulated angle
+  // against arcEndDegree: floating-point drift in arcStartDegree + i * arcStep
+  // could make the final value exceed arcEndDegree (e.g. 29.000000000000004),
+  // dropping the last vertex so the arc never reached bearing2. Pin the last
+  // vertex to arcEndDegree so the arc always ends exactly on bearing2.
+  for (let i = 0; i <= steps; i++) {
+    const alpha = i === steps ? arcEndDegree : arcStartDegree + i * arcStep;
     coordinates.push(
       destination(center, radius, alpha, options).geometry.coordinates
     );
-    i++;
-    alpha = arcStartDegree + i * arcStep;
   }
   return lineString(coordinates, properties);
 }

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -3,6 +3,9 @@
   "version": "7.3.5",
   "description": "Creates a circular arc, of a circle of the given radius and center point, between two bearings.",
   "author": "Turf Authors",
+  "contributors": [
+    "Alexander Kireev <@chatman-media>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"

--- a/packages/turf-line-arc/test.ts
+++ b/packages/turf-line-arc/test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { loadJsonFileSync } from "load-json-file";
 import { writeJsonFileSync } from "write-json-file";
 import { truncate } from "@turf/truncate";
+import { destination } from "@turf/destination";
 import { featureCollection, point } from "@turf/helpers";
 import { lineArc } from "./index.js";
 
@@ -75,6 +76,30 @@ test("turf-line-arc #2446", (t) => {
 
   t.doesNotThrow(() =>
     lineArc(center, radius * 1.852, startAngle, endAngle, options)
+  );
+
+  t.end();
+});
+
+test("turf-line-arc -- reaches bearing2 despite floating-point drift", (t) => {
+  // For some bearing/step combinations arcStartDegree + steps * arcStep
+  // overshoots arcEndDegree by a rounding epsilon (e.g. 0 + 7 * (29 / 7) ===
+  // 29.000000000000004 > 29). The old `while (alpha <= arcEndDegree)` loop then
+  // dropped the final vertex, returning `steps` points instead of `steps + 1`
+  // and ending the arc a full step short of bearing2.
+  const center = point([-75, 40]);
+  const arc = lineArc(center, 5, 0, 29, { steps: 7 });
+  const coords = arc.geometry.coordinates;
+
+  t.equals(coords.length, 7 + 1, "arc has steps + 1 vertices");
+
+  // The final vertex must sit on bearing2 (29°). destination(center, r, 29)
+  // gives the reference coordinate; the old code stopped at bearing ~24.857°.
+  const expectedLast = destination(center, 5, 29).geometry.coordinates;
+  t.deepEquals(
+    truncate(point(coords[coords.length - 1])).geometry.coordinates,
+    truncate(point(expectedLast)).geometry.coordinates,
+    "last vertex lies on bearing2"
   );
 
   t.end();


### PR DESCRIPTION
## Summary

`lineArc` could return an arc that stops one step short of `bearing2`.

The loop generates points with `while (alpha <= arcEndDegree)`, advancing `alpha = arcStartDegree + i * arcStep`. For some bearing/step combinations the accumulated angle overshoots `arcEndDegree` by a floating-point epsilon on the last iteration, so the loop exits early and the final vertex is dropped.

The result is an arc with `steps` vertices instead of the documented `steps + 1`, ending a full `arcStep` before `bearing2`.

### Reproduction

```js
import { lineArc } from "@turf/line-arc";
import { point } from "@turf/helpers";

const arc = lineArc(point([-75, 40]), 5, 0, 29, { steps: 7 });
arc.geometry.coordinates.length; // 7  (expected 8 = steps + 1)
// last vertex is at bearing ~24.857° instead of 29°
```

Here `0 + 7 * (29 / 7) === 29.000000000000004 > 29`, so the `alpha <= arcEndDegree` check fails on the final step.

### Fix

Iterate a fixed `steps + 1` times and pin the last vertex to `arcEndDegree`, so the arc always ends exactly on `bearing2`. A small fuzz over many `(bearing1, bearing2, steps)` combinations showed ~0.9% of cases dropped the final vertex before this change and 0 after; behaviour is unchanged for inputs that did not trigger the rounding overshoot (existing fixtures are byte-identical).

Added a regression test (`lineArc(center, 5, 0, 29, { steps: 7 })`) that asserts `steps + 1` vertices and that the last vertex lies on `bearing2`. It fails on the current code and passes with the fix; the full `@turf/line-arc` suite passes.

Note: this is orthogonal to open PR #2910 (which changes the arc radius approximation but keeps the same loop), so there is no conflict.

## Breaking change

No. Output is unchanged except that affected arcs now include the previously-missing endpoint, matching the documented `steps + 1` contract.

## Issues

No existing issue; self-discovered.

---

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change. (not a breaking change)
- [x] Any issues this resolves. (none — self-discovered)
- [x] Inclusion of your details in the `contributors` field of `package.json`.
- [x] Confirmation you've read the steps for preparing a pull request.