### PR TITLE
Add prettier and eslint caching for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pnpm-debug.log*
 
 # build caches
 .nx
+.eslintcache
 
 # editor-specific
 .vscode

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "docs": "node ./scripts/generate-readmes.mts",
     "lint": "pnpm run /lint:.*/",
     "lint:docs": "documentation lint packages/turf-*/index.js",
-    "lint:eslint": "eslint packages",
+    "lint:eslint": "eslint --cache packages",
     "lint:mrl": "mrl check",
-    "lint:prettier": "prettier --check .",
+    "lint:prettier": "prettier --cache --check .",
     "prepare": "husky && lerna run build",
     "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
   },
@@ -18,7 +18,7 @@
     "**/*.{js,ts}": [
       "eslint --fix"
     ],
-    "packages/*/index.{js,ts}": [
+    "packages/*/index.ts": [
       "node ./scripts/generate-readmes.mts",
       "git add ./packages/*/README.md"
     ],


### PR DESCRIPTION
- Thanks to @smallsaucepan in #2988 for these changes
- Deliberately not using this in CI. Prettier takes about 30s, may revisit cache rehydration later
- Also cleans up the lint-staged README generation config, which no longer has to worry about .js files

Subsequent eslint/prettier runs are much faster (m4 macbook pro)
```
% time pnpm lint:prettier
$ prettier --cache --check .
Checking formatting...
All matched files use Prettier code style!
pnpm lint:prettier  14.26s user 1.19s system 141% cpu 10.892 total

% time pnpm lint:prettier
$ prettier --cache --check .
Checking formatting...
All matched files use Prettier code style!
pnpm lint:prettier  1.93s user 0.74s system 134% cpu 1.985 total

% time pnpm lint:eslint
$ eslint --cache packages
pnpm lint:eslint  5.42s user 0.44s system 178% cpu 3.281 total

% time pnpm lint:eslint
$ eslint --cache packages
pnpm lint:eslint  0.83s user 0.18s system 135% cpu 0.743 total
```