### PR TITLE
Use TypeScript project references

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -9,6 +9,7 @@ import {
   packageEntry,
   packageScript,
   requireDependency,
+  standardTsconfig,
   REMOVE,
 } from "@monorepolint/rules";
 
@@ -96,7 +97,7 @@ export default {
           // Example of a URL that will break: https://unpkg.com/@turf/turf/dist/turf.min.js
           // Example of a URL that will keep working: https://unpkg.com/@turf/turf
           browser: "turf.min.js",
-          files: ["dist", "turf.min.js"],
+          files: ["dist", "turf.min.js", "!**/*.tsbuildinfo"],
           exports: {
             "./package.json": "./package.json",
             ".": {
@@ -122,7 +123,7 @@ export default {
           module: REMOVE,
           types: REMOVE,
           sideEffects: false,
-          files: ["dist"],
+          files: ["dist", "!**/*.tsbuildinfo"],
           publishConfig: {
             access: "public",
           },
@@ -164,7 +165,7 @@ export default {
     packageScript({
       options: {
         scripts: {
-          build: "tsc",
+          build: "tsc --build",
         },
       },
       includePackages: PACKAGES,
@@ -174,7 +175,7 @@ export default {
       options: {
         scripts: {
           build:
-            "tsc && esbuild index.ts --bundle --minify --target=chrome109,edge147,firefox140,ios18.5,opera127,safari26.3 --outfile=turf.min.js",
+            "tsc --build && esbuild index.ts --bundle --minify --target=chrome109,edge147,firefox140,ios18.5,opera127,safari26.3 --outfile=turf.min.js",
         },
       },
       includePackages: [MAIN_PACKAGE],
@@ -242,6 +243,13 @@ export default {
         dependencies: {
           "@types/geojson": "catalog:",
         },
+      },
+      includePackages: [MAIN_PACKAGE, ...PACKAGES],
+    }),
+
+    standardTsconfig({
+      options: {
+        template: { extends: "../../tsconfig.shared.json" },
       },
       includePackages: [MAIN_PACKAGE, ...PACKAGES],
     }),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:eslint": "eslint --cache packages",
     "lint:mrl": "mrl check",
     "lint:prettier": "prettier --cache --check .",
-    "prepare": "husky && lerna run build",
+    "prepare": "husky && pnpm --filter @turf/turf build",
     "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:mrl": "mrl check",
     "lint:prettier": "prettier --cache --check .",
     "prepare": "husky && pnpm --filter @turf/turf build",
-    "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks"
+    "test": "pnpm run lint && lerna run test && lerna run --scope @turf/turf last-checks",
+    "watch": "pnpm --filter @turf/turf watch"
   },
   "lint-staged": {
     "package.json": [

--- a/packages/turf-along/package.json
+++ b/packages/turf-along/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-along/tsconfig.json
+++ b/packages/turf-along/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-angle/tsconfig.json
+++ b/packages/turf-angle/tsconfig.json
@@ -1,3 +1,26 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-rhumb-bearing"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-sector"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-area/tsconfig.json
+++ b/packages/turf-area/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-bbox-clip/tsconfig.json
+++ b/packages/turf-bbox-clip/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-bbox"
+    }
+  ]
 }

--- a/packages/turf-bbox-polygon/package.json
+++ b/packages/turf-bbox-polygon/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-bbox-polygon/tsconfig.json
+++ b/packages/turf-bbox-polygon/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-bbox/tsconfig.json
+++ b/packages/turf-bbox/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -30,11 +30,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-bearing/tsconfig.json
+++ b/packages/turf-bearing/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-destination"
+    }
+  ]
 }

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-bezier-spline/tsconfig.json
+++ b/packages/turf-bezier-spline/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-clockwise/package.json
+++ b/packages/turf-boolean-clockwise/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-clockwise/tsconfig.json
+++ b/packages/turf-boolean-clockwise/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-concave/package.json
+++ b/packages/turf-boolean-concave/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-concave/tsconfig.json
+++ b/packages/turf-boolean-concave/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-contains/package.json
+++ b/packages/turf-boolean-contains/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-contains/tsconfig.json
+++ b/packages/turf-boolean-contains/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-boolean-point-on-line"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-split"
+    }
+  ]
 }

--- a/packages/turf-boolean-crosses/package.json
+++ b/packages/turf-boolean-crosses/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-crosses/tsconfig.json
+++ b/packages/turf-boolean-crosses/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-equal"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-intersect"
+    },
+    {
+      "path": "../turf-polygon-to-line"
+    }
+  ]
 }

--- a/packages/turf-boolean-disjoint/package.json
+++ b/packages/turf-boolean-disjoint/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-disjoint/tsconfig.json
+++ b/packages/turf-boolean-disjoint/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-line-intersect"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-polygon-to-line"
+    }
+  ]
 }

--- a/packages/turf-boolean-equal/package.json
+++ b/packages/turf-boolean-equal/package.json
@@ -39,11 +39,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-equal/tsconfig.json
+++ b/packages/turf-boolean-equal/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clean-coords"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-intersects/package.json
+++ b/packages/turf-boolean-intersects/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-intersects/tsconfig.json
+++ b/packages/turf-boolean-intersects/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-disjoint"
+    }
+  ]
 }

--- a/packages/turf-boolean-overlap/package.json
+++ b/packages/turf-boolean-overlap/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-overlap/tsconfig.json
+++ b/packages/turf-boolean-overlap/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-intersect"
+    },
+    {
+      "path": "../turf-line-overlap"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -35,11 +35,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-parallel/tsconfig.json
+++ b/packages/turf-boolean-parallel/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clean-coords"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-line-segment"
+    },
+    {
+      "path": "../turf-rhumb-bearing"
+    }
+  ]
 }

--- a/packages/turf-boolean-point-in-polygon/package.json
+++ b/packages/turf-boolean-point-in-polygon/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-point-in-polygon/tsconfig.json
+++ b/packages/turf-boolean-point-in-polygon/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-point-on-line/tsconfig.json
+++ b/packages/turf-boolean-point-on-line/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-touches/package.json
+++ b/packages/turf-boolean-touches/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-boolean-touches/tsconfig.json
+++ b/packages/turf-boolean-touches/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-boolean-point-on-line"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-boolean-valid/package.json
+++ b/packages/turf-boolean-valid/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-boolean-valid/tsconfig.json
+++ b/packages/turf-boolean-valid/tsconfig.json
@@ -1,3 +1,32 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-boolean-crosses"
+    },
+    {
+      "path": "../turf-boolean-disjoint"
+    },
+    {
+      "path": "../turf-boolean-overlap"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-boolean-point-on-line"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-intersect"
+    }
+  ]
 }

--- a/packages/turf-boolean-within/package.json
+++ b/packages/turf-boolean-within/package.json
@@ -40,11 +40,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-boolean-within/tsconfig.json
+++ b/packages/turf-boolean-within/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-contains"
+    },
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -40,11 +40,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tstyche"

--- a/packages/turf-buffer/tsconfig.json
+++ b/packages/turf-buffer/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-center"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-projection"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-center-mean/tsconfig.json
+++ b/packages/turf-center-mean/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-center"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-center-median/tsconfig.json
+++ b/packages/turf-center-median/tsconfig.json
@@ -1,3 +1,32 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-center-mean"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-center"
+    },
+    {
+      "path": "../turf-center-of-mass"
+    },
+    {
+      "path": "../turf-random"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -30,11 +30,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-center-of-mass/tsconfig.json
+++ b/packages/turf-center-of-mass/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-convex"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-center/tsconfig.json
+++ b/packages/turf-center/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-centroid/tsconfig.json
+++ b/packages/turf-centroid/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-circle/tsconfig.json
+++ b/packages/turf-circle/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -35,11 +35,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-clean-coords/tsconfig.json
+++ b/packages/turf-clean-coords/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-on-line"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-clone/tsconfig.json
+++ b/packages/turf-clone/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -40,11 +40,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-clusters-dbscan/tsconfig.json
+++ b/packages/turf-clusters-dbscan/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-clusters"
+    }
+  ]
 }

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -39,11 +39,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-clusters-kmeans/tsconfig.json
+++ b/packages/turf-clusters-kmeans/tsconfig.json
@@ -1,3 +1,26 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-clusters"
+    },
+    {
+      "path": "../turf-random"
+    }
+  ]
 }

--- a/packages/turf-clusters/package.json
+++ b/packages/turf-clusters/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-clusters/tsconfig.json
+++ b/packages/turf-clusters/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-collect/package.json
+++ b/packages/turf-collect/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-collect/tsconfig.json
+++ b/packages/turf-collect/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-combine/package.json
+++ b/packages/turf-combine/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-combine/tsconfig.json
+++ b/packages/turf-combine/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -43,11 +43,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-concave/tsconfig.json
+++ b/packages/turf-concave/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-tin"
+    }
+  ]
 }

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-convex/tsconfig.json
+++ b/packages/turf-convex/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-destination/tsconfig.json
+++ b/packages/turf-destination/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -30,11 +30,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-difference/tsconfig.json
+++ b/packages/turf-difference/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-directional-mean/tsconfig.json
+++ b/packages/turf-directional-mean/tsconfig.json
@@ -1,3 +1,26 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-length"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-dissolve/tsconfig.json
+++ b/packages/turf-dissolve/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-flatten"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-distance-weight/tsconfig.json
+++ b/packages/turf-distance-weight/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-distance/tsconfig.json
+++ b/packages/turf-distance/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-ellipse/tsconfig.json
+++ b/packages/turf-ellipse/tsconfig.json
@@ -1,3 +1,35 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-transform-rotate"
+    },
+    {
+      "path": "../turf-area"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-circle"
+    },
+    {
+      "path": "../turf-intersect"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-envelope/package.json
+++ b/packages/turf-envelope/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-envelope/tsconfig.json
+++ b/packages/turf-envelope/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-explode/tsconfig.json
+++ b/packages/turf-explode/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-flatten/tsconfig.json
+++ b/packages/turf-flatten/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-flip/tsconfig.json
+++ b/packages/turf-flip/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-geojson-rbush/package.json
+++ b/packages/turf-geojson-rbush/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-geojson-rbush/tsconfig.json
+++ b/packages/turf-geojson-rbush/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-random"
+    }
+  ]
 }

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -39,11 +39,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-great-circle/tsconfig.json
+++ b/packages/turf-great-circle/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-helpers/package.json
+++ b/packages/turf-helpers/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-helpers/tsconfig.json
+++ b/packages/turf-helpers/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": []
 }

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -42,11 +42,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-hex-grid/tsconfig.json
+++ b/packages/turf-hex-grid/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-intersect"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-interpolate/tsconfig.json
+++ b/packages/turf-interpolate/tsconfig.json
@@ -1,3 +1,41 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-hex-grid"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-point-grid"
+    },
+    {
+      "path": "../turf-square-grid"
+    },
+    {
+      "path": "../turf-triangle-grid"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -31,11 +31,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-intersect/tsconfig.json
+++ b/packages/turf-intersect/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-invariant/package.json
+++ b/packages/turf-invariant/package.json
@@ -35,11 +35,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-invariant/tsconfig.json
+++ b/packages/turf-invariant/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -39,11 +39,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-isobands/tsconfig.json
+++ b/packages/turf-isobands/tsconfig.json
@@ -1,3 +1,41 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-area"
+    },
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-explode"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-envelope"
+    },
+    {
+      "path": "../turf-point-grid"
+    },
+    {
+      "path": "../turf-random"
+    },
+    {
+      "path": "../turf-rhumb-destination"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-isolines/tsconfig.json
+++ b/packages/turf-isolines/tsconfig.json
@@ -1,3 +1,32 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-envelope"
+    },
+    {
+      "path": "../turf-point-grid"
+    },
+    {
+      "path": "../turf-random"
+    },
+    {
+      "path": "../turf-rhumb-destination"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -31,11 +31,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-kinks/tsconfig.json
+++ b/packages/turf-kinks/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-length/tsconfig.json
+++ b/packages/turf-length/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-line-arc/tsconfig.json
+++ b/packages/turf-line-arc/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-circle"
+    },
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -39,11 +39,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-line-chunk/tsconfig.json
+++ b/packages/turf-line-chunk/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-length"
+    },
+    {
+      "path": "../turf-line-slice-along"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-line-intersect/tsconfig.json
+++ b/packages/turf-line-intersect/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tstyche"

--- a/packages/turf-line-offset/tsconfig.json
+++ b/packages/turf-line-offset/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-line-overlap/tsconfig.json
+++ b/packages/turf-line-overlap/tsconfig.json
@@ -1,3 +1,29 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-boolean-point-on-line"
+    },
+    {
+      "path": "../turf-geojson-rbush"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-segment"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-nearest-point-on-line"
+    }
+  ]
 }

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -31,11 +31,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-line-segment/tsconfig.json
+++ b/packages/turf-line-segment/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-line-slice-along/package.json
+++ b/packages/turf-line-slice-along/package.json
@@ -31,11 +31,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-line-slice-along/tsconfig.json
+++ b/packages/turf-line-slice-along/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-along"
+    },
+    {
+      "path": "../turf-length"
+    }
+  ]
 }

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -35,11 +35,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-line-slice/tsconfig.json
+++ b/packages/turf-line-slice/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-nearest-point-on-line"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-line-split/tsconfig.json
+++ b/packages/turf-line-split/tsconfig.json
@@ -1,3 +1,32 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-geojson-rbush"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-intersect"
+    },
+    {
+      "path": "../turf-line-segment"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-nearest-point-on-line"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-line-to-polygon/tsconfig.json
+++ b/packages/turf-line-to-polygon/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -31,11 +31,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-mask/tsconfig.json
+++ b/packages/turf-mask/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-meta/package.json
+++ b/packages/turf-meta/package.json
@@ -53,11 +53,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-meta/tsconfig.json
+++ b/packages/turf-meta/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-random"
+    }
+  ]
 }

--- a/packages/turf-midpoint/package.json
+++ b/packages/turf-midpoint/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-midpoint/tsconfig.json
+++ b/packages/turf-midpoint/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-moran-index/tsconfig.json
+++ b/packages/turf-moran-index/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-distance-weight"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-nearest-neighbor-analysis/tsconfig.json
+++ b/packages/turf-nearest-neighbor-analysis/tsconfig.json
@@ -1,3 +1,32 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-area"
+    },
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-nearest-point"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-nearest-point-on-line/tsconfig.json
+++ b/packages/turf-nearest-point-on-line/tsconfig.json
@@ -1,3 +1,26 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-along"
+    },
+    {
+      "path": "../turf-length"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-nearest-point-to-line/tsconfig.json
+++ b/packages/turf-nearest-point-to-line/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-point-to-line-distance"
+    },
+    {
+      "path": "../turf-circle"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-nearest-point/tsconfig.json
+++ b/packages/turf-nearest-point/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-planepoint/package.json
+++ b/packages/turf-planepoint/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-planepoint/tsconfig.json
+++ b/packages/turf-planepoint/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-point-grid/tsconfig.json
+++ b/packages/turf-point-grid/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-within"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-point-on-feature/tsconfig.json
+++ b/packages/turf-point-on-feature/tsconfig.json
@@ -1,3 +1,26 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-center"
+    },
+    {
+      "path": "../turf-explode"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-nearest-point"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-point-to-line-distance/tsconfig.json
+++ b/packages/turf-point-to-line-distance/tsconfig.json
@@ -1,3 +1,35 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-nearest-point-on-line"
+    },
+    {
+      "path": "../turf-projection"
+    },
+    {
+      "path": "../turf-rhumb-bearing"
+    },
+    {
+      "path": "../turf-rhumb-distance"
+    },
+    {
+      "path": "../turf-circle"
+    }
+  ]
 }

--- a/packages/turf-point-to-polygon-distance/package.json
+++ b/packages/turf-point-to-polygon-distance/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-point-to-polygon-distance/tsconfig.json
+++ b/packages/turf-point-to-polygon-distance/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-point-to-line-distance"
+    },
+    {
+      "path": "../turf-polygon-to-line"
+    }
+  ]
 }

--- a/packages/turf-points-within-polygon/package.json
+++ b/packages/turf-points-within-polygon/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-points-within-polygon/tsconfig.json
+++ b/packages/turf-points-within-polygon/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-polygon-smooth/tsconfig.json
+++ b/packages/turf-polygon-smooth/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-polygon-tangents/tsconfig.json
+++ b/packages/turf-polygon-tangents/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-boolean-within"
+    },
+    {
+      "path": "../turf-explode"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-nearest-point"
+    }
+  ]
 }

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-polygon-to-line/tsconfig.json
+++ b/packages/turf-polygon-to-line/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -37,11 +37,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-polygonize/tsconfig.json
+++ b/packages/turf-polygonize/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-envelope"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -44,11 +44,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-projection/tsconfig.json
+++ b/packages/turf-projection/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-quadrat-analysis/tsconfig.json
+++ b/packages/turf-quadrat-analysis/tsconfig.json
@@ -1,3 +1,35 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-area"
+    },
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-point-grid"
+    },
+    {
+      "path": "../turf-random"
+    },
+    {
+      "path": "../turf-square-grid"
+    },
+    {
+      "path": "../turf-nearest-neighbor-analysis"
+    }
+  ]
 }

--- a/packages/turf-random/package.json
+++ b/packages/turf-random/package.json
@@ -30,11 +30,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-random/tsconfig.json
+++ b/packages/turf-random/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-rectangle-grid/tsconfig.json
+++ b/packages/turf-rectangle-grid/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-intersects"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-rewind/tsconfig.json
+++ b/packages/turf-rewind/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-clockwise"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-rhumb-bearing/tsconfig.json
+++ b/packages/turf-rhumb-bearing/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-destination"
+    }
+  ]
 }

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -42,11 +42,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-rhumb-destination/tsconfig.json
+++ b/packages/turf-rhumb-destination/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -40,11 +40,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-rhumb-distance/tsconfig.json
+++ b/packages/turf-rhumb-distance/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-distance"
+    }
+  ]
 }

--- a/packages/turf-sample/package.json
+++ b/packages/turf-sample/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-sample/tsconfig.json
+++ b/packages/turf-sample/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -30,11 +30,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-sector/tsconfig.json
+++ b/packages/turf-sector/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-circle"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-line-arc"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-shortest-path/tsconfig.json
+++ b/packages/turf-shortest-path/tsconfig.json
@@ -1,3 +1,35 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-clean-coords"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-transform-scale"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-simplify/tsconfig.json
+++ b/packages/turf-simplify/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clean-coords"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-square-grid/tsconfig.json
+++ b/packages/turf-square-grid/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-rectangle-grid"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-square/package.json
+++ b/packages/turf-square/package.json
@@ -32,11 +32,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-square/tsconfig.json
+++ b/packages/turf-square/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -35,11 +35,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-standard-deviational-ellipse/tsconfig.json
+++ b/packages/turf-standard-deviational-ellipse/tsconfig.json
@@ -1,3 +1,29 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-center-mean"
+    },
+    {
+      "path": "../turf-ellipse"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-points-within-polygon"
+    },
+    {
+      "path": "../turf-random"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-tag/package.json
+++ b/packages/turf-tag/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-tag/tsconfig.json
+++ b/packages/turf-tag/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-tesselate/package.json
+++ b/packages/turf-tesselate/package.json
@@ -41,11 +41,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-tesselate/tsconfig.json
+++ b/packages/turf-tesselate/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-tin/package.json
+++ b/packages/turf-tin/package.json
@@ -31,11 +31,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-tin/tsconfig.json
+++ b/packages/turf-tin/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    }
+  ]
 }

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -36,11 +36,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-transform-rotate/tsconfig.json
+++ b/packages/turf-transform-rotate/tsconfig.json
@@ -1,3 +1,32 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-rhumb-bearing"
+    },
+    {
+      "path": "../turf-rhumb-destination"
+    },
+    {
+      "path": "../turf-rhumb-distance"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -40,11 +40,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-transform-scale/tsconfig.json
+++ b/packages/turf-transform-scale/tsconfig.json
@@ -1,3 +1,44 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-center"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-rhumb-bearing"
+    },
+    {
+      "path": "../turf-rhumb-destination"
+    },
+    {
+      "path": "../turf-rhumb-distance"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-hex-grid"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -38,11 +38,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-transform-translate/tsconfig.json
+++ b/packages/turf-transform-translate/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-rhumb-destination"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -34,11 +34,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-triangle-grid/tsconfig.json
+++ b/packages/turf-triangle-grid/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-intersect"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-truncate"
+    }
+  ]
 }

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -35,11 +35,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-truncate/tsconfig.json
+++ b/packages/turf-truncate/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -30,11 +30,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-union/tsconfig.json
+++ b/packages/turf-union/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    }
+  ]
 }

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -33,11 +33,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts",
     "test:types": "tsc --ignoreConfig --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts"

--- a/packages/turf-unkink-polygon/tsconfig.json
+++ b/packages/turf-unkink-polygon/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-area"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-kinks"
+    }
+  ]
 }

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -39,11 +39,12 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "bench": "tsx bench.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "pnpm run /test:.*/",
     "test:tape": "tsx test.ts"
   },

--- a/packages/turf-voronoi/tsconfig.json
+++ b/packages/turf-voronoi/tsconfig.json
@@ -1,3 +1,14 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-invariant"
+    }
+  ]
 }

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -55,10 +55,11 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "turf.min.js"
+    "turf.min.js",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
-    "build": "tsc && esbuild index.ts --bundle --minify --target=chrome109,edge147,firefox140,ios18.5,opera127,safari26.3 --outfile=turf.min.js",
+    "build": "tsc --build && esbuild index.ts --bundle --minify --target=chrome109,edge147,firefox140,ios18.5,opera127,safari26.3 --outfile=turf.min.js",
     "last-checks": "pnpm run last-checks:testjs && pnpm run last-checks:example",
     "last-checks:example": "tsx test.example.js",
     "last-checks:testjs": "tsx test.ts",

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -63,7 +63,8 @@
     "last-checks": "pnpm run last-checks:testjs && pnpm run last-checks:example",
     "last-checks:example": "tsx test.example.js",
     "last-checks:testjs": "tsx test.ts",
-    "test": "echo '@turf/turf tests run in the last-checks step'"
+    "test": "echo '@turf/turf tests run in the last-checks step'",
+    "watch": "tsc --build --watch"
   },
   "devDependencies": {
     "@types/tape": "^5.8.1",

--- a/packages/turf/test.ts
+++ b/packages/turf/test.ts
@@ -109,6 +109,7 @@ test("turf -- check if files exists", (t) => {
       if (file === "main.js") continue;
       if (file === "main.es.js") continue;
       if (file === "index.d.ts") continue;
+      if (file.startsWith("!")) continue;
       if (!fs.existsSync(path.join(dir, file)))
         t.fail(`${name} missing file ${file} in "files"`);
     }

--- a/packages/turf/tsconfig.json
+++ b/packages/turf/tsconfig.json
@@ -1,3 +1,347 @@
 {
-  "extends": "../../tsconfig.shared.json"
+  "extends": "../../tsconfig.shared.json",
+  "references": [
+    {
+      "path": "../turf-along"
+    },
+    {
+      "path": "../turf-angle"
+    },
+    {
+      "path": "../turf-area"
+    },
+    {
+      "path": "../turf-bbox"
+    },
+    {
+      "path": "../turf-bbox-clip"
+    },
+    {
+      "path": "../turf-bbox-polygon"
+    },
+    {
+      "path": "../turf-bearing"
+    },
+    {
+      "path": "../turf-bezier-spline"
+    },
+    {
+      "path": "../turf-boolean-clockwise"
+    },
+    {
+      "path": "../turf-boolean-concave"
+    },
+    {
+      "path": "../turf-boolean-contains"
+    },
+    {
+      "path": "../turf-boolean-crosses"
+    },
+    {
+      "path": "../turf-boolean-disjoint"
+    },
+    {
+      "path": "../turf-boolean-equal"
+    },
+    {
+      "path": "../turf-boolean-intersects"
+    },
+    {
+      "path": "../turf-boolean-overlap"
+    },
+    {
+      "path": "../turf-boolean-parallel"
+    },
+    {
+      "path": "../turf-boolean-point-in-polygon"
+    },
+    {
+      "path": "../turf-boolean-point-on-line"
+    },
+    {
+      "path": "../turf-boolean-touches"
+    },
+    {
+      "path": "../turf-boolean-valid"
+    },
+    {
+      "path": "../turf-boolean-within"
+    },
+    {
+      "path": "../turf-buffer"
+    },
+    {
+      "path": "../turf-center"
+    },
+    {
+      "path": "../turf-center-mean"
+    },
+    {
+      "path": "../turf-center-median"
+    },
+    {
+      "path": "../turf-center-of-mass"
+    },
+    {
+      "path": "../turf-centroid"
+    },
+    {
+      "path": "../turf-circle"
+    },
+    {
+      "path": "../turf-clean-coords"
+    },
+    {
+      "path": "../turf-clone"
+    },
+    {
+      "path": "../turf-clusters"
+    },
+    {
+      "path": "../turf-clusters-dbscan"
+    },
+    {
+      "path": "../turf-clusters-kmeans"
+    },
+    {
+      "path": "../turf-collect"
+    },
+    {
+      "path": "../turf-combine"
+    },
+    {
+      "path": "../turf-concave"
+    },
+    {
+      "path": "../turf-convex"
+    },
+    {
+      "path": "../turf-destination"
+    },
+    {
+      "path": "../turf-difference"
+    },
+    {
+      "path": "../turf-directional-mean"
+    },
+    {
+      "path": "../turf-dissolve"
+    },
+    {
+      "path": "../turf-distance"
+    },
+    {
+      "path": "../turf-distance-weight"
+    },
+    {
+      "path": "../turf-ellipse"
+    },
+    {
+      "path": "../turf-envelope"
+    },
+    {
+      "path": "../turf-explode"
+    },
+    {
+      "path": "../turf-flatten"
+    },
+    {
+      "path": "../turf-flip"
+    },
+    {
+      "path": "../turf-geojson-rbush"
+    },
+    {
+      "path": "../turf-great-circle"
+    },
+    {
+      "path": "../turf-helpers"
+    },
+    {
+      "path": "../turf-hex-grid"
+    },
+    {
+      "path": "../turf-interpolate"
+    },
+    {
+      "path": "../turf-intersect"
+    },
+    {
+      "path": "../turf-invariant"
+    },
+    {
+      "path": "../turf-isobands"
+    },
+    {
+      "path": "../turf-isolines"
+    },
+    {
+      "path": "../turf-kinks"
+    },
+    {
+      "path": "../turf-length"
+    },
+    {
+      "path": "../turf-line-arc"
+    },
+    {
+      "path": "../turf-line-chunk"
+    },
+    {
+      "path": "../turf-line-intersect"
+    },
+    {
+      "path": "../turf-line-offset"
+    },
+    {
+      "path": "../turf-line-overlap"
+    },
+    {
+      "path": "../turf-line-segment"
+    },
+    {
+      "path": "../turf-line-slice"
+    },
+    {
+      "path": "../turf-line-slice-along"
+    },
+    {
+      "path": "../turf-line-split"
+    },
+    {
+      "path": "../turf-line-to-polygon"
+    },
+    {
+      "path": "../turf-mask"
+    },
+    {
+      "path": "../turf-meta"
+    },
+    {
+      "path": "../turf-midpoint"
+    },
+    {
+      "path": "../turf-moran-index"
+    },
+    {
+      "path": "../turf-nearest-neighbor-analysis"
+    },
+    {
+      "path": "../turf-nearest-point"
+    },
+    {
+      "path": "../turf-nearest-point-on-line"
+    },
+    {
+      "path": "../turf-nearest-point-to-line"
+    },
+    {
+      "path": "../turf-planepoint"
+    },
+    {
+      "path": "../turf-point-grid"
+    },
+    {
+      "path": "../turf-point-on-feature"
+    },
+    {
+      "path": "../turf-point-to-line-distance"
+    },
+    {
+      "path": "../turf-point-to-polygon-distance"
+    },
+    {
+      "path": "../turf-points-within-polygon"
+    },
+    {
+      "path": "../turf-polygon-smooth"
+    },
+    {
+      "path": "../turf-polygon-tangents"
+    },
+    {
+      "path": "../turf-polygon-to-line"
+    },
+    {
+      "path": "../turf-polygonize"
+    },
+    {
+      "path": "../turf-projection"
+    },
+    {
+      "path": "../turf-quadrat-analysis"
+    },
+    {
+      "path": "../turf-random"
+    },
+    {
+      "path": "../turf-rectangle-grid"
+    },
+    {
+      "path": "../turf-rewind"
+    },
+    {
+      "path": "../turf-rhumb-bearing"
+    },
+    {
+      "path": "../turf-rhumb-destination"
+    },
+    {
+      "path": "../turf-rhumb-distance"
+    },
+    {
+      "path": "../turf-sample"
+    },
+    {
+      "path": "../turf-sector"
+    },
+    {
+      "path": "../turf-shortest-path"
+    },
+    {
+      "path": "../turf-simplify"
+    },
+    {
+      "path": "../turf-square"
+    },
+    {
+      "path": "../turf-square-grid"
+    },
+    {
+      "path": "../turf-standard-deviational-ellipse"
+    },
+    {
+      "path": "../turf-tag"
+    },
+    {
+      "path": "../turf-tesselate"
+    },
+    {
+      "path": "../turf-tin"
+    },
+    {
+      "path": "../turf-transform-rotate"
+    },
+    {
+      "path": "../turf-transform-scale"
+    },
+    {
+      "path": "../turf-transform-translate"
+    },
+    {
+      "path": "../turf-triangle-grid"
+    },
+    {
+      "path": "../turf-truncate"
+    },
+    {
+      "path": "../turf-union"
+    },
+    {
+      "path": "../turf-unkink-polygon"
+    },
+    {
+      "path": "../turf-voronoi"
+    }
+  ]
 }

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -2,6 +2,7 @@
   "include": ["${configDir}/index.ts", "${configDir}/lib/**/*.ts"],
   "compilerOptions": {
     "outDir": "${configDir}/dist",
+    "composite": true, // Lets us use tsc in --build mode which will automatically build transitive dependencies and handles caching
     "target": "es2022", // This aligns with node@22 and should also be broadly compatible with browsers
     "module": "node18", // This is a relatively strict setting, which should work in node@22 and bundlers
     "declaration": true,


### PR DESCRIPTION
This PR enables TypeScript's [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) to improve build times and devex.

Currently we build packages in dependency-graph order using `lerna`, which works but winds up doing a lot of TypeScript work repeatedly. In each package it will start a new process which is going to parse all of its transitively depended upon files all the way into node_modules. When multiplied across 115 packages, it means that some of the base types are getting parsed every time.

When project references are enabled, we can use TypeScript's `--build` flag, which will handle the dependency graph itself and parse all of the files exactly once instead. In addition, it will output an extra file `dist/tsconfig.tsbuildinfo` in every package, which lets it do incremental compilation so that only new changes will have to be evaluated after the first build has completed.

In addition, it gives us a `--watch` mode that is extremely responsive to file changes. Instead of needing to remember to build before pushing to CI (did you break a package that depends on what you changed?) watch mode will just do all of the typechecking for the entire repo in real time as you save.

Note: All of the packages in the repo *must* be transitively depended upon by @turf/turf, or they will not be built. That should be an acceptable tradeoff. Any new packages need to be reexported from there anyhow, or we can add to the `pnpm --filter` command to add them as separate build steps temporarily. The consumer-style testing does not fall under this requirement, as they use the `test` script instead.

---

Time to run `pnpm install --frozen-lockfile` in CI (which currently executes the build). I'm sure there's a bit of a noisy-neighbor problem that makes these a little variable, but the change clearly is a major improvement either way.

| | [Before](https://github.com/Turfjs/turf/actions/runs/31097179797) | [After](https://github.com/Turfjs/turf/actions/runs/31190948392)
| - | - | - |
| Node 22 | 4:43 | 1:08 |
| Node 24 | 2:35 | 0:50 |
| Node 26 | 3:43 | 1:05 |

Time to run `time pnpm prepare` locally (M4 Macbook Pro):
| Cache | Lerna | Project References |
| - | - | - |
| Cold | 0:24 | 0:22 |
| Warm | 0:01 | 0:01 |

Note that lerna's build actually does *much* more work, but uses a high degree of parallelism to come in around the same time. That approach works ok on fast hardware, but doing much less work wins on CI and saves everyone CPU usage locally.