### PR TITLE
Enforce README.md changes are up-to-date in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: pnpm install --frozen-lockfile
-      - run: git diff --exit-code
       - run: pnpm build
+      - run: pnpm run docs
+      - run: git diff --exit-code
       - run: pnpm test

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ packages:
 
 allowBuilds:
   esbuild: false
-  nx: false
 
 catalog:
   "@types/benchmark": ^2.1.5


### PR DESCRIPTION
The pre-commit hook isn't always authoritative, so rework the CI to make sure we catch any stale READMEs going forward.