### PR TITLE
Fix boolean-disjoint missing overlapping collinear lines

### DIFF
--- a/packages/turf-boolean-disjoint/index.ts
+++ b/packages/turf-boolean-disjoint/index.ts
@@ -125,6 +125,19 @@ function isLineOnLine(
   if (doLinesIntersect.features.length > 0) {
     return true;
   }
+  // lineIntersect() only reports points where segments cross, so collinear
+  // (partially) overlapping lines are missed. Check whether a vertex of either
+  // line lies on the other line to also catch those overlapping cases.
+  for (const coords of lineString1.coordinates) {
+    if (isPointOnLine(lineString2, { type: "Point", coordinates: coords })) {
+      return true;
+    }
+  }
+  for (const coords of lineString2.coordinates) {
+    if (isPointOnLine(lineString1, { type: "Point", coordinates: coords })) {
+      return true;
+    }
+  }
   return false;
 }
 

--- a/packages/turf-boolean-disjoint/test/false/LineString/LineString/LineString-Overlap.geojson
+++ b/packages/turf-boolean-disjoint/test/false/LineString/LineString/LineString-Overlap.geojson
@@ -1,0 +1,27 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [4, 1],
+          [5, 4]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [4, 1],
+          [6, 7]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
boolean-disjoint leans on lineIntersect to decide whether two lines touch, but lineIntersect only returns points where segments actually cross, so two collinear lines lying on top of each other come back as disjoint when they aren't.

I added a check for whether a vertex of either line falls on the other line. That covers the overlap case, since an overlapping interval always has an endpoint that is a vertex of one of the lines, and it leaves genuinely parallel, non-touching lines disjoint as before.

Added a regression fixture under test/false for two overlapping collinear lines. No breaking change.

Resolves #1842