### PR TITLE
fix(square): return a bounding box that surrounds the input

### DIFF
--- a/packages/turf-square/index.ts
+++ b/packages/turf-square/index.ts
@@ -1,4 +1,3 @@
-import { distance } from "@turf/distance";
 import { BBox } from "geojson";
 
 /**
@@ -21,22 +20,24 @@ function square(bbox: BBox): BBox {
   var east = bbox[2];
   var north = bbox[3];
 
-  var horizontalDistance = distance(bbox.slice(0, 2), [east, south]);
-  var verticalDistance = distance(bbox.slice(0, 2), [west, north]);
-  if (horizontalDistance >= verticalDistance) {
+  // Spans are compared in degrees, the same units they are grown in below, so
+  // that the result always surrounds the input.
+  var horizontalSpan = east - west;
+  var verticalSpan = north - south;
+  if (horizontalSpan >= verticalSpan) {
     var verticalMidpoint = (south + north) / 2;
     return [
       west,
-      verticalMidpoint - (east - west) / 2,
+      verticalMidpoint - horizontalSpan / 2,
       east,
-      verticalMidpoint + (east - west) / 2,
+      verticalMidpoint + horizontalSpan / 2,
     ];
   } else {
     var horizontalMidpoint = (west + east) / 2;
     return [
-      horizontalMidpoint - (north - south) / 2,
+      horizontalMidpoint - verticalSpan / 2,
       south,
-      horizontalMidpoint + (north - south) / 2,
+      horizontalMidpoint + verticalSpan / 2,
       north,
     ];
   }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -3,6 +3,9 @@
   "version": "7.4.0",
   "description": "Takes a bounding box and calculates the minimum square bounding box that would contain the input.",
   "author": "Turf Authors",
+  "contributors": [
+    "Jayesh Bhade <@Jaybhade>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Turfjs/turf/issues"
@@ -49,7 +52,6 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@turf/distance": "workspace:*",
     "@turf/helpers": "workspace:*",
     "@types/geojson": "catalog:"
   },

--- a/packages/turf-square/test.ts
+++ b/packages/turf-square/test.ts
@@ -13,3 +13,14 @@ test("square", function (t) {
   t.deepEqual(sq2, [0, -2.5, 10, 7.5]);
   t.end();
 });
+
+test("square -- surrounds the input away from the equator", function (t) {
+  // Wider than they are tall in degrees, but the great circle distance along
+  // their southern edge is the shorter of the two.
+  const bbox1: BBox = [0, 60, 10, 66];
+  const bbox2: BBox = [100, -70, 112, -63];
+
+  t.deepEqual(square(bbox1), [0, 58, 10, 68]);
+  t.deepEqual(square(bbox2), [100, -72.5, 112, -60.5]);
+  t.end();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5132,9 +5132,6 @@ importers:
 
   packages/turf-square:
     dependencies:
-      '@turf/distance':
-        specifier: workspace:*
-        version: link:../turf-distance
       '@turf/helpers':
         specifier: workspace:*
         version: link:../turf-helpers


### PR DESCRIPTION
## Summary

`@turf/square` documents itself as returning "the minimum square bounding box that would **contain** the input", but away from the equator it can return a box that cuts the input in half.

The function picks the longer side by comparing **great circle distances in kilometres**, and then grows the shorter side by a span measured in **degrees**:

```js
var horizontalDistance = distance(bbox.slice(0, 2), [east, south]); // km
var verticalDistance = distance(bbox.slice(0, 2), [west, north]);   // km
if (horizontalDistance >= verticalDistance) {
  // ... grows north/south by (east - west)   <- degrees
} else {
  // ... grows east/west by (north - south)   <- degrees
}
```

A degree of longitude is `cos(latitude)` as long on the ground as a degree of latitude, so the two measures disagree for any box whose aspect ratio falls between `cos(lat)` and `1`. Such a box is wider than it is tall in degrees, but has the *shorter* horizontal edge in kilometres, so it takes the `else` branch — and that branch sets the width to the height **in degrees**, which is narrower than the width it already had. The east and west of the input get chopped off.

Real bounding boxes hit this constantly:

| input | before | after |
| --- | --- | --- |
| Germany `[5.87, 47.27, 15.04, 55.06]` | `[6.56, 47.27, 14.35, 55.06]` — **1.38° of longitude cut off** | `[5.87, 46.58, 15.04, 55.75]` |
| Japan `[122.93, 24.4, 145.82, 45.55]` | `[123.8, 24.4, 144.95, 45.55]` — **1.74° cut off** | `[122.93, 23.53, 145.82, 46.42]` |

Over 200,000 randomly generated bounding boxes, **14.8%** came back not containing their input, the worst losing 15.2° of longitude.

## The change

Compare the spans in the same units they are grown in. That restores the documented guarantee, and the side of the result is `max(width, height)` — still the minimum square that contains the input.

Checked against the same 200,000 random boxes: every result now contains its input, is square, and has no slack beyond the longer input side. Behaviour at the equator — including both existing test cases and the JSDoc example — is unchanged, since that is exactly where the two measures agree.

`@turf/distance` is no longer used by the package, so its import and dependency entry are dropped.

## Not a fix for #1727

#1727 asks for a box that is square *on the ground* rather than square in degrees. That is a separate question about projection semantics — the two cannot both hold for an axis-aligned lat/lon box — and this PR does not touch it. It only makes the function stop returning a box smaller than the one it was given.

## Breaking change?

The output changes for inputs that were previously clipped (roughly 15% of boxes, all of them away from the equator). Those outputs were violating the function's documented contract, so this is a bug fix rather than an intentional behaviour change, but it is worth calling out for the v8 notes.

## Verification

- Added `square -- surrounds the input away from the equator` to `packages/turf-square/test.ts`, covering a northern and a southern case. It fails on `master` (2 of 4 assertions) and passes with the fix.
- `pnpm run lint` at root — eslint, prettier, monorepolint and documentation lint all clean.
- `pnpm exec lerna run test` at root — 119 of 121 packages pass. `@turf/directional-mean` and `@turf/standard-deviational-ellipse` fail on this machine, but they fail identically on a clean `master` checkout (last-digit floating point drift in their fixtures) and neither depends on `@turf/square`.
- `@turf/turf` `last-checks` — 326/326 pass.

---

- [x] Meaningful title, including the name of the package being modified.
- [x] Summary of the changes.
- [x] Heads up if this is a breaking change.
- [x] Any issues this resolves — none; deliberately not #1727, see above.
- [x] Inclusion of your details in the `contributors` field of `package.json`.
- [x] Confirmation you've read the steps for preparing a pull request.
