### PR TITLE
break(invariant) `getType` remove unused `_name` parameter

### DIFF
--- a/packages/turf-invariant/README.md
+++ b/packages/turf-invariant/README.md
@@ -132,7 +132,6 @@ Get GeoJSON object's type, Geometry type is prioritize.
 ### Parameters
 
 *   `geojson` **[GeoJSON][7]** GeoJSON object
-*   `name` **[string][8]** name of the variable to display in error message (unused) (optional, default `"geojson"`)
 
 ### Examples
 

--- a/packages/turf-invariant/README.md
+++ b/packages/turf-invariant/README.md
@@ -132,7 +132,6 @@ Get GeoJSON object's type, Geometry type is prioritize.
 ### Parameters
 
 *   `geojson` **[GeoJSON][7]** GeoJSON object
-*   `_name` **[string][8]?**&#x20;
 *   `name` **[string][8]** name of the variable to display in error message (unused) (optional, default `"geojson"`)
 
 ### Examples

--- a/packages/turf-invariant/index.ts
+++ b/packages/turf-invariant/index.ts
@@ -245,7 +245,6 @@ function getGeom<G extends Geometry>(geojson: Feature<G> | G): G {
  * Get GeoJSON object's type, Geometry type is prioritize.
  *
  * @param {GeoJSON} geojson GeoJSON object
- * @param {string} [name="geojson"] name of the variable to display in error message (unused)
  * @returns {string} GeoJSON type
  * @example
  * var point = {

--- a/packages/turf-invariant/index.ts
+++ b/packages/turf-invariant/index.ts
@@ -260,8 +260,7 @@ function getGeom<G extends Geometry>(geojson: Feature<G> | G): G {
  * //="Point"
  */
 function getType(
-  geojson: Feature<any> | FeatureCollection<any> | Geometry,
-  _name?: string
+  geojson: Feature<any> | FeatureCollection<any> | Geometry
 ): string {
   if (geojson.type === "FeatureCollection") {
     return "FeatureCollection";


### PR DESCRIPTION
This hasn't been used in a long time, so remove it from the public signature finally.