### PR TITLE
TypeScript v7

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -194,7 +194,7 @@ export default {
       options: {
         scripts: {
           "test:types":
-            "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts",
+            "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts",
         },
       },
       includePackages: TYPES_PACKAGES,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "meow": "^13.2.0",
     "prettier": "^3.9.4",
     "progress": "^2.0.3",
-    "typescript": "^5.9.3",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.66.0",
     "yaml": "^2.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@monorepolint/core": "0.6.0-alpha.6",
     "@monorepolint/rules": "0.6.0-alpha.6",
     "@types/node": "22.15.3",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "acorn": "^8.17.0",
     "camelcase": "^8.0.0",
     "d3-queue": "^3.0.7",
@@ -51,7 +52,7 @@
     "meow": "^13.2.0",
     "prettier": "^3.9.4",
     "progress": "^2.0.3",
-    "typescript": "catalog:",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.66.0",
     "yaml": "^2.9.0"
   },

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -44,7 +44,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -47,7 +47,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/center": "workspace:*",

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -39,7 +39,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@placemarkio/check-geojson": "^0.1.14",

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -42,7 +42,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/meta": "workspace:*",

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -47,7 +47,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/centroid": "workspace:*",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -46,7 +46,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/centroid": "workspace:*",

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -44,7 +44,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -39,7 +39,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-geojson-rbush/package.json
+++ b/packages/turf-geojson-rbush/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -46,7 +46,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -49,7 +49,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -38,7 +38,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -42,7 +42,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/envelope": "workspace:*",

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -38,7 +38,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/meta": "workspace:*",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -46,7 +46,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -44,7 +44,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -38,7 +38,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -1323,16 +1323,20 @@ function lineEach<P extends GeoJsonProperties = GeoJsonProperties>(
   // validation
   if (!geojson) throw new Error("geojson is required");
 
