### PR TITLE
break(turf-projection) change toWgs84 and toMercator `G =` to `G extends`

### DIFF
--- a/packages/turf-projection/index.ts
+++ b/packages/turf-projection/index.ts
@@ -18,15 +18,11 @@ import { clone } from "@turf/clone";
  * //addToMap
  * var addToMap = [pt, converted];
  */
-function toMercator<G = AllGeoJSON | Position>(
+function toMercator<G extends AllGeoJSON | Position>(
   geojson: G,
   options: { mutate?: boolean } = {}
 ): G {
-  return project(
-    geojson as GeoJSON | Position,
-    convertToMercator,
-    options
-  ) as G;
+  return project(geojson, convertToMercator, options);
 }
 
 /**
@@ -44,11 +40,11 @@ function toMercator<G = AllGeoJSON | Position>(
  * //addToMap
  * var addToMap = [pt, converted];
  */
-function toWgs84<G = AllGeoJSON | Position>(
+function toWgs84<G extends AllGeoJSON | Position>(
   geojson: G,
   options: { mutate?: boolean } = {}
 ): G {
-  return project(geojson as GeoJSON | Position, convertToWgs84, options) as G;
+  return project(geojson, convertToWgs84, options);
 }
 
 /**


### PR DESCRIPTION
`G = AllGeoJSON | Position` allows calls using something that isn't a GeoJSON or Position, where `extends` correctly restricts the input to the expected types. This also lets us clean up some override casting within the `toMercator` and `toWgs84` implementations.