### PR TITLE
fix(@turf/midpoint): interpolate altitude (z-coordinate) for 3D points

### DIFF
--- a/packages/turf-midpoint/index.ts
+++ b/packages/turf-midpoint/index.ts
@@ -3,6 +3,7 @@ import { bearing } from "@turf/bearing";
 import { destination } from "@turf/destination";
 import { distance } from "@turf/distance";
 import { Coord } from "@turf/helpers";
+import { getCoord } from "@turf/invariant";
 
 /**
  * Takes two points and returns a point midway between them. The midpoint is
@@ -27,6 +28,14 @@ function midpoint(point1: Coord, point2: Coord): Feature<Point> {
   const dist = distance(point1, point2);
   const heading = bearing(point1, point2);
   const midpoint = destination(point1, dist / 2, heading);
+
+  // Interpolate altitude (z-coordinate) when both input points carry one.
+  // destination() propagates only the origin's z unchanged; average them instead.
+  const coord1 = getCoord(point1);
+  const coord2 = getCoord(point2);
+  if (coord1[2] !== undefined && coord2[2] !== undefined) {
+    midpoint.geometry.coordinates[2] = (coord1[2] + coord2[2]) / 2;
+  }
 
   return midpoint;
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -64,6 +64,7 @@
     "@turf/destination": "workspace:*",
     "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
+    "@turf/invariant": "workspace:*",
     "@types/geojson": "catalog:",
     "tslib": "catalog:"
   }

--- a/packages/turf-midpoint/test.ts
+++ b/packages/turf-midpoint/test.ts
@@ -68,3 +68,34 @@ test("midpoint -- long distance", function (t) {
 
   t.end();
 });
+test("midpoint -- interpolates altitude (z-coordinate) from 3D points", function (t) {
+  var pt1 = point([0, 0, 100]);
+  var pt2 = point([10, 0, 200]);
+
+  var mid = midpoint(pt1, pt2);
+  var coords = mid.geometry.coordinates;
+
+  // The midpoint of two 3D points must interpolate z as the average
+  t.equal(
+    coords[2],
+    150,
+    "z should be the average of the two input altitudes (100+200)/2 = 150"
+  );
+
+  t.end();
+});
+
+test("midpoint -- returns undefined z when inputs have no altitude", function (t) {
+  var pt1 = point([0, 0]);
+  var pt2 = point([10, 0]);
+
+  var mid = midpoint(pt1, pt2);
+
+  t.equal(
+    mid.geometry.coordinates[2],
+    undefined,
+    "z should be undefined when inputs have no altitude"
+  );
+
+  t.end();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4173,6 +4173,9 @@ importers:
       '@turf/helpers':
         specifier: workspace:*
         version: link:../turf-helpers
+      '@turf/invariant':
+        specifier: workspace:*
+        version: link:../turf-invariant
       '@types/geojson':
         specifier: 'catalog:'
         version: 7946.0.14
@@ -7288,6 +7291,7 @@ packages:
   '@lerna/create@9.0.3':
     resolution: {integrity: sha512-hUTEWrR8zH+/Z3bp/R1aLm6DW8vB/BB7KH7Yeg4fMfrvSwxegiLVW9uJFAzWkK4mzEagmj/Dti85Yg9MN13t0g==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    deprecated: This package is an implementation detail of Lerna and is no longer published separately.
 
   '@ljharb/resumer@0.1.3':
     resolution: {integrity: sha512-d+tsDgfkj9X5QTriqM4lKesCkMMJC3IrbPKHvayP00ELx2axdXvDfWkqjxrLXIzGcQzmj7VAUT1wopqARTvafw==}
@@ -8443,6 +8447,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -9158,6 +9163,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -9167,6 +9173,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -11361,10 +11368,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}


### PR DESCRIPTION
## Summary

Fixes `@turf/midpoint` returning the wrong z-coordinate when both input points have altitude (elevation).

Closes #3086

## Root Cause

`midpoint(p1, p2)` calls `destination(p1, dist/2, heading)`.
`destination()` propagates **only the origin's z** unchanged, so the result always got `z = z1`, ignoring `z2` entirely.

## Fix

After computing the geographic midpoint, extract both z-values via `getCoord()` and set:

```ts
midpoint.geometry.coordinates[2] = (coord1[2] + coord2[2]) / 2;
```

This runs only when both input points have a z-coordinate; 2D inputs are unaffected.

## Changes

- `packages/turf-midpoint/index.ts` — average z when both inputs have altitude
- `packages/turf-midpoint/package.json` — add `@turf/invariant` as explicit dependency
- `packages/turf-midpoint/test.ts` — two new tests (3D interpolation + 2D unchanged)

## Test results

**Before fix:**
```
# tests 8 / # pass 7 / # fail 1
not ok 7 z should be the average of the two input altitudes (100+200)/2 = 150
  actual:   100   expected: 150
```

**After fix:**
```
# tests 8 / # pass 8
```