### PR TITLE
Dependabot - Keep GitHub actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Yesterday I noticed that Dependabot can keep the GitHub actions updated with pinned versions (https://github.com/Turfjs/turf-www/pull/231). That's pretty handy since it isn't something we're as likely to visit compared to using PNPM to keep the code side dependencies up to date.