### PR TITLE
fix(boolean-crosses): make MultiPoint/LineString crossing order-independent

### DIFF
--- a/packages/turf-boolean-crosses/index.ts
+++ b/packages/turf-boolean-crosses/index.ts
@@ -76,8 +76,8 @@ function doMultiPointAndLineStringCross(
   var foundIntPoint = false;
   var foundExtPoint = false;
   var pointLength = multiPoint.coordinates.length;
-  var i = 0;
-  while (i < pointLength && !foundIntPoint && !foundExtPoint) {
+  for (var i = 0; i < pointLength && (!foundIntPoint || !foundExtPoint); i++) {
+    var pointOnLine = false;
     for (var i2 = 0; i2 < lineString.coordinates.length - 1; i2++) {
       var incEndVertices = true;
       if (i2 === 0 || i2 === lineString.coordinates.length - 2) {
@@ -91,12 +91,15 @@ function doMultiPointAndLineStringCross(
           incEndVertices
         )
       ) {
-        foundIntPoint = true;
-      } else {
-        foundExtPoint = true;
+        pointOnLine = true;
+        break;
       }
     }
-    i++;
+    if (pointOnLine) {
+      foundIntPoint = true;
+    } else {
+      foundExtPoint = true;
+    }
   }
   return foundIntPoint && foundExtPoint;
 }

--- a/packages/turf-boolean-crosses/test/false/MultiPoint/LineString/MultiPointAllInteriorNotCrossLine.geojson
+++ b/packages/turf-boolean-crosses/test/false/MultiPoint/LineString/MultiPointAllInteriorNotCrossLine.geojson
@@ -1,0 +1,29 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [
+          [1, 2],
+          [1, 3]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [1, 1],
+          [1, 2],
+          [1, 3],
+          [1, 4]
+        ]
+      }
+    }
+  ]
+}

--- a/packages/turf-boolean-crosses/test/true/MultiPoint/LineString/MultiPointsCrossLineExteriorFirst.geojson
+++ b/packages/turf-boolean-crosses/test/true/MultiPoint/LineString/MultiPointsCrossLineExteriorFirst.geojson
@@ -1,0 +1,29 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [
+          [12, 12],
+          [1, 2]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [1, 1],
+          [1, 2],
+          [1, 3],
+          [1, 4]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

`doMultiPointAndLineStringCross` decides whether a MultiPoint crosses a LineString, which is a set predicate: it must be true when the point set has at least one member interior to the line and at least one member exterior to it. A set predicate has to be order-invariant, but two bugs make it depend on coordinate order and on per-segment accidents.

1. **Outer loop stops after the first point.** The `while` guard was `!foundIntPoint && !foundExtPoint`, so the loop exits as soon as either flag is set, i.e. after classifying the very first MultiPoint coordinate. Whether the predicate sees the rest of the set then depends on which point happens to come first. The sibling `doesMultiPointCrossPoly` already uses the correct guard `(!foundIntPoint || !foundExtPoint)` (keep scanning until both an interior and an exterior point are found).

2. **Inner loop conflates "not on this segment" with "exterior to the line".** Each non-matching segment set `foundExtPoint = true`, so a point that lies on the line but not on the first segment tested was wrongly counted as exterior. A single interior point could therefore report a cross.

## Fix

- Iterate the whole MultiPoint with the order-invariant guard `(!foundIntPoint || !foundExtPoint)`, matching `doesMultiPointCrossPoly`.
- Classify each point once: scan its segments, and only after the inner loop decide interior (on any segment) vs exterior (on none).

## Tests

Two fixtures added:

- `test/true/MultiPoint/LineString/MultiPointsCrossLineExteriorFirst.geojson` — exterior point listed first; must still cross.
- `test/false/MultiPoint/LineString/MultiPointAllInteriorNotCrossLine.geojson` — all points interior; must not cross.

Both fail on the current source and pass after the fix. Full package suite: 22/22.