### PR TITLE
Clarify geomEach behavior and add a test

### DIFF
--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -344,6 +344,8 @@ Returns **void**&#x20;
 
 Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
 
+Note: Nested GeometryCollections are not recursively unwrapped.
+
 ### Parameters
 
 *   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10] | [GeometryObject][10] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -591,6 +591,8 @@ function coordAll(geojson: AllGeoJSON): number[][] {
 /**
  * Iterate over each geometry in any GeoJSON object, similar to Array.forEach()
  *
+ * Note: Nested GeometryCollections are not recursively unwrapped.
+ *
  * @function
  * @param {FeatureCollection|Feature|Geometry|GeometryObject|Feature<GeometryCollection>} geojson any GeoJSON object
  * @param {geomEachCallback} callback a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId)

--- a/packages/turf-meta/test.ts
+++ b/packages/turf-meta/test.ts
@@ -12,6 +12,7 @@ import {
   lineStrings,
 } from "@turf/helpers";
 import * as meta from "./index.js";
+import { GeometryCollection } from "geojson";
 
 const pt = point([0, 0], { a: 1 });
 const pt2 = point([1, 1]);
@@ -1653,5 +1654,25 @@ test("meta -- segmentEach -- Issue #1273", (t) => {
   );
   t.deepEqual(segmentIndexes, [0, 0, 0, 1, 1, 1]);
   t.deepEqual(geometryIndexes, [0, 1, 2, 0, 1, 2]);
+  t.end();
+});
+
+test("meta -- geomEach handles infinitely nested GeometryCollection", (t) => {
+  const evilNestedGeometryCollection: GeometryCollection = {
+    type: "GeometryCollection",
+    geometries: [{ type: "Point", coordinates: [0, 0] }],
+  };
+  evilNestedGeometryCollection.geometries.push(evilNestedGeometryCollection);
+
+  const calls: any[] = [];
+  meta.geomEach(evilNestedGeometryCollection, (g) => {
+    calls.push(g);
+  });
+
+  t.deepEqual(calls, [
+    evilNestedGeometryCollection.geometries[0], // first Geometry of the root collection
+    evilNestedGeometryCollection.geometries[0], // first Geometry of the nested collection
+    evilNestedGeometryCollection, // second Geometry of the nested collection, which is not recursed further
+  ]);
   t.end();
 });


### PR DESCRIPTION
`geomEach` actually has some strange behavior when operating on nested GeometryCollections. It will unwrap twice (root GeometryCollection with a nested GeometryCollection) or just once (Feature containing a GeometryCollection). It does not infinitely recurse.

The [RFC](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.8) states:
```
  To maximize interoperability, implementations SHOULD avoid nested
   GeometryCollections.  Furthermore, GeometryCollections composed of a
   single part or a number of parts of a single type SHOULD be avoided
   when that single part or a single object of multipart type
   (MultiPoint, MultiLineString, or MultiPolygon) could be used instead.
```

So I'm not sure if anyone is really expecting this to work in practice, but for now lets just add a warning to the docs and add a test demonstrating the behavior so we don't accidentally break things here.

I'd be open to changing the functionality in the future if someone feels like this should be improved. In general the methods in meta seem like they require a lot of focus to work on and make sure that performance isn't regressed. A lot of the rest of Turf depends on them to be as fast as possible. I'm not sure we've visited the benchmarks with modern JS engines though, and I'd like the typings to get more strict to help in other packages.