### PR TITLE
Ban top-level await

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,21 @@ export default tsEslint.config(
       "prefer-const": "off",
     },
   },
+  // ban top-level await in our source files
+  // Node's commonjs require() of ESM syntax requires that they be synchronous
+  {
+    files: ["packages/*/index.ts", "packages/*/lib/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "AwaitExpression[argument.type!='AwaitExpression'][parent.type!='FunctionExpression'][parent.type!='FunctionDeclaration'][parent.type!='ArrowFunctionExpression']",
+          message: "Top-level await is not allowed.",
+        },
+      ],
+    },
+  },
   {
     files: ["packages/*/types.ts", "packages/*/test.ts"],
 


### PR DESCRIPTION
This is a bit of a safeguard, as node may throw [ERR_REQUIRE_ASYNC_MODULE](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) if this syntax gets used.