### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,10 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  publish:
+    name: "Publish Release"
     environment: release
-    strategy:
-      fail-fast: true
-      matrix:
-        node:
-          - 26
-        platform:
-          - ubuntu-latest
-    name: "${{matrix.platform}} / Node.js ${{ matrix.node }}"
-    runs-on: ${{matrix.platform}}
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
@@ -32,11 +24,12 @@ jobs:
         with:
           run_install: false
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 26
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
+          node-version: "26"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
I think that publishing is broken using [OIDC](https://github.com/Turfjs/turf/actions/runs/30821961062/job/91718423848). The failures may have been coming from it deciding to use an old version of Node with an older version of npm which doesn't support OIDC yet.

This drops the matrix config entirely and more closely matches the entire workflow to the [docs](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow). As a side effect, it should also make it clearer what version of Node we expect to get used, and it picks up the package-manager-cache: false setting which is suggested for security.
