### PR TITLE
Update support/7.x CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,10 @@ name: CI build
 on:
   push:
     branches:
-      - master
-      - support/6.x
+      - support/7.x
   pull_request:
     branches:
-      - master
-      - support/6.x
+      - support/7.x
 
 permissions:
   contents: read


### PR DESCRIPTION
The support/7.x workflows need to actually filter on this branch, or the conditions won't match.