### PR TITLE
Revert "Update CI again"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22, 24, 26]
-        exclude:
-          # master (v8) removes [18, 20]
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 18 || '' }}
-          - node-version: ${{ (github.base_ref || github.ref_name) == 'master' && 20 || '' }}
+        node-version: [22, 24, 26]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Reverts Turfjs/turf#3128

This was incorrect and we need to do https://github.com/Turfjs/turf/pull/3130 instead.