### PR TITLE
boolean-disjoint - add test for explicit line/line touch on a boundary point

### DIFF
--- a/packages/turf-boolean-disjoint/test/false/LineString/LineString/LineStringTouchesLineString.geojson
+++ b/packages/turf-boolean-disjoint/test/false/LineString/LineString/LineStringTouchesLineString.geojson
@@ -1,0 +1,27 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [0, 0],
+          [0, 1]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [0, 1],
+          [1, 1]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Just adding an explicit test for this case on the boolean-disjoint that I was curious about while looking at #3097