### PR TITLE
Move write-json-file into the pnpm catalog

### DIFF
--- a/packages/turf-angle/package.json
+++ b/packages/turf-angle/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bearing": "workspace:*",

--- a/packages/turf-area/package.json
+++ b/packages/turf-area/package.json
@@ -49,7 +49,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-bbox-clip/package.json
+++ b/packages/turf-bbox-clip/package.json
@@ -56,7 +56,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-bearing/package.json
+++ b/packages/turf-bearing/package.json
@@ -47,7 +47,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-bezier-spline/package.json
+++ b/packages/turf-bezier-spline/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-boolean-parallel/package.json
+++ b/packages/turf-boolean-parallel/package.json
@@ -52,7 +52,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clean-coords": "workspace:*",

--- a/packages/turf-boolean-point-on-line/package.json
+++ b/packages/turf-boolean-point-on-line/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-buffer/package.json
+++ b/packages/turf-buffer/package.json
@@ -61,7 +61,7 @@
     "tstyche": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-center-mean/package.json
+++ b/packages/turf-center-mean/package.json
@@ -58,7 +58,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-center-median/package.json
+++ b/packages/turf-center-median/package.json
@@ -54,7 +54,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/center-mean": "workspace:*",

--- a/packages/turf-center-of-mass/package.json
+++ b/packages/turf-center-of-mass/package.json
@@ -48,7 +48,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/centroid": "workspace:*",

--- a/packages/turf-center/package.json
+++ b/packages/turf-center/package.json
@@ -54,7 +54,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-centroid/package.json
+++ b/packages/turf-centroid/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-circle/package.json
+++ b/packages/turf-circle/package.json
@@ -54,7 +54,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/destination": "workspace:*",

--- a/packages/turf-clean-coords/package.json
+++ b/packages/turf-clean-coords/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-on-line": "workspace:*",

--- a/packages/turf-clusters-dbscan/package.json
+++ b/packages/turf-clusters-dbscan/package.json
@@ -63,7 +63,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-clusters-kmeans/package.json
+++ b/packages/turf-clusters-kmeans/package.json
@@ -63,7 +63,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-concave/package.json
+++ b/packages/turf-concave/package.json
@@ -62,7 +62,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-convex/package.json
+++ b/packages/turf-convex/package.json
@@ -52,7 +52,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-destination/package.json
+++ b/packages/turf-destination/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-difference/package.json
+++ b/packages/turf-difference/package.json
@@ -47,7 +47,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-directional-mean/package.json
+++ b/packages/turf-directional-mean/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bearing": "workspace:*",

--- a/packages/turf-dissolve/package.json
+++ b/packages/turf-dissolve/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/flatten": "workspace:*",

--- a/packages/turf-distance-weight/package.json
+++ b/packages/turf-distance-weight/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/centroid": "workspace:*",

--- a/packages/turf-distance/package.json
+++ b/packages/turf-distance/package.json
@@ -49,7 +49,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-ellipse/package.json
+++ b/packages/turf-ellipse/package.json
@@ -57,7 +57,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/destination": "workspace:*",

--- a/packages/turf-explode/package.json
+++ b/packages/turf-explode/package.json
@@ -49,7 +49,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-flatten/package.json
+++ b/packages/turf-flatten/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-flip/package.json
+++ b/packages/turf-flip/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-geojson-rbush/package.json
+++ b/packages/turf-geojson-rbush/package.json
@@ -59,7 +59,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-great-circle/package.json
+++ b/packages/turf-great-circle/package.json
@@ -58,7 +58,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-hex-grid/package.json
+++ b/packages/turf-hex-grid/package.json
@@ -62,7 +62,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",

--- a/packages/turf-interpolate/package.json
+++ b/packages/turf-interpolate/package.json
@@ -54,7 +54,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-intersect/package.json
+++ b/packages/turf-intersect/package.json
@@ -49,7 +49,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-isobands/package.json
+++ b/packages/turf-isobands/package.json
@@ -61,7 +61,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/area": "workspace:*",

--- a/packages/turf-isolines/package.json
+++ b/packages/turf-isolines/package.json
@@ -61,7 +61,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-kinks/package.json
+++ b/packages/turf-kinks/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-length/package.json
+++ b/packages/turf-length/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",

--- a/packages/turf-line-arc/package.json
+++ b/packages/turf-line-arc/package.json
@@ -52,7 +52,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/circle": "workspace:*",

--- a/packages/turf-line-chunk/package.json
+++ b/packages/turf-line-chunk/package.json
@@ -58,7 +58,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-line-intersect/package.json
+++ b/packages/turf-line-intersect/package.json
@@ -56,7 +56,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-line-offset/package.json
+++ b/packages/turf-line-offset/package.json
@@ -57,7 +57,7 @@
     "tstyche": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-line-overlap/package.json
+++ b/packages/turf-line-overlap/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-line-segment/package.json
+++ b/packages/turf-line-segment/package.json
@@ -48,7 +48,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-line-slice/package.json
+++ b/packages/turf-line-slice/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-line-split/package.json
+++ b/packages/turf-line-split/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-line-to-polygon/package.json
+++ b/packages/turf-line-to-polygon/package.json
@@ -54,7 +54,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-mask/package.json
+++ b/packages/turf-mask/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-moran-index/package.json
+++ b/packages/turf-moran-index/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/distance-weight": "workspace:*",

--- a/packages/turf-nearest-neighbor-analysis/package.json
+++ b/packages/turf-nearest-neighbor-analysis/package.json
@@ -51,7 +51,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/area": "workspace:*",

--- a/packages/turf-nearest-point-on-line/package.json
+++ b/packages/turf-nearest-point-on-line/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",

--- a/packages/turf-nearest-point-to-line/package.json
+++ b/packages/turf-nearest-point-to-line/package.json
@@ -57,7 +57,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-nearest-point/package.json
+++ b/packages/turf-nearest-point/package.json
@@ -52,7 +52,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-point-grid/package.json
+++ b/packages/turf-point-grid/package.json
@@ -56,7 +56,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-within": "workspace:*",

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -52,7 +52,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",

--- a/packages/turf-point-to-line-distance/package.json
+++ b/packages/turf-point-to-line-distance/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bearing": "workspace:*",

--- a/packages/turf-point-to-polygon-distance/package.json
+++ b/packages/turf-point-to-polygon-distance/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",

--- a/packages/turf-polygon-smooth/package.json
+++ b/packages/turf-polygon-smooth/package.json
@@ -52,7 +52,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-polygon-tangents/package.json
+++ b/packages/turf-polygon-tangents/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-polygon-to-line/package.json
+++ b/packages/turf-polygon-to-line/package.json
@@ -50,7 +50,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-polygonize/package.json
+++ b/packages/turf-polygonize/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "workspace:*",

--- a/packages/turf-projection/package.json
+++ b/packages/turf-projection/package.json
@@ -64,7 +64,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-quadrat-analysis/package.json
+++ b/packages/turf-quadrat-analysis/package.json
@@ -51,7 +51,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/area": "workspace:*",

--- a/packages/turf-rectangle-grid/package.json
+++ b/packages/turf-rectangle-grid/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-intersects": "workspace:*",

--- a/packages/turf-rewind/package.json
+++ b/packages/turf-rewind/package.json
@@ -56,7 +56,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/boolean-clockwise": "workspace:*",

--- a/packages/turf-rhumb-bearing/package.json
+++ b/packages/turf-rhumb-bearing/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-rhumb-destination/package.json
+++ b/packages/turf-rhumb-destination/package.json
@@ -60,7 +60,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-rhumb-distance/package.json
+++ b/packages/turf-rhumb-distance/package.json
@@ -58,7 +58,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-sector/package.json
+++ b/packages/turf-sector/package.json
@@ -49,7 +49,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/circle": "workspace:*",

--- a/packages/turf-shortest-path/package.json
+++ b/packages/turf-shortest-path/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-simplify/package.json
+++ b/packages/turf-simplify/package.json
@@ -57,7 +57,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clean-coords": "workspace:*",

--- a/packages/turf-square-grid/package.json
+++ b/packages/turf-square-grid/package.json
@@ -51,7 +51,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-standard-deviational-ellipse/package.json
+++ b/packages/turf-standard-deviational-ellipse/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/center-mean": "workspace:*",

--- a/packages/turf-transform-rotate/package.json
+++ b/packages/turf-transform-rotate/package.json
@@ -55,7 +55,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/centroid": "workspace:*",

--- a/packages/turf-transform-scale/package.json
+++ b/packages/turf-transform-scale/package.json
@@ -61,7 +61,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/bbox": "workspace:*",

--- a/packages/turf-transform-translate/package.json
+++ b/packages/turf-transform-translate/package.json
@@ -57,7 +57,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/packages/turf-triangle-grid/package.json
+++ b/packages/turf-triangle-grid/package.json
@@ -54,7 +54,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/distance": "workspace:*",

--- a/packages/turf-truncate/package.json
+++ b/packages/turf-truncate/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-union/package.json
+++ b/packages/turf-union/package.json
@@ -48,7 +48,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/helpers": "workspace:*",

--- a/packages/turf-unkink-polygon/package.json
+++ b/packages/turf-unkink-polygon/package.json
@@ -53,7 +53,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/area": "workspace:*",

--- a/packages/turf-voronoi/package.json
+++ b/packages/turf-voronoi/package.json
@@ -56,7 +56,7 @@
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "write-json-file": "^6.0.0"
+    "write-json-file": "catalog:"
   },
   "dependencies": {
     "@turf/clone": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+    write-json-file:
+      specifier: ^6.0.0
+      version: 6.0.0
   typescript5:
     typescript:
       specifier: 5.9.3
@@ -800,7 +803,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-area:
@@ -837,7 +840,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-bbox:
@@ -908,7 +911,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-bbox-polygon:
@@ -973,7 +976,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-bezier-spline:
@@ -1010,7 +1013,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-boolean-clockwise:
@@ -1394,7 +1397,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-boolean-point-in-polygon:
@@ -1465,7 +1468,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-boolean-touches:
@@ -1676,7 +1679,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-center:
@@ -1719,7 +1722,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-center-mean:
@@ -1765,7 +1768,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-center-median:
@@ -1823,7 +1826,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-center-of-mass:
@@ -1869,7 +1872,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-centroid:
@@ -1906,7 +1909,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-circle:
@@ -1949,7 +1952,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-clean-coords:
@@ -1995,7 +1998,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-clone:
@@ -2118,7 +2121,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-clusters-kmeans:
@@ -2182,7 +2185,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-collect:
@@ -2314,7 +2317,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-convex:
@@ -2357,7 +2360,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-destination:
@@ -2397,7 +2400,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-difference:
@@ -2437,7 +2440,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-directional-mean:
@@ -2489,7 +2492,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-dissolve:
@@ -2535,7 +2538,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-distance:
@@ -2572,7 +2575,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-distance-weight:
@@ -2615,7 +2618,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-ellipse:
@@ -2679,7 +2682,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-envelope:
@@ -2753,7 +2756,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-flatten:
@@ -2790,7 +2793,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-flip:
@@ -2830,7 +2833,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-geojson-rbush:
@@ -2882,7 +2885,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-great-circle:
@@ -2925,7 +2928,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-helpers:
@@ -2999,7 +3002,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-interpolate:
@@ -3069,7 +3072,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-intersect:
@@ -3109,7 +3112,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-invariant:
@@ -3204,7 +3207,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-isolines:
@@ -3262,7 +3265,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-kinks:
@@ -3299,7 +3302,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-length:
@@ -3339,7 +3342,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-arc:
@@ -3382,7 +3385,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-chunk:
@@ -3428,7 +3431,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-intersect:
@@ -3471,7 +3474,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-offset:
@@ -3517,7 +3520,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-overlap:
@@ -3575,7 +3578,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-segment:
@@ -3615,7 +3618,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-slice:
@@ -3658,7 +3661,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-slice-along:
@@ -3762,7 +3765,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-line-to-polygon:
@@ -3805,7 +3808,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-mask:
@@ -3848,7 +3851,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-meta:
@@ -3956,7 +3959,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-nearest-neighbor-analysis:
@@ -4014,7 +4017,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-nearest-point:
@@ -4057,7 +4060,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-nearest-point-on-line:
@@ -4109,7 +4112,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-nearest-point-to-line:
@@ -4161,7 +4164,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-planepoint:
@@ -4241,7 +4244,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-point-on-feature:
@@ -4290,7 +4293,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-point-to-line-distance:
@@ -4351,7 +4354,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-point-to-polygon-distance:
@@ -4400,7 +4403,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-points-within-polygon:
@@ -4471,7 +4474,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-polygon-tangents:
@@ -4520,7 +4523,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-polygon-to-line:
@@ -4557,7 +4560,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-polygonize:
@@ -4603,7 +4606,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-projection:
@@ -4649,7 +4652,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-quadrat-analysis:
@@ -4710,7 +4713,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-random:
@@ -4784,7 +4787,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-rewind:
@@ -4830,7 +4833,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-rhumb-bearing:
@@ -4867,7 +4870,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-rhumb-destination:
@@ -4907,7 +4910,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-rhumb-distance:
@@ -4947,7 +4950,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-sample:
@@ -5024,7 +5027,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-shortest-path:
@@ -5085,7 +5088,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-simplify:
@@ -5131,7 +5134,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-square:
@@ -5202,7 +5205,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-standard-deviational-ellipse:
@@ -5257,7 +5260,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-tag:
@@ -5417,7 +5420,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-transform-scale:
@@ -5487,7 +5490,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-transform-translate:
@@ -5536,7 +5539,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-triangle-grid:
@@ -5582,7 +5585,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-truncate:
@@ -5619,7 +5622,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-union:
@@ -5659,7 +5662,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-unkink-polygon:
@@ -5711,7 +5714,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   packages/turf-voronoi:
@@ -5757,7 +5760,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       write-json-file:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.0.0
 
   test/node-cjs:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ catalog:
   tstyche: ^6.2.0
   tsx: ^4.22.4
   typescript: ^6.0.3
+  "write-json-file": ^6.0.0
 
 catalogs:
   # keep a named catalog of typescript@5 for the consumer tests


### PR DESCRIPTION
The devDependency upgrade PR (https://github.com/Turfjs/turf/pull/3107) is pretty noisy with `write-json-file` changes. Since its used in so many packages, we should move it into the catalog first so that the upgrades are less noisy.

Hopefully the dependency goes away entirely once the test/bench gets migrated to native node execution and some shared harness code.