### PR TITLE
perf(boolean-intersects): delegate flattening to booleanDisjoint

### DIFF
--- a/packages/turf-boolean-intersects/index.ts
+++ b/packages/turf-boolean-intersects/index.ts
@@ -1,6 +1,5 @@
 import { Feature, Geometry } from "geojson";
 import { booleanDisjoint } from "@turf/boolean-disjoint";
-import { flattenEach } from "@turf/meta";
 
 /**
  * Boolean-intersects returns (TRUE) if the intersection of the two geometries is NOT an empty set.
@@ -36,18 +35,9 @@ function booleanIntersects(
     ignoreSelfIntersections?: boolean;
   } = {}
 ) {
-  let bool = false;
-  flattenEach(feature1, (flatten1) => {
-    flattenEach(feature2, (flatten2) => {
-      if (bool === true) {
-        return true;
-      }
-      bool = !booleanDisjoint(flatten1.geometry, flatten2.geometry, {
-        ignoreSelfIntersections,
-      });
-    });
-  });
-  return bool;
+  // booleanDisjoint already compares every flattened geometry pair, so
+  // intersects is simply its negation.
+  return !booleanDisjoint(feature1, feature2, { ignoreSelfIntersections });
 }
 
 export { booleanIntersects };

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -6,7 +6,8 @@
   "contributors": [
     "Rowan Winsemius <@rowanwins>",
     "Denis Carriere <@DenisCarriere>",
-    "David Whittingham <@01100100>"
+    "David Whittingham <@01100100>",
+    "Espen Hovlandsdal <@rexxars>"
   ],
   "license": "MIT",
   "bugs": {
@@ -67,8 +68,6 @@
   },
   "dependencies": {
     "@turf/boolean-disjoint": "workspace:*",
-    "@turf/helpers": "workspace:*",
-    "@turf/meta": "workspace:*",
     "@types/geojson": "catalog:",
     "tslib": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,12 +1193,6 @@ importers:
       '@turf/boolean-disjoint':
         specifier: workspace:*
         version: link:../turf-boolean-disjoint
-      '@turf/helpers':
-        specifier: workspace:*
-        version: link:../turf-helpers
-      '@turf/meta':
-        specifier: workspace:*
-        version: link:../turf-meta
       '@types/geojson':
         specifier: 'catalog:'
         version: 7946.0.14


### PR DESCRIPTION
`booleanIntersects` flattens both features into every pair of simple geometries and calls `booleanDisjoint` per pair. But `booleanDisjoint` performs the exact same nested flattenEach internally, with the inverse accumulation ("all pairs disjoint" vs "any pair intersects"). Since `intersects == !disjoint` holds for multi-geometries too, the entire body can be reduced to:

```ts
return !booleanDisjoint(feature1, feature2, { ignoreSelfIntersections });
```

This is the same category of #3011 - deduplicating/delegating to what the negated variant does, and reducing maintenance surface. I also removed `@turf/meta` and `@turf/helpers` from the package's dependencies since nothing in the package imports them anymore (helpers was unused even before this change). Let's see if CI complains.

Benchmarks show a marked improvement on my M4 MacBook Pro:


| Fixture               | Before | After  | Change |
| --------------------- | ------ | ------ | ------ |
| Point-Point           | 9.67M  | 19.27M | +99%   |
| Point-LineString-1    | 8.68M  | 16.51M | +90%   |
| LineString-Point-2    | 8.65M  | 16.92M | +96%   |
| MultiPoint-Point      | 4.73M  | 9.46M  | +100%  |
| MultiPoint-MultiPoint | 2.62M  | 5.75M  | +120%  |
| Point-Polygon         | 6.53M  | 10.38M | +59%   |
| LineString-In-Polygon | 7.03M  | 11.97M | +70%   |
| LineString-LineString | 1.14M  | 1.23M  | +8%    |
| Polygon-Polygon       | 0.84M  | 0.91M  | +8%    |
| Polygon-MultiPolygon  | 409K   | 419K   | +3%    |

Please provide the following when creating a PR:

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this [resolves](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
- [x] Inclusion of your details in the `contributors` field of `package.json` - you've earned it! 👏
- [x] Confirmation you've read the steps for [preparing a pull request](https://github.com/Turfjs/turf/blob/master/docs/CONTRIBUTING.md#preparing-a-pull-request).
