### PR TITLE
Make last-checks tests less strict about @turf/helpers devDependencies

### DIFF
--- a/packages/turf/test.ts
+++ b/packages/turf/test.ts
@@ -44,7 +44,7 @@ for (const name of fs.readdirSync(directory)) {
 modules = modules.filter(({ name }) => name !== "turf");
 
 test("turf -- invalid dependencies", (t) => {
-  for (const { name, dependencies, devDependencies } of modules) {
+  for (const { name, dependencies, devDependencies, dir } of modules) {
     for (const invalidDependency of [
       "load-json-file",
       "write-json-file",
@@ -62,10 +62,19 @@ test("turf -- invalid dependencies", (t) => {
     }
     if (devDependencies["eslint"] || devDependencies["eslint-config-mourner"])
       t.fail(`${name} eslint is handled at the root level`);
-    if (devDependencies["@turf/helpers"])
-      t.fail(
-        `${name} @turf/helpers should be located in Dependencies instead of DevDependencies`
-      );
+    if (devDependencies["@turf/helpers"]) {
+      // When @turf/helpers is a devDependency, we want a little extra assurance that we won't accidentally
+      // start depending on it in our dist. Check every file in the dist for an import statement and throw an
+      // error if we see something suspicious.
+      for (const file of glob.sync(`${dir}/dist/**/*.{js,cjs,mjs}`)) {
+        const fileContents = fs.readFileSync(file, "utf8");
+        if (fileContents.includes(`from "@turf/helpers"`)) {
+          t.fail(
+            `${name} @turf/helpers should be located in Dependencies instead of DevDependencies`
+          );
+        }
+      }
+    }
     // if (devDependencies['mkdirp']) t.fail(`${name} tests should not have to create folders`);
   }
   t.skip('remove "mkdirp" from testing');


### PR DESCRIPTION
It is possible to have a Turf module that only uses @turf/helpers in dev code (#3011). This loosens the check in last-checks to allow helpers to be a devDependency only if it is not used in code that winds up in the dist.

The check itself is a little sloppy (we check cjs for import statements, and we check using just raw string operations instead of parsing). In v8 we will only be shipping esm code though, and this is just a CI-time issue so we can always re-work the check later if we really need to move to a proper parser.