### PR TITLE
Condense last-checks into @turf/turf's test script directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:mrl": "mrl check",
     "lint:prettier": "prettier --cache --check .",
     "prepare": "husky",
-    "test": "pnpm run lint && pnpm -r run test && pnpm -r --filter '@turf/turf' last-checks",
+    "test": "pnpm run lint && pnpm -r run test",
     "watch": "pnpm --filter @turf/turf watch"
   },
   "lint-staged": {

--- a/packages/turf/package.json
+++ b/packages/turf/package.json
@@ -60,10 +60,7 @@
   ],
   "scripts": {
     "build": "tsc --build && esbuild index.ts --bundle --minify --target=chrome109,edge147,firefox140,ios18.5,opera127,safari26.3 --outfile=turf.min.js",
-    "last-checks": "pnpm run last-checks:testjs && pnpm run last-checks:example",
-    "last-checks:example": "tsx test.example.js",
-    "last-checks:testjs": "tsx test.ts",
-    "test": "echo '@turf/turf tests run in the last-checks step'",
+    "test": "tsx test.ts && tsx test.example.js",
     "watch": "tsc --build --watch"
   },
   "devDependencies": {

--- a/packages/turf/test.ts
+++ b/packages/turf/test.ts
@@ -335,7 +335,7 @@ test("turf -- update to newer Typescript definitions", (t) => {
 
 // File Paths
 const testFilePath = path.join(__dirname, "test.example.js");
-const turfModulesPath = path.join(__dirname, "..", "turf-*", "index.js");
+const turfModulesPath = path.join(__dirname, "..", "turf-*", "index.ts");
 const turfTypescriptPath = path.join(__dirname, "..", "turf-*", "index.d.ts");
 
 // Test Strings


### PR DESCRIPTION
I don't think there is any remaining reason why the @turf/turf tests need to be special cased into `last-checks`. The tests themselves do need to be ordered, but pnpm will take care of the package dependency ordering, and the script itself runs the two steps in order.

[Originally added](https://github.com/Turfjs/turf/commit/b3b5284882fc9b23c803da1c23217629b5ed6897#diff-cef2ddf2d0e8a2b54c7bc13bae1febdcaf52d4cef3704170b74efed73198a855R20-R23) a long time ago