### PR TITLE
Small docs clarifications from the release of 7.4.0

### DIFF
--- a/packages/turf-boolean-contains/README.md
+++ b/packages/turf-boolean-contains/README.md
@@ -4,8 +4,9 @@
 
 ## booleanContains
 
-Tests whether geometry a contains geometry b.
-The interiors of both geometries must intersect, and the interior and boundary of geometry b must not intersect the exterior of geometry a.
+booleanContains returns True if the second geometry is completely contained by the first geometry.
+The interiors of both geometries must intersect, and the interior and boundary of the second geometry must not intersect the exterior of the first geometry.
+
 booleanContains(a, b) is equivalent to booleanWithin(b, a)
 
 ### Parameters

--- a/packages/turf-boolean-contains/index.ts
+++ b/packages/turf-boolean-contains/index.ts
@@ -18,8 +18,9 @@ import { feature, featureCollection, lineString } from "@turf/helpers";
 import { lineSplit } from "@turf/line-split";
 
 /**
- * Tests whether geometry a contains geometry b.
- * The interiors of both geometries must intersect, and the interior and boundary of geometry b must not intersect the exterior of geometry a.
+ * booleanContains returns True if the second geometry is completely contained by the first geometry.
+ * The interiors of both geometries must intersect, and the interior and boundary of the second geometry must not intersect the exterior of the first geometry.
+ *
  * booleanContains(a, b) is equivalent to booleanWithin(b, a)
  *
  * @function

--- a/packages/turf-boolean-within/README.md
+++ b/packages/turf-boolean-within/README.md
@@ -4,8 +4,9 @@
 
 ## booleanWithin
 
-Tests whether geometry a is contained by geometry b.
+booleanWithin returns true if the first geometry is completely within the second geometry.
 The interiors of both geometries must intersect, and the interior and boundary of geometry a must not intersect the exterior of geometry b.
+
 booleanWithin(a, b) is equivalent to booleanContains(b, a)
 
 ### Parameters

--- a/packages/turf-boolean-within/index.ts
+++ b/packages/turf-boolean-within/index.ts
@@ -2,8 +2,9 @@ import { Feature, Geometry } from "geojson";
 import { booleanContains } from "@turf/boolean-contains";
 
 /**
- * Tests whether geometry a is contained by geometry b.
+ * booleanWithin returns true if the first geometry is completely within the second geometry.
  * The interiors of both geometries must intersect, and the interior and boundary of geometry a must not intersect the exterior of geometry b.
+ *
  * booleanWithin(a, b) is equivalent to booleanContains(b, a)
  *
  * @function


### PR DESCRIPTION
I didn't love the new wording on boolean-within and boolean-contains docs, so I reverted it a bit by hand for the 7.4.0 website update. This brings the changes back into the main repo so that the next release won't need these manual fixes any more.