### PR TITLE
Update CI again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24, 26]
+        node-version: [18, 20, 22, 24, 26]
+        exclude:
+          # master (v8) removes [18, 20]
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 18 || '' }}
+          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 20 || '' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Another attempt because https://github.com/Turfjs/turf/pull/3121 was not correct.

support/7.x actually winds up using the merged workflow from master, so go back to the messier `exclude` rules