### PR TITLE
fix(boolean-contains): treat an equal two-vertex line as contained

### DIFF
--- a/packages/turf-boolean-contains/index.ts
+++ b/packages/turf-boolean-contains/index.ts
@@ -7,6 +7,7 @@ import {
   MultiPolygon,
   Point,
   Polygon,
+  Position,
 } from "geojson";
 import { bbox as calcBbox } from "@turf/bbox";
 import { booleanPointInPolygon } from "@turf/boolean-point-in-polygon";
@@ -176,7 +177,9 @@ function isMultiPointInPoly(polygon: Polygon, multiPoint: MultiPoint) {
 
 function isLineOnLine(lineString1: LineString, lineString2: LineString) {
   let haveFoundInteriorPoint = false;
-  for (const coords of lineString2.coordinates) {
+  const coordinates = lineString2.coordinates;
+  for (let i = 0; i < coordinates.length; i++) {
+    const coords = coordinates[i];
     if (
       isPointOnLine({ type: "Point", coordinates: coords }, lineString1, {
         ignoreEndVertices: true,
@@ -190,6 +193,23 @@ function isLineOnLine(lineString1: LineString, lineString2: LineString) {
       })
     ) {
       return false;
+    }
+    // A segment whose endpoints are both on lineString1 (e.g. lineString2's
+    // vertices coincide with lineString1's boundary) still shares interior with
+    // lineString1. Probe the segment midpoint so an interior overlap is detected
+    // even when no vertex of lineString2 is strictly interior.
+    if (!haveFoundInteriorPoint && i > 0) {
+      const midpoint: Position = [
+        (coordinates[i - 1][0] + coords[0]) / 2,
+        (coordinates[i - 1][1] + coords[1]) / 2,
+      ];
+      if (
+        isPointOnLine({ type: "Point", coordinates: midpoint }, lineString1, {
+          ignoreEndVertices: true,
+        })
+      ) {
+        haveFoundInteriorPoint = true;
+      }
     }
   }
   return haveFoundInteriorPoint;

--- a/packages/turf-boolean-contains/test/true/LineString/LineString/LineContainsEqualTwoVertexLine.geojson
+++ b/packages/turf-boolean-contains/test/true/LineString/LineString/LineContainsEqualTwoVertexLine.geojson
@@ -1,0 +1,27 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [0, 0],
+          [10, 0]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [0, 0],
+          [10, 0]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

`booleanContains` documents the duality `contains(a, b) === within(b, a)`, and as a containment relation it is reflexive: a geometry contains an equal copy of itself. Both properties break for the simplest LineString case.

Two identical 2-vertex lines, e.g. `[[0,0],[10,0]]` and `[[0,0],[10,0]]`, return `contains = false`.

The cause is in `isLineOnLine`, which only records an interior overlap when a **vertex** of `lineString2` is strictly interior to `lineString1` (`ignoreEndVertices: true`). For two equal 2-vertex lines, both of line2's vertices are endpoints, so neither is strictly interior, and the function reports no interior overlap even though the lines are identical.

This is a vertex-counting artifact rather than a geometric one: inserting a redundant collinear midpoint into line2 (`[[0,0],[5,0],[10,0]]`) flips the answer to `true`, because the added vertex is now strictly interior. The same line, described with one more vertex, should not change containment.

## Fix

Keep the existing vertex check, and additionally probe each segment midpoint of `lineString2`. If a segment's midpoint is strictly interior to `lineString1`, the segment shares interior with `lineString1`, so an interior overlap exists even when no vertex of `lineString2` is strictly interior. This is the minimal probe that handles the equal-2-vertex case without changing any other result.

## Tests

Fixture added: `test/true/LineString/LineString/LineContainsEqualTwoVertexLine.geojson` (two identical 2-vertex lines must contain each other). It fails on the current source and passes after the fix.

- `boolean-contains`: 40/40.
- `boolean-within` (duality regression): 40/40.