### PR TITLE
Update CI workflow for v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - support/6.x
+      - support/7.x
   pull_request:
     branches:
       - master
       - support/6.x
+      - support/7.x
 
 permissions:
   contents: read
@@ -20,7 +22,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x, 26.x]
+        node-version: [22, 24, 26]
+        include:
+          # support/7.x adds [18, 20]
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/7.x' && 18 || '' }}
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/7.x' && 20 || '' }}
+          # support/6.x adds [18, 20]
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/6.x' && 18 || '' }}
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/6.x' && 20 || '' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24, 26]
-        include:
-          # support/7.x adds [18, 20]
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/7.x' && 18 || '' }}
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/7.x' && 20 || '' }}
-          # support/6.x adds [18, 20]
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/6.x' && 18 || '' }}
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'support/6.x' && 20 || '' }}
+        node-version: [18, 20, 22, 24, 26]
+        exclude:
+          # master (v8) removes [18, 20]
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 18 || '' }}
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 20 || '' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - master
-      - support/6.x
-      - support/7.x
   pull_request:
     branches:
       - master
-      - support/6.x
-      - support/7.x
 
 permissions:
   contents: read
@@ -22,11 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22, 24, 26]
-        exclude:
-          # master (v8) removes [18, 20]
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 18 || '' }}
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 20 || '' }}
+        node-version: [22, 24, 26]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Removes node@18, node@20 from `master` CI to align with our goals of dropping support for CJS entirely.

The workflows for `support/6.x` and `support/7.x` are actually owned by those branches and so we can safely delete that handling from the version on `master`.

`support/7.x` CI tested
- pre-merge https://github.com/Turfjs/turf/pull/3123
- post-merge https://github.com/Turfjs/turf/pull/3127