+  // @ts-expect-error: Known type conflict
   flattenEach(geojson, function (feature, featureIndex, multiFeatureIndex) {
     if (feature.geometry === null) return;
     var type = feature.geometry.type;
+    // @ts-expect-error: Known type conflict
     var coords = feature.geometry.coordinates;
     switch (type) {
+      // @ts-expect-error: Known type conflict
       case "LineString":
         // @ts-expect-error: Known type conflict
         if (callback(feature, featureIndex, multiFeatureIndex, 0, 0) === false)
           return false;
         break;
+      // @ts-expect-error: Known type conflict
       case "Polygon":
         for (
           var geometryIndex = 0;
@@ -1342,7 +1346,6 @@ function lineEach<P extends GeoJsonProperties = GeoJsonProperties>(
           if (
             // @ts-expect-error: Known type conflict
             callback(
-              // @ts-expect-error: Known type conflict
               lineString(coords[geometryIndex], feature.properties),
               featureIndex,
               multiFeatureIndex,

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -60,7 +60,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/random": "workspace:*",

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -39,7 +39,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/along": "workspace:*",

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/circle": "workspace:*",

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/circle": "workspace:*",

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -44,7 +44,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -44,7 +44,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -51,7 +51,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -42,7 +42,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/random": "workspace:*",

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -38,7 +38,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -47,7 +47,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/truncate": "workspace:*",

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/bbox-polygon": "workspace:*",

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -42,7 +42,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@types/benchmark": "catalog:",

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
-    "test:types": "tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
+    "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"
   },
   "devDependencies": {
     "@turf/kinks": "workspace:*",

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -72,7 +72,7 @@
     "glob": "^11.1.0",
     "tape": "^5.10.2",
     "tsx": "^4.22.4",
-    "typescript": "^5.9.3"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@turf/along": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,11 @@ catalogs:
       specifier: ^4.22.4
       version: 4.22.4
     typescript:
-      specifier: ^5.9.3
+      specifier: ^6.0.3
+      version: 6.0.3
+  typescript5:
+    typescript:
+      specifier: 5.9.3
       version: 5.9.3
 
 overrides:
@@ -316,11 +320,11 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: 'catalog:'
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.66.0
-        version: 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
+        version: 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -701,8 +705,8 @@ importers:
         specifier: ^4.22.4
         version: 4.22.4
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: 'catalog:'
+        version: 6.0.3
 
   packages/turf-along:
     dependencies:
@@ -745,7 +749,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-angle:
     dependencies:
@@ -794,7 +798,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -831,7 +835,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -865,7 +869,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-bbox-clip:
     dependencies:
@@ -902,7 +906,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -933,7 +937,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-bearing:
     dependencies:
@@ -967,7 +971,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1004,7 +1008,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1041,7 +1045,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-concave:
     dependencies:
@@ -1075,7 +1079,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-contains:
     dependencies:
@@ -1127,7 +1131,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-crosses:
     dependencies:
@@ -1176,7 +1180,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-disjoint:
     dependencies:
@@ -1222,7 +1226,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-equal:
     dependencies:
@@ -1265,7 +1269,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-intersects:
     dependencies:
@@ -1299,7 +1303,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-overlap:
     dependencies:
@@ -1348,7 +1352,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-parallel:
     dependencies:
@@ -1388,7 +1392,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1425,7 +1429,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-point-on-line:
     dependencies:
@@ -1459,7 +1463,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1508,7 +1512,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-valid:
     dependencies:
@@ -1572,7 +1576,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-boolean-within:
     dependencies:
@@ -1612,7 +1616,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-buffer:
     dependencies:
@@ -1664,13 +1668,13 @@ importers:
         version: 5.10.2
       tstyche:
         specifier: 'catalog:'
-        version: 6.2.0(typescript@5.9.3)
+        version: 6.2.0(typescript@6.0.3)
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1713,7 +1717,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1759,7 +1763,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1817,7 +1821,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1863,7 +1867,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1900,7 +1904,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1943,7 +1947,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1989,7 +1993,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2023,7 +2027,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-clusters:
     dependencies:
@@ -2054,7 +2058,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-clusters-dbscan:
     dependencies:
@@ -2112,7 +2116,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2176,7 +2180,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2219,7 +2223,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-combine:
     dependencies:
@@ -2250,7 +2254,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-concave:
     dependencies:
@@ -2308,7 +2312,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2351,7 +2355,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2391,7 +2395,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2431,7 +2435,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2483,7 +2487,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2529,7 +2533,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2566,7 +2570,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2609,7 +2613,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2673,7 +2677,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2713,7 +2717,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-explode:
     dependencies:
@@ -2747,7 +2751,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2784,7 +2788,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2824,7 +2828,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2876,7 +2880,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2919,7 +2923,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2947,7 +2951,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-hex-grid:
     dependencies:
@@ -2993,7 +2997,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3063,7 +3067,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3103,7 +3107,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3134,7 +3138,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-isobands:
     dependencies:
@@ -3198,7 +3202,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3256,7 +3260,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3293,7 +3297,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3333,7 +3337,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3376,7 +3380,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3422,7 +3426,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3465,7 +3469,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3505,13 +3509,13 @@ importers:
         version: 5.10.2
       tstyche:
         specifier: 'catalog:'
-        version: 6.2.0(typescript@5.9.3)
+        version: 6.2.0(typescript@6.0.3)
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3569,7 +3573,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3609,7 +3613,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3652,7 +3656,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3701,7 +3705,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-line-split:
     dependencies:
@@ -3756,7 +3760,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3799,7 +3803,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3842,7 +3846,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3876,7 +3880,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-midpoint:
     dependencies:
@@ -3913,7 +3917,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-moran-index:
     dependencies:
@@ -3950,7 +3954,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4008,7 +4012,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4051,7 +4055,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4103,7 +4107,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4155,7 +4159,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4189,7 +4193,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-point-grid:
     dependencies:
@@ -4235,7 +4239,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4284,7 +4288,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4345,7 +4349,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4394,7 +4398,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4431,7 +4435,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-polygon-smooth:
     dependencies:
@@ -4465,7 +4469,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4514,7 +4518,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4551,7 +4555,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4597,7 +4601,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4643,7 +4647,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4704,7 +4708,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4735,7 +4739,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-rectangle-grid:
     dependencies:
@@ -4778,7 +4782,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4824,7 +4828,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4861,7 +4865,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4901,7 +4905,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4941,7 +4945,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4972,7 +4976,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-sector:
     dependencies:
@@ -5018,7 +5022,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5079,7 +5083,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5125,7 +5129,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5159,7 +5163,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-square-grid:
     dependencies:
@@ -5196,7 +5200,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5251,7 +5255,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5294,7 +5298,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-tesselate:
     dependencies:
@@ -5328,7 +5332,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-tin:
     dependencies:
@@ -5356,7 +5360,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/turf-transform-rotate:
     dependencies:
@@ -5411,7 +5415,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5481,7 +5485,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5530,7 +5534,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5576,7 +5580,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5613,7 +5617,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5653,7 +5657,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5705,7 +5709,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5751,7 +5755,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5775,7 +5779,7 @@ importers:
         version: link:../../packages/turf
     devDependencies:
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript5
         version: 5.9.3
 
   test/ts-bundler-esm:
@@ -5785,7 +5789,7 @@ importers:
         version: link:../../packages/turf
     devDependencies:
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript5
         version: 5.9.3
 
   test/ts-node-cjs:
@@ -5795,7 +5799,7 @@ importers:
         version: link:../../packages/turf
     devDependencies:
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript5
         version: 5.9.3
 
   test/ts-node-esm:
@@ -5805,7 +5809,7 @@ importers:
         version: link:../../packages/turf
     devDependencies:
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript5
         version: 5.9.3
 
 packages:
@@ -9985,6 +9989,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -11176,31 +11185,31 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3))(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
       eslint: 10.8.0(supports-color@9.4.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 10.8.0(supports-color@9.4.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11213,6 +11222,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.66.0(supports-color@9.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.66.0
+      debug: 4.4.3(supports-color@9.4.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.66.0':
     dependencies:
       '@typescript-eslint/types': 8.66.0
@@ -11222,15 +11240,19 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 10.8.0(supports-color@9.4.0)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11251,14 +11273,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(supports-color@9.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@9.4.0)
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@9.4.0))
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
       eslint: 10.8.0(supports-color@9.4.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15102,6 +15139,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -15110,9 +15151,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tstyche@6.2.0(typescript@5.9.3):
+  tstyche@6.2.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tsx@4.22.4:
     dependencies:
@@ -15179,18 +15220,20 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3):
+  typescript-eslint@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3))(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
       eslint: 10.8.0(supports-color@9.4.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ catalogs:
       specifier: ^4.22.4
       version: 4.22.4
     typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
+      specifier: ^7.0.2
+      version: 7.0.2
   typescript5:
     typescript:
       specifier: 5.9.3
@@ -262,6 +262,9 @@ importers:
       '@types/node':
         specifier: 22.15.3
         version: 22.15.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
       acorn:
         specifier: ^8.17.0
         version: 8.17.0
@@ -320,11 +323,11 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-eslint:
         specifier: ^8.66.0
-        version: 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+        version: 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -706,7 +709,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-along:
     dependencies:
@@ -749,7 +752,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-angle:
     dependencies:
@@ -798,7 +801,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -835,7 +838,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -869,7 +872,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-bbox-clip:
     dependencies:
@@ -906,7 +909,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -937,7 +940,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-bearing:
     dependencies:
@@ -971,7 +974,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1008,7 +1011,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1045,7 +1048,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-concave:
     dependencies:
@@ -1079,7 +1082,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-contains:
     dependencies:
@@ -1131,7 +1134,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-crosses:
     dependencies:
@@ -1180,7 +1183,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-disjoint:
     dependencies:
@@ -1226,7 +1229,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-equal:
     dependencies:
@@ -1269,7 +1272,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-intersects:
     dependencies:
@@ -1303,7 +1306,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-overlap:
     dependencies:
@@ -1352,7 +1355,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-parallel:
     dependencies:
@@ -1392,7 +1395,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1429,7 +1432,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-point-on-line:
     dependencies:
@@ -1463,7 +1466,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1512,7 +1515,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-valid:
     dependencies:
@@ -1576,7 +1579,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-boolean-within:
     dependencies:
@@ -1616,7 +1619,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-buffer:
     dependencies:
@@ -1668,13 +1671,13 @@ importers:
         version: 5.10.2
       tstyche:
         specifier: 'catalog:'
-        version: 6.2.0(typescript@6.0.3)
+        version: 6.2.0(typescript@7.0.2)
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1717,7 +1720,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1763,7 +1766,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1821,7 +1824,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1867,7 +1870,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1904,7 +1907,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1947,7 +1950,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1993,7 +1996,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2027,7 +2030,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-clusters:
     dependencies:
@@ -2058,7 +2061,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-clusters-dbscan:
     dependencies:
@@ -2116,7 +2119,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2180,7 +2183,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2223,7 +2226,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-combine:
     dependencies:
@@ -2254,7 +2257,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-concave:
     dependencies:
@@ -2312,7 +2315,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2355,7 +2358,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2395,7 +2398,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2435,7 +2438,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2487,7 +2490,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2533,7 +2536,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2570,7 +2573,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2613,7 +2616,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2677,7 +2680,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2717,7 +2720,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-explode:
     dependencies:
@@ -2751,7 +2754,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2788,7 +2791,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2828,7 +2831,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2880,7 +2883,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2923,7 +2926,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2951,7 +2954,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-hex-grid:
     dependencies:
@@ -2997,7 +3000,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3067,7 +3070,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3107,7 +3110,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3138,7 +3141,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-isobands:
     dependencies:
@@ -3202,7 +3205,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3260,7 +3263,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3297,7 +3300,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3337,7 +3340,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3380,7 +3383,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3426,7 +3429,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3469,7 +3472,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3509,13 +3512,13 @@ importers:
         version: 5.10.2
       tstyche:
         specifier: 'catalog:'
-        version: 6.2.0(typescript@6.0.3)
+        version: 6.2.0(typescript@7.0.2)
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3573,7 +3576,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3613,7 +3616,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3656,7 +3659,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3705,7 +3708,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-line-split:
     dependencies:
@@ -3760,7 +3763,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3803,7 +3806,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3846,7 +3849,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3880,7 +3883,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-midpoint:
     dependencies:
@@ -3917,7 +3920,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-moran-index:
     dependencies:
@@ -3954,7 +3957,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4012,7 +4015,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4055,7 +4058,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4107,7 +4110,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4159,7 +4162,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4193,7 +4196,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-point-grid:
     dependencies:
@@ -4239,7 +4242,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4288,7 +4291,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4349,7 +4352,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4398,7 +4401,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4435,7 +4438,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-polygon-smooth:
     dependencies:
@@ -4469,7 +4472,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4518,7 +4521,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4555,7 +4558,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4601,7 +4604,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4647,7 +4650,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4708,7 +4711,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4739,7 +4742,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-rectangle-grid:
     dependencies:
@@ -4782,7 +4785,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4828,7 +4831,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4865,7 +4868,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4905,7 +4908,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4945,7 +4948,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4976,7 +4979,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-sector:
     dependencies:
@@ -5022,7 +5025,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5083,7 +5086,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5129,7 +5132,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5163,7 +5166,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-square-grid:
     dependencies:
@@ -5200,7 +5203,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5255,7 +5258,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5298,7 +5301,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-tesselate:
     dependencies:
@@ -5332,7 +5335,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-tin:
     dependencies:
@@ -5360,7 +5363,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/turf-transform-rotate:
     dependencies:
@@ -5415,7 +5418,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5485,7 +5488,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5534,7 +5537,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5580,7 +5583,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5617,7 +5620,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5657,7 +5660,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5709,7 +5712,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5755,7 +5758,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       write-json-file:
         specifier: ^6.0.0
         version: 6.0.0
@@ -6782,6 +6785,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.66.0':
     resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@vue/compiler-core@3.5.39':
     resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
@@ -9994,6 +10121,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -11185,31 +11317,40 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
+      '@typescript-eslint/utils': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
       '@typescript-eslint/visitor-keys': 8.66.0
       eslint: 10.8.0(supports-color@9.4.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)
       '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 10.8.0(supports-color@9.4.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.66.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/types': 8.66.0
+      debug: 4.4.3(supports-color@9.4.0)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -11222,41 +11363,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.66.0(supports-color@9.4.0)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.66.0
-      debug: 4.4.3(supports-color@9.4.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@8.66.0':
     dependencies:
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
 
+  '@typescript-eslint/tsconfig-utils@8.66.0(@typescript/typescript6@6.0.2)':
+    dependencies:
+      typescript: '@typescript/typescript6@6.0.2'
+
   '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)
+      '@typescript-eslint/utils': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 10.8.0(supports-color@9.4.0)
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.66.0': {}
+
+  '@typescript-eslint/typescript-estree@8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@9.4.0)
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/typescript-estree@8.66.0(supports-color@9.4.0)(typescript@5.9.3)':
     dependencies:
@@ -11273,29 +11420,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.66.0(supports-color@9.4.0)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/visitor-keys': 8.66.0
-      debug: 4.4.3(supports-color@9.4.0)
-      minimatch: 10.2.5
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@9.4.0))
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)
       eslint: 10.8.0(supports-color@9.4.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -11303,6 +11435,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@vue/compiler-core@3.5.39':
     dependencies:
@@ -15135,13 +15331,13 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
+    dependencies:
+      typescript: '@typescript/typescript6@6.0.2'
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  ts-api-utils@2.5.0(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -15151,9 +15347,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tstyche@6.2.0(typescript@6.0.3):
+  tstyche@6.2.0(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tsx@4.22.4:
     dependencies:
@@ -15220,20 +15416,43 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3):
+  typescript-eslint@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@9.4.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
+      '@typescript-eslint/parser': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
+      '@typescript-eslint/typescript-estree': 8.66.0(@typescript/typescript6@6.0.2)(supports-color@9.4.0)
+      '@typescript-eslint/utils': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(supports-color@9.4.0))(supports-color@9.4.0)
       eslint: 10.8.0(supports-color@9.4.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uglify-js@3.19.3:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   tape: ^5.10.2
   tstyche: ^6.2.0
   tsx: ^4.22.4
-  typescript: ^6.0.3
+  typescript: ^7.0.2
 
 catalogs:
   # keep a named catalog of typescript@5 for the consumer tests

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,12 @@ catalog:
   tape: ^5.10.2
   tstyche: ^6.2.0
   tsx: ^4.22.4
-  typescript: ^5.9.3
+  typescript: ^6.0.3
+
+catalogs:
+  # keep a named catalog of typescript@5 for the consumer tests
+  typescript5:
+    typescript: 5.9.3
 
 overrides:
   # we do not use the vue capabilities of documentation, so remove this optional dependency

--- a/test/ts-bundler-cjs/package.json
+++ b/test/ts-bundler-cjs/package.json
@@ -10,7 +10,7 @@
     "test:ts": "tsc"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript5"
   },
   "dependencies": {
     "@turf/turf": "workspace:*"

--- a/test/ts-bundler-esm/package.json
+++ b/test/ts-bundler-esm/package.json
@@ -11,7 +11,7 @@
     "test:ts": "tsc"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript5"
   },
   "dependencies": {
     "@turf/turf": "workspace:*"

--- a/test/ts-node-cjs/package.json
+++ b/test/ts-node-cjs/package.json
@@ -10,7 +10,7 @@
     "test:ts": "tsc"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript5"
   },
   "dependencies": {
     "@turf/turf": "workspace:*"

--- a/test/ts-node-esm/package.json
+++ b/test/ts-node-esm/package.json
@@ -11,7 +11,7 @@
     "test:ts": "tsc"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript5"
   },
   "dependencies": {
     "@turf/turf": "workspace:*"

--- a/tsconfig.types.shared.json
+++ b/tsconfig.types.shared.json
@@ -1,0 +1,6 @@
+{
+  "include": ["${configDir}/types.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
VSCode needs a new extension (TypeScript 7) to be installed before the editor uses typescript@7.

@turf/meta shows that typescript@6 and typescript@7 are different-ish when using @ts-ignore-error. This package needs a rework anyhow though for turf@8.

Finally, we need to run TypeScript in [side-by-side mode](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0) for typescript-eslint to continue working, [at least until typescript@7.1](https://github.com/typescript-eslint/typescript-eslint/issues/10940). Similarly, [tstyche](https://github.com/tstyche/tstyche/issues/443) is also blocked at the moment in their v7 support.

(re-created as an un-stacked PR so that the build would run for timing purposes)

CI timings to get through `pnpm install --frozen-lockfile` which includes the build step:

```
typescript 6
node 22 3:09
node 24 2:41
node 26 2:47

typescript 7
node 22 1:22
node 24 1:29
node 26 1:30
```