### PR TITLE
Use official EPSG:3857 code instead of deprecated EPSG:900913 in projection docs

### DIFF
--- a/packages/turf-projection/README.md
+++ b/packages/turf-projection/README.md
@@ -4,7 +4,7 @@
 
 ## toMercator
 
-Converts a WGS84 GeoJSON object into Mercator (EPSG:900913) projection
+Converts a WGS84 GeoJSON object into Mercator (EPSG:3857) projection
 
 ### Parameters
 
@@ -27,7 +27,7 @@ Returns **[GeoJSON][1]** Projected GeoJSON
 
 ## toWgs84
 
-Converts a Mercator (EPSG:900913) GeoJSON object into WGS84 projection
+Converts a Mercator (EPSG:3857) GeoJSON object into WGS84 projection
 
 ### Parameters
 

--- a/packages/turf-projection/index.ts
+++ b/packages/turf-projection/index.ts
@@ -4,7 +4,7 @@ import { AllGeoJSON, isNumber } from "@turf/helpers";
 import { clone } from "@turf/clone";
 
 /**
- * Converts a WGS84 GeoJSON object into Mercator (EPSG:900913) projection
+ * Converts a WGS84 GeoJSON object into Mercator (EPSG:3857) projection
  *
  * @function
  * @param {GeoJSON|Position} geojson WGS84 GeoJSON object
@@ -26,7 +26,7 @@ function toMercator<G = AllGeoJSON | Position>(
 }
 
 /**
- * Converts a Mercator (EPSG:900913) GeoJSON object into WGS84 projection
+ * Converts a Mercator (EPSG:3857) GeoJSON object into WGS84 projection
  *
  * @function
  * @param {GeoJSON|Position} geojson Mercator GeoJSON object
@@ -93,7 +93,7 @@ function convert(
 }
 
 /**
- * Convert lon/lat values to 900913 x/y.
+ * Convert lon/lat values to 3857 x/y.
  * (from https://github.com/mapbox/sphericalmercator)
  *
  * @private
@@ -102,7 +102,7 @@ function convert(
  */
 function convertToMercator(lonLat: number[]) {
   var D2R = Math.PI / 180,
-    // 900913 properties
+    // 3857 properties
     A = 6378137.0,
     MAXEXTENT = 20037508.342789244;
 
@@ -125,7 +125,7 @@ function convertToMercator(lonLat: number[]) {
 }
 
 /**
- * Convert 900913 x/y values to lon/lat.
+ * Convert 3857 x/y values to lon/lat.
  * (from https://github.com/mapbox/sphericalmercator)
  *
  * @private
@@ -133,7 +133,7 @@ function convertToMercator(lonLat: number[]) {
  * @returns {Array<number>} WGS84 [lon, lat] point
  */
 function convertToWgs84(xy: number[]) {
-  // 900913 properties.
+  // 3857 properties.
   var R2D = 180 / Math.PI;
   var A = 6378137.0;
 

--- a/packages/turf-projection/test.ts
+++ b/packages/turf-projection/test.ts
@@ -31,7 +31,7 @@ test("to-mercator", (t) => {
   for (const { filename, name, geojson } of fromWgs84) {
     var expected = clone(geojson);
     coordEach(expected, function (coord) {
-      var newCoord = proj4("WGS84", "EPSG:900913", coord);
+      var newCoord = proj4("WGS84", "EPSG:3857", coord);
       coord[0] = newCoord[0];
       coord[1] = newCoord[1];
     });
@@ -60,7 +60,7 @@ test("to-wgs84", (t) => {
   for (const { filename, name, geojson } of fromMercator) {
     var expected = clone(geojson);
     coordEach(expected, function (coord) {
-      var newCoord = proj4("EPSG:900913", "WGS84", coord);
+      var newCoord = proj4("EPSG:3857", "WGS84", coord);
       coord[0] = newCoord[0];
       coord[1] = newCoord[1];
     });


### PR DESCRIPTION
The projection package referred to Mercator as EPSG:900913, the old deprecated Google code. Swapped it for the official EPSG:3857 in the README, the JSDoc, and the inline comments. Also updated the proj4 calls in the tests to EPSG:3857; proj4 treats the two as aliases so the expected values are unchanged.

No behaviour change, it's just docs and comments. The projection tape tests still pass (47/47).

Resolves #2891