### PR TITLE
Remove AllGeoJSON type, @turf/meta fixes

### DIFF
--- a/packages/turf-bbox/index.ts
+++ b/packages/turf-bbox/index.ts
@@ -1,5 +1,5 @@
 import { BBox } from "geojson";
-import { AllGeoJSON } from "@turf/helpers";
+import type { GeoJSON } from "geojson";
 import { coordEach } from "@turf/meta";
 
 /**
@@ -20,7 +20,7 @@ import { coordEach } from "@turf/meta";
  * var addToMap = [line, bboxPolygon]
  */
 function bbox(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   options: {
     recompute?: boolean;
   } = {}

--- a/packages/turf-bbox/package.json
+++ b/packages/turf-bbox/package.json
@@ -46,13 +46,13 @@
   "devDependencies": {
     "@types/benchmark": "catalog:",
     "@types/tape": "catalog:",
+    "@turf/helpers": "workspace:*",
     "benchmark": "catalog:",
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@turf/helpers": "workspace:*",
     "@turf/meta": "workspace:*",
     "@types/geojson": "catalog:"
   },

--- a/packages/turf-center/index.ts
+++ b/packages/turf-center/index.ts
@@ -1,6 +1,6 @@
-import { BBox, Feature, GeoJsonProperties, Point } from "geojson";
+import type { BBox, Feature, GeoJSON, GeoJsonProperties, Point } from "geojson";
 import { bbox } from "@turf/bbox";
-import { point, Id, AllGeoJSON } from "@turf/helpers";
+import { point, type Id } from "@turf/helpers";
 
 /**
  * Takes a {@link Feature} or {@link FeatureCollection} and returns the absolute center point of all features.
@@ -27,7 +27,7 @@ import { point, Id, AllGeoJSON } from "@turf/helpers";
  * center.properties['marker-color'] = '#000';
  */
 function center<P extends GeoJsonProperties = GeoJsonProperties>(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   options: { properties?: P; bbox?: BBox; id?: Id } = {}
 ): Feature<Point, P> {
   const ext = bbox(geojson);

--- a/packages/turf-centroid/index.ts
+++ b/packages/turf-centroid/index.ts
@@ -1,5 +1,5 @@
-import { Feature, GeoJsonProperties, Point } from "geojson";
-import { point, AllGeoJSON } from "@turf/helpers";
+import type { Feature, GeoJSON, GeoJsonProperties, Point } from "geojson";
+import { point } from "@turf/helpers";
 import { coordEach } from "@turf/meta";
 
 /**
@@ -19,7 +19,7 @@ import { coordEach } from "@turf/meta";
  * var addToMap = [polygon, centroid]
  */
 function centroid<P extends GeoJsonProperties = GeoJsonProperties>(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   options: {
     properties?: P;
   } = {}

--- a/packages/turf-clone/index.ts
+++ b/packages/turf-clone/index.ts
@@ -1,5 +1,4 @@
-import { Feature, GeoJsonProperties } from "geojson";
-import { AllGeoJSON } from "@turf/helpers";
+import type { Feature, GeoJSON, GeoJsonProperties } from "geojson";
 
 /**
  * Returns a cloned copy of the passed GeoJSON Object, including possible 'Foreign Members'.
@@ -13,7 +12,7 @@ import { AllGeoJSON } from "@turf/helpers";
  *
  * var lineCloned = turf.clone(line);
  */
-function clone<T extends AllGeoJSON>(geojson: T): T {
+function clone<T extends GeoJSON>(geojson: T): T {
   if (!geojson) {
     throw new Error("geojson is required");
   }

--- a/packages/turf-clone/package.json
+++ b/packages/turf-clone/package.json
@@ -47,13 +47,13 @@
     "@turf/meta": "workspace:*",
     "@types/benchmark": "catalog:",
     "@types/tape": "catalog:",
+    "@turf/helpers": "workspace:*",
     "benchmark": "catalog:",
     "tape": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@turf/helpers": "workspace:*",
     "@types/geojson": "catalog:"
   },
   "engines": {

--- a/packages/turf-convex/index.ts
+++ b/packages/turf-convex/index.ts
@@ -1,5 +1,5 @@
-import { Feature, GeoJsonProperties, Polygon } from "geojson";
-import { AllGeoJSON, polygon } from "@turf/helpers";
+import type { Feature, GeoJSON, GeoJsonProperties, Polygon } from "geojson";
+import { polygon } from "@turf/helpers";
 import { coordEach } from "@turf/meta";
 import concaveman from "concaveman";
 
@@ -32,7 +32,7 @@ import concaveman from "concaveman";
  * var addToMap = [points, hull]
  */
 function convex<P extends GeoJsonProperties = GeoJsonProperties>(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   options: {
     concavity?: number;
     properties?: P;

--- a/packages/turf-envelope/index.ts
+++ b/packages/turf-envelope/index.ts
@@ -1,5 +1,4 @@
-import type { Feature, Polygon } from "geojson";
-import type { AllGeoJSON } from "@turf/helpers";
+import type { Feature, GeoJSON, Polygon } from "geojson";
 import { bbox } from "@turf/bbox";
 import { bboxPolygon } from "@turf/bbox-polygon";
 
@@ -21,7 +20,7 @@ import { bboxPolygon } from "@turf/bbox-polygon";
  * //addToMap
  * var addToMap = [features, enveloped];
  */
-function envelope(geojson: AllGeoJSON): Feature<Polygon> {
+function envelope(geojson: GeoJSON): Feature<Polygon> {
   return bboxPolygon(bbox(geojson));
 }
 

--- a/packages/turf-explode/index.ts
+++ b/packages/turf-explode/index.ts
@@ -1,7 +1,6 @@
 import { coordEach, featureEach } from "@turf/meta";
 import { point, featureCollection } from "@turf/helpers";
-import type { AllGeoJSON } from "@turf/helpers";
-import type { Feature, FeatureCollection, Point } from "geojson";
+import type { Feature, FeatureCollection, GeoJSON, Point } from "geojson";
 
 /**
  * Takes a feature or set of features and returns all positions as {@link Point|points}.
@@ -18,7 +17,7 @@ import type { Feature, FeatureCollection, Point } from "geojson";
  * //addToMap
  * var addToMap = [polygon, explode]
  */
-function explode(geojson: AllGeoJSON): FeatureCollection<Point> {
+function explode(geojson: GeoJSON): FeatureCollection<Point> {
   const points: Feature<Point>[] = [];
   if (geojson.type === "FeatureCollection") {
     featureEach(geojson, function (feature) {

--- a/packages/turf-flatten/index.ts
+++ b/packages/turf-flatten/index.ts
@@ -1,6 +1,5 @@
 import { flattenEach } from "@turf/meta";
 import { featureCollection } from "@turf/helpers";
-import type { AllGeoJSON } from "@turf/helpers";
 import type {
   Feature,
   Point,
@@ -10,6 +9,7 @@ import type {
   FeatureCollection,
   Polygon,
   MultiPolygon,
+  GeoJSON,
 } from "geojson";
 
 /**
@@ -42,9 +42,9 @@ function flatten<T extends Polygon | MultiPolygon>(
   geojson: Feature<T> | FeatureCollection<T> | T
 ): FeatureCollection<Polygon>;
 
-function flatten(geojson: AllGeoJSON): FeatureCollection<any>;
+function flatten(geojson: GeoJSON): FeatureCollection<any>;
 
-function flatten(geojson: AllGeoJSON): FeatureCollection {
+function flatten(geojson: GeoJSON): FeatureCollection {
   if (!geojson) throw new Error("geojson is required");
 
   var results: Feature[] = [];

--- a/packages/turf-flip/index.ts
+++ b/packages/turf-flip/index.ts
@@ -1,6 +1,7 @@
 import { coordEach } from "@turf/meta";
-import { isObject, AllGeoJSON } from "@turf/helpers";
+import { isObject } from "@turf/helpers";
 import { clone } from "@turf/clone";
+import type { GeoJSON } from "geojson";
 
 /**
  * Takes input features and flips all of their coordinates from `[x, y]` to `[y, x]`.
@@ -18,7 +19,7 @@ import { clone } from "@turf/clone";
  * //addToMap
  * var addToMap = [serbia, saudiArabia];
  */
-function flip<T extends AllGeoJSON>(
+function flip<T extends GeoJSON>(
   geojson: T,
   options?: {
     mutate?: boolean;

--- a/packages/turf-helpers/README.md
+++ b/packages/turf-helpers/README.md
@@ -41,17 +41,11 @@ Geometries made up of lines i.e. lines and polygons.
 
 Type: ([LineString][3] | [MultiLineString][4] | [Polygon][5] | [MultiPolygon][6])
 
-## AllGeoJSON
-
-Convenience type for all possible GeoJSON.
-
-Type: ([Feature][7] | [FeatureCollection][8] | [Geometry][9] | [GeometryCollection][10])
-
 ## earthRadius
 
-The Earth radius in meters. Used by Turf modules that model the Earth as a sphere. The [mean radius][11] was selected because it is [recommended ][12] by the Haversine formula (used by turf/distance) to reduce error.
+The Earth radius in meters. Used by Turf modules that model the Earth as a sphere. The [mean radius][7] was selected because it is [recommended ][8] by the Haversine formula (used by turf/distance) to reduce error.
 
-Type: [number][13]
+Type: [number][9]
 
 ## factors
 
@@ -59,27 +53,27 @@ Unit of measurement factors based on earthRadius.
 
 Keys are the name of the unit, values are the number of that unit in a single radian
 
-Type: Record<[Units][2], [number][13]>
+Type: Record<[Units][2], [number][9]>
 
 ## areaFactors
 
 Area of measurement factors based on 1 square meter.
 
-Type: Record<[AreaUnits][14], [number][13]>
+Type: Record<[AreaUnits][10], [number][9]>
 
 ## feature
 
-Wraps a GeoJSON [Geometry][9] in a GeoJSON [Feature][7].
+Wraps a GeoJSON [Geometry][11] in a GeoJSON [Feature][12].
 
 ### Parameters
 
 *   `geom` **(G | null)**&#x20;
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
-*   `geometry` **[GeometryObject][9]** input geometry
+*   `geometry` **[GeometryObject][11]** input geometry
 
 ### Examples
 
@@ -94,19 +88,19 @@ var feature = turf.feature(geometry);
 //=feature
 ```
 
-Returns **[Feature][7]<[GeometryObject][9], [GeoJsonProperties][7]>** a GeoJSON Feature
+Returns **[Feature][12]<[GeometryObject][11], [GeoJsonProperties][12]>** a GeoJSON Feature
 
 ## geometry
 
-Creates a GeoJSON [Geometry][9] from a Geometry string type & coordinates.
+Creates a GeoJSON [Geometry][11] from a Geometry string type & coordinates.
 For GeometryCollection type use `helpers.geometryCollection`
 
 ### Parameters
 
 *   `type` **(`"Point"` | `"LineString"` | `"Polygon"` | `"MultiPoint"` | `"MultiLineString"` | `"MultiPolygon"`)** Geometry Type
-*   `coordinates` **[Array][17]\<any>** Coordinates
-*   `_options` **Record<[string][18], never>**  (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]\<any>** Coordinates
+*   `_options` **Record<[string][16], never>**  (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
 ### Examples
 
@@ -117,19 +111,19 @@ var geometry = turf.geometry(type, coordinates);
 // => geometry
 ```
 
-Returns **[Geometry][9]** a GeoJSON Geometry
+Returns **[Geometry][11]** a GeoJSON Geometry
 
 ## point
 
-Creates a [Point][19] [Feature][7] from a Position.
+Creates a [Point][17] [Feature][12] from a Position.
 
 ### Parameters
 
-*   `coordinates` **[Position][20]** longitude, latitude position (each in decimal degrees)
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Position][18]** longitude, latitude position (each in decimal degrees)
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -140,19 +134,19 @@ var point = turf.point([-75.343, 39.984]);
 //=point
 ```
 
-Returns **[Feature][7]<[Point][19], [GeoJsonProperties][7]>** a Point feature
+Returns **[Feature][12]<[Point][17], [GeoJsonProperties][12]>** a Point feature
 
 ## points
 
-Creates a [Point][19] [FeatureCollection][8] from an Array of Point coordinates.
+Creates a [Point][17] [FeatureCollection][19] from an Array of Point coordinates.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Position][20]>** an array of Points
-*   `properties` **[GeoJsonProperties][7]** Translate these properties to each Feature (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Position][18]>** an array of Points
+*   `properties` **[GeoJsonProperties][12]** Translate these properties to each Feature (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north]
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north]
         associated with the FeatureCollection
     *   `options.id` **Id?** Identifier associated with the FeatureCollection
 
@@ -168,19 +162,19 @@ var points = turf.points([
 //=points
 ```
 
-Returns **[FeatureCollection][8]<[Point][19]>** Point Feature
+Returns **[FeatureCollection][19]<[Point][17]>** Point Feature
 
 ## polygon
 
-Creates a [Polygon][5] [Feature][7] from an Array of LinearRings.
+Creates a [Polygon][5] [Feature][12] from an Array of LinearRings.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Array][17]<[Position][20]>>**&#x20;
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Array][15]<[Position][18]>>**&#x20;
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -191,19 +185,19 @@ var polygon = turf.polygon([[[-5, 52], [-4, 56], [-2, 51], [-7, 54], [-5, 52]]],
 //=polygon
 ```
 
-Returns **[Feature][7]<[Polygon][5], [GeoJsonProperties][7]>** Polygon Feature
+Returns **[Feature][12]<[Polygon][5], [GeoJsonProperties][12]>** Polygon Feature
 
 ## polygons
 
-Creates a [Polygon][5] [FeatureCollection][8] from an Array of Polygon coordinates.
+Creates a [Polygon][5] [FeatureCollection][19] from an Array of Polygon coordinates.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Array][17]<[Array][17]<[Position][20]>>>**&#x20;
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Array][15]<[Array][15]<[Position][18]>>>**&#x20;
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the FeatureCollection
 
 ### Examples
@@ -217,19 +211,19 @@ var polygons = turf.polygons([
 //=polygons
 ```
 
-Returns **[FeatureCollection][8]<[Polygon][5], [GeoJsonProperties][7]>** Polygon FeatureCollection
+Returns **[FeatureCollection][19]<[Polygon][5], [GeoJsonProperties][12]>** Polygon FeatureCollection
 
 ## lineString
 
-Creates a [LineString][3] [Feature][7] from an Array of Positions.
+Creates a [LineString][3] [Feature][12] from an Array of Positions.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Position][20]>** an array of Positions
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Position][18]>** an array of Positions
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -242,19 +236,19 @@ var linestring2 = turf.lineString([[-14, 43], [-13, 40], [-15, 45], [-10, 49]], 
 //=linestring2
 ```
 
-Returns **[Feature][7]<[LineString][3], [GeoJsonProperties][7]>** LineString Feature
+Returns **[Feature][12]<[LineString][3], [GeoJsonProperties][12]>** LineString Feature
 
 ## lineStrings
 
-Creates a [LineString][3] [FeatureCollection][8] from an Array of LineString coordinates.
+Creates a [LineString][3] [FeatureCollection][19] from an Array of LineString coordinates.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Array][17]<[Position][20]>>**&#x20;
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Array][15]<[Position][18]>>**&#x20;
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north]
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north]
         associated with the FeatureCollection
     *   `options.id` **Id?** Identifier associated with the FeatureCollection
 
@@ -269,18 +263,18 @@ var linestrings = turf.lineStrings([
 //=linestrings
 ```
 
-Returns **[FeatureCollection][8]<[LineString][3], [GeoJsonProperties][7]>** LineString FeatureCollection
+Returns **[FeatureCollection][19]<[LineString][3], [GeoJsonProperties][12]>** LineString FeatureCollection
 
 ## featureCollection
 
-Takes one or more [Features][7] and creates a [FeatureCollection][8].
+Takes one or more [Features][12] and creates a [FeatureCollection][19].
 
 ### Parameters
 
-*   `features` **[Array][17]<[Feature][7]<[GeometryObject][9], [GeoJsonProperties][7]>>** input features
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `features` **[Array][15]<[Feature][12]<[GeometryObject][11], [GeoJsonProperties][12]>>** input features
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -299,20 +293,20 @@ var collection = turf.featureCollection([
 //=collection
 ```
 
-Returns **[FeatureCollection][8]<[GeometryObject][9], [GeoJsonProperties][7]>** FeatureCollection of Features
+Returns **[FeatureCollection][19]<[GeometryObject][11], [GeoJsonProperties][12]>** FeatureCollection of Features
 
 ## multiLineString
 
-Creates a [Feature][7]<[MultiLineString][4]> based on a
+Creates a [Feature][12]<[MultiLineString][4]> based on a
 coordinate array. Properties can be added optionally.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Array][17]<[Position][20]>>**&#x20;
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Array][15]<[Position][18]>>**&#x20;
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -323,22 +317,22 @@ var multiLine = turf.multiLineString([[[0,0],[10,10]]]);
 //=multiLine
 ```
 
-*   Throws **[Error][21]** if no coordinates are passed
+*   Throws **[Error][20]** if no coordinates are passed
 
-Returns **[Feature][7]<[MultiLineString][4], [GeoJsonProperties][7]>** a MultiLineString feature
+Returns **[Feature][12]<[MultiLineString][4], [GeoJsonProperties][12]>** a MultiLineString feature
 
 ## multiPoint
 
-Creates a [Feature][7]<[MultiPoint][22]> based on a
+Creates a [Feature][12]<[MultiPoint][21]> based on a
 coordinate array. Properties can be added optionally.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Position][20]>** an array of Positions
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Position][18]>** an array of Positions
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -349,22 +343,22 @@ var multiPt = turf.multiPoint([[0,0],[10,10]]);
 //=multiPt
 ```
 
-*   Throws **[Error][21]** if no coordinates are passed
+*   Throws **[Error][20]** if no coordinates are passed
 
-Returns **[Feature][7]<[MultiPoint][22], [GeoJsonProperties][7]>** a MultiPoint feature
+Returns **[Feature][12]<[MultiPoint][21], [GeoJsonProperties][12]>** a MultiPoint feature
 
 ## multiPolygon
 
-Creates a [Feature][7]<[MultiPolygon][6]> based on a
+Creates a [Feature][12]<[MultiPolygon][6]> based on a
 coordinate array. Properties can be added optionally.
 
 ### Parameters
 
-*   `coordinates` **[Array][17]<[Array][17]<[Array][17]<[Position][20]>>>**&#x20;
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `coordinates` **[Array][15]<[Array][15]<[Array][15]<[Position][18]>>>**&#x20;
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -375,9 +369,9 @@ var multiPoly = turf.multiPolygon([[[[0,0],[0,10],[10,10],[10,0],[0,0]]]]);
 //=multiPoly
 ```
 
-*   Throws **[Error][21]** if no coordinates are passed
+*   Throws **[Error][20]** if no coordinates are passed
 
-Returns **[Feature][7]<[MultiPolygon][6], [GeoJsonProperties][7]>** a multipolygon feature
+Returns **[Feature][12]<[MultiPolygon][6], [GeoJsonProperties][12]>** a multipolygon feature
 
 ## geometryCollection
 
@@ -386,11 +380,11 @@ coordinate array. Properties can be added optionally.
 
 ### Parameters
 
-*   `geometries` **[Array][17]<([Point][19] | [LineString][3] | [Polygon][5] | [MultiPoint][22] | [MultiLineString][4] | [MultiPolygon][6])>** an array of GeoJSON Geometries
-*   `properties` **[GeoJsonProperties][7]** an Object of key-value pairs to add as properties (optional, default `{}`)
-*   `options` **[Object][15]** Optional Parameters (optional, default `{}`)
+*   `geometries` **[Array][15]<([Point][17] | [LineString][3] | [Polygon][5] | [MultiPoint][21] | [MultiLineString][4] | [MultiPolygon][6])>** an array of GeoJSON Geometries
+*   `properties` **[GeoJsonProperties][12]** an Object of key-value pairs to add as properties (optional, default `{}`)
+*   `options` **[Object][13]** Optional Parameters (optional, default `{}`)
 
-    *   `options.bbox` **[BBox][16]?** Bounding Box Array \[west, south, east, north] associated with the Feature
+    *   `options.bbox` **[BBox][14]?** Bounding Box Array \[west, south, east, north] associated with the Feature
     *   `options.id` **Id?** Identifier associated with the Feature
 
 ### Examples
@@ -403,7 +397,7 @@ var collection = turf.geometryCollection([pt, line]);
 // => collection
 ```
 
-Returns **[Feature][7]<[GeometryCollection][10], [GeoJsonProperties][7]>** a GeoJSON GeometryCollection Feature
+Returns **[Feature][12]<[GeometryCollection][22], [GeoJsonProperties][12]>** a GeoJSON GeometryCollection Feature
 
 ## round
 
@@ -411,8 +405,8 @@ Round number to precision
 
 ### Parameters
 
-*   `num` **[number][13]** Number
-*   `precision` **[number][13]** Precision (optional, default `0`)
+*   `num` **[number][9]** Number
+*   `precision` **[number][9]** Precision (optional, default `0`)
 
 ### Examples
 
@@ -424,7 +418,7 @@ turf.round(120.4321, 2)
 //=120.43
 ```
 
-Returns **[number][13]** rounded number
+Returns **[number][9]** rounded number
 
 ## radiansToLength
 
@@ -433,11 +427,11 @@ Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, ce
 
 ### Parameters
 
-*   `radians` **[number][13]** in radians across the sphere
+*   `radians` **[number][9]** in radians across the sphere
 *   `units` **[Units][2]** can be degrees, radians, miles, inches, yards, metres,
     meters, kilometres, kilometers. (optional, default `"kilometers"`)
 
-Returns **[number][13]** distance
+Returns **[number][9]** distance
 
 ## lengthToRadians
 
@@ -446,11 +440,11 @@ Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, ce
 
 ### Parameters
 
-*   `distance` **[number][13]** in real units
+*   `distance` **[number][9]** in real units
 *   `units` **[Units][2]** can be degrees, radians, miles, inches, yards, metres,
     meters, kilometres, kilometers. (optional, default `"kilometers"`)
 
-Returns **[number][13]** radians
+Returns **[number][9]** radians
 
 ## lengthToDegrees
 
@@ -459,11 +453,11 @@ Valid units: miles, nauticalmiles, inches, yards, meters, metres, centimeters, k
 
 ### Parameters
 
-*   `distance` **[number][13]** in real units
+*   `distance` **[number][9]** in real units
 *   `units` **[Units][2]** can be degrees, radians, miles, inches, yards, metres,
     meters, kilometres, kilometers. (optional, default `"kilometers"`)
 
-Returns **[number][13]** degrees
+Returns **[number][9]** degrees
 
 ## bearingToAzimuth
 
@@ -472,9 +466,9 @@ and returns an angle between 0-360 degrees (positive clockwise), 0 being the nor
 
 ### Parameters
 
-*   `bearing` **[number][13]** angle, between -180 and +180 degrees
+*   `bearing` **[number][9]** angle, between -180 and +180 degrees
 
-Returns **[number][13]** angle between 0 and 360 degrees
+Returns **[number][9]** angle between 0 and 360 degrees
 
 ## azimuthToBearing
 
@@ -483,9 +477,9 @@ and returns an angle between -180 and +180 degrees (positive clockwise), 0 being
 
 ### Parameters
 
-*   `angle` **[number][13]** between 0 and 360 degrees
+*   `angle` **[number][9]** between 0 and 360 degrees
 
-Returns **[number][13]** bearing between -180 and +180 degrees
+Returns **[number][9]** bearing between -180 and +180 degrees
 
 ## radiansToDegrees
 
@@ -493,9 +487,9 @@ Converts an angle in radians to degrees
 
 ### Parameters
 
-*   `radians` **[number][13]** angle in radians
+*   `radians` **[number][9]** angle in radians
 
-Returns **[number][13]** degrees between 0 and 360 degrees
+Returns **[number][9]** degrees between 0 and 360 degrees
 
 ## degreesToRadians
 
@@ -503,9 +497,9 @@ Converts an angle in degrees to radians
 
 ### Parameters
 
-*   `degrees` **[number][13]** angle between 0 and 360 degrees
+*   `degrees` **[number][9]** angle between 0 and 360 degrees
 
-Returns **[number][13]** angle in radians
+Returns **[number][9]** angle in radians
 
 ## convertLength
 
@@ -513,11 +507,11 @@ Converts a length from one unit to another.
 
 ### Parameters
 
-*   `length` **[number][13]** Length to be converted
+*   `length` **[number][9]** Length to be converted
 *   `originalUnit` **[Units][2]** Input length unit (optional, default `"kilometers"`)
 *   `finalUnit` **[Units][2]** Returned length unit (optional, default `"kilometers"`)
 
-Returns **[number][13]** The converted length
+Returns **[number][9]** The converted length
 
 ## convertArea
 
@@ -525,11 +519,11 @@ Converts an area from one unit to another.
 
 ### Parameters
 
-*   `area` **[number][13]** Area to be converted
-*   `originalUnit` **[AreaUnits][14]** Input area unit (optional, default `"meters"`)
-*   `finalUnit` **[AreaUnits][14]** Returned area unit (optional, default `"kilometers"`)
+*   `area` **[number][9]** Area to be converted
+*   `originalUnit` **[AreaUnits][10]** Input area unit (optional, default `"meters"`)
+*   `finalUnit` **[AreaUnits][10]** Returned area unit (optional, default `"kilometers"`)
 
-Returns **[number][13]** The converted length
+Returns **[number][9]** The converted length
 
 ## isNumber
 
@@ -593,37 +587,37 @@ Returns **void**&#x20;
 
 [6]: https://tools.ietf.org/html/rfc7946#section-3.1.7
 
-[7]: https://tools.ietf.org/html/rfc7946#section-3.2
+[7]: https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius
 
-[8]: https://tools.ietf.org/html/rfc7946#section-3.3
+[8]: https://rosettacode.org/wiki/Haversine_formula#:~:text=This%20value%20is%20recommended
 
-[9]: https://tools.ietf.org/html/rfc7946#section-3.1
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[10]: https://tools.ietf.org/html/rfc7946#section-3.1.8
+[10]: #areaunits
 
-[11]: https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius
+[11]: https://tools.ietf.org/html/rfc7946#section-3.1
 
-[12]: https://rosettacode.org/wiki/Haversine_formula#:~:text=This%20value%20is%20recommended
+[12]: https://tools.ietf.org/html/rfc7946#section-3.2
 
-[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[14]: #areaunits
+[14]: https://tools.ietf.org/html/rfc7946#section-5
 
-[15]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[15]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[16]: https://tools.ietf.org/html/rfc7946#section-5
+[16]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[17]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[17]: https://tools.ietf.org/html/rfc7946#section-3.1.2
 
-[18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[18]: https://developer.mozilla.org/docs/Web/API/Position
 
-[19]: https://tools.ietf.org/html/rfc7946#section-3.1.2
+[19]: https://tools.ietf.org/html/rfc7946#section-3.3
 
-[20]: https://developer.mozilla.org/docs/Web/API/Position
+[20]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
 
-[21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
+[21]: https://tools.ietf.org/html/rfc7946#section-3.1.3
 
-[22]: https://tools.ietf.org/html/rfc7946#section-3.1.3
+[22]: https://tools.ietf.org/html/rfc7946#section-3.1.8
 
 [23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 

--- a/packages/turf-helpers/index.ts
+++ b/packages/turf-helpers/index.ts
@@ -100,14 +100,6 @@ export type Corners = "sw" | "se" | "nw" | "ne" | "center" | "centroid";
 export type Lines = LineString | MultiLineString | Polygon | MultiPolygon;
 
 /**
- * Convenience type for all possible GeoJSON.
- *
- * @typedef
- */
-export type AllGeoJSON =
-  Feature | FeatureCollection | Geometry | GeometryCollection;
-
-/**
  * The Earth radius in meters. Used by Turf modules that model the Earth as a sphere. The {@link https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius mean radius} was selected because it is {@link https://rosettacode.org/wiki/Haversine_formula#:~:text=This%20value%20is%20recommended recommended } by the Haversine formula (used by turf/distance) to reduce error.
  *
  * @constant

--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -24,9 +24,9 @@ Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
 
 ### Parameters
 
-*   `geojson` **AllGeoJSON** any GeoJSON object
-*   `callback` **[coordEachCallback][4]** a method that takes (currentCoord, coordIndex, featureIndex, multiFeatureIndex)
-*   `excludeWrapCoord` **[boolean][5]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
+*   `geojson` **[GeoJSON][4]** any GeoJSON object
+*   `callback` **[coordEachCallback][5]** a method that takes (currentCoord, coordIndex, featureIndex, multiFeatureIndex)
+*   `excludeWrapCoord` **[boolean][6]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
 
 ### Examples
 
@@ -85,10 +85,10 @@ Reduce coordinates in any GeoJSON object, similar to Array.reduce()
 
 ### Parameters
 
-*   `geojson` **AllGeoJSON** any GeoJSON object
-*   `callback` **[coordReduceCallback][6]** a method that takes (previousValue, currentCoord, coordIndex)
+*   `geojson` **[GeoJSON][4]** any GeoJSON object
+*   `callback` **[coordReduceCallback][7]** a method that takes (previousValue, currentCoord, coordIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
-*   `excludeWrapCoord` **[boolean][5]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
+*   `excludeWrapCoord` **[boolean][6]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
 
 ### Examples
 
@@ -119,7 +119,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentProperties` **[GeoJsonProperties][7]** The current Properties being processed.
+*   `currentProperties` **[GeoJsonProperties][8]** The current Properties being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **void**&#x20;
@@ -130,8 +130,8 @@ Iterate over properties in any GeoJSON object, similar to Array.forEach()
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7])** any GeoJSON object
-*   `callback` **[propEachCallback][9]** a method that takes (currentProperties, featureIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8])** any GeoJSON object
+*   `callback` **[propEachCallback][10]** a method that takes (currentProperties, featureIndex)
 
 ### Examples
 
@@ -172,7 +172,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentProperties` **[GeoJsonProperties][7]** The current Properties being processed.
+*   `currentProperties` **[GeoJsonProperties][8]** The current Properties being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **Reducer**&#x20;
@@ -185,8 +185,8 @@ the reduction, so an array of all properties is unnecessary.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** any GeoJSON object
-*   `callback` **[propReduceCallback][11]** a method that takes (previousValue, currentProperties, featureIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Geometry][11])** any GeoJSON object
+*   `callback` **[propReduceCallback][12]** a method that takes (previousValue, currentProperties, featureIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -215,7 +215,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentFeature` **[Feature][7]\<any>** The current Feature being processed.
+*   `currentFeature` **[Feature][8]\<any>** The current Feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **void**&#x20;
@@ -227,8 +227,8 @@ Array.forEach.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[featureEachCallback][13]** a method that takes (currentFeature, featureIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Feature][8]<[GeometryCollection][13]>)** any GeoJSON object
+*   `callback` **[featureEachCallback][14]** a method that takes (currentFeature, featureIndex)
 
 ### Examples
 
@@ -269,7 +269,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentFeature` **[Feature][7]** The current Feature being processed.
+*   `currentFeature` **[Feature][8]** The current Feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **Reducer**&#x20;
@@ -280,8 +280,8 @@ Reduce features in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[featureReduceCallback][14]** a method that takes (previousValue, currentFeature, featureIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Feature][8]<[GeometryCollection][13]>)** any GeoJSON object
+*   `callback` **[featureReduceCallback][15]** a method that takes (previousValue, currentFeature, featureIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -308,7 +308,7 @@ Get all coordinates from any GeoJSON object.
 
 ### Parameters
 
-*   `geojson` **AllGeoJSON** any GeoJSON object
+*   `geojson` **[GeoJSON][4]** any GeoJSON object
 
 ### Examples
 
@@ -332,10 +332,10 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentGeometry` **[GeometryObject][10]** The current Geometry being processed.
+*   `currentGeometry` **[GeometryObject][11]** The current Geometry being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
-*   `featureProperties` **[GeoJsonProperties][7]** The current Feature Properties being processed.
-*   `featureBBox` **[BBox][15]** The current Feature BBox being processed.
+*   `featureProperties` **[GeoJsonProperties][8]** The current Feature Properties being processed.
+*   `featureBBox` **[BBox][16]** The current Feature BBox being processed.
 *   `featureId` **Id** The current Feature Id being processed.
 
 Returns **void**&#x20;
@@ -348,8 +348,8 @@ Note: Nested GeometryCollections are not recursively unwrapped.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10] | [GeometryObject][10] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[geomEachCallback][16]** a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Geometry][11] | [GeometryObject][11] | [Feature][8]<[GeometryCollection][13]>)** any GeoJSON object
+*   `callback` **[geomEachCallback][17]** a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
 
 ### Examples
 
@@ -393,10 +393,10 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentGeometry` **[GeometryObject][10]** The current Geometry being processed.
+*   `currentGeometry` **[GeometryObject][11]** The current Geometry being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
-*   `featureProperties` **[GeoJsonProperties][7]** The current Feature Properties being processed.
-*   `featureBBox` **[BBox][15]** The current Feature BBox being processed.
+*   `featureProperties` **[GeoJsonProperties][8]** The current Feature Properties being processed.
+*   `featureBBox` **[BBox][16]** The current Feature BBox being processed.
 *   `featureId` **Id** The current Feature Id being processed.
 
 Returns **Reducer**&#x20;
@@ -407,8 +407,8 @@ Reduce geometry in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [GeometryObject][10] | [GeometryCollection][12] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[geomReduceCallback][17]** a method that takes (previousValue, currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [GeometryObject][11] | [GeometryCollection][13] | [Feature][8]<[GeometryCollection][13]>)** any GeoJSON object
+*   `callback` **[geomReduceCallback][18]** a method that takes (previousValue, currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -440,7 +440,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentFeature` **[Feature][7]** The current flattened feature being processed.
+*   `currentFeature` **[Feature][8]** The current flattened feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 
@@ -453,8 +453,8 @@ Array.forEach.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [GeometryObject][10] | [GeometryCollection][12] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[flattenEachCallback][18]** a method that takes (currentFeature, featureIndex, multiFeatureIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [GeometryObject][11] | [GeometryCollection][13] | [Feature][8]<[GeometryCollection][13]>)** any GeoJSON object
+*   `callback` **[flattenEachCallback][19]** a method that takes (currentFeature, featureIndex, multiFeatureIndex)
 
 ### Examples
 
@@ -496,7 +496,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentFeature` **[Feature][7]** The current Feature being processed.
+*   `currentFeature` **[Feature][8]** The current Feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 
@@ -508,8 +508,8 @@ Reduce flattened features in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [GeometryObject][10] | [GeometryCollection][12] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[flattenReduceCallback][19]** a method that takes (previousValue, currentFeature, featureIndex, multiFeatureIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [GeometryObject][11] | [GeometryCollection][13] | [Feature][8]<[GeometryCollection][13]>)** any GeoJSON object
+*   `callback` **[flattenReduceCallback][20]** a method that takes (previousValue, currentFeature, featureIndex, multiFeatureIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -539,7 +539,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentSegment` **[Feature][7]<[LineString][20]>** The current Segment being processed.
+*   `currentSegment` **[Feature][8]<[LineString][21]>** The current Segment being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed.
@@ -555,7 +555,7 @@ Iterate over 2-vertex line segment in any GeoJSON object, similar to Array.forEa
 ### Parameters
 
 *   `geojson` **AllGeoJSON** any GeoJSON
-*   `callback` **[segmentEachCallback][21]** a method that takes (currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex)
+*   `callback` **[segmentEachCallback][22]** a method that takes (currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex)
 
 ### Examples
 
@@ -603,7 +603,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentSegment` **[Feature][7]<[LineString][20]>** The current Segment being processed.
+*   `currentSegment` **[Feature][8]<[LineString][21]>** The current Segment being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed.
@@ -618,8 +618,8 @@ Reduce 2-vertex line segment in any GeoJSON object, similar to Array.reduce()
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** any GeoJSON
-*   `callback` **[segmentReduceCallback][22]** a method that takes (previousValue, currentSegment, currentIndex)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Geometry][11])** any GeoJSON
+*   `callback` **[segmentReduceCallback][23]** a method that takes (previousValue, currentSegment, currentIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -656,7 +656,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentLine` **[Feature][7]<[LineString][20]>** The current LineString|LinearRing being processed
+*   `currentLine` **[Feature][8]<[LineString][21]>** The current LineString|LinearRing being processed
 *   `featureIndex` **[number][3]** The current index of the Feature being processed
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed
@@ -670,8 +670,8 @@ similar to Array.forEach.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8]\<Lines> | [Feature][7]\<Lines> | Lines | [Feature][7]<[GeometryCollection][12]> | [GeometryCollection][12])** object
-*   `callback` **[lineEachCallback][23]** a method that takes (currentLine, featureIndex, multiFeatureIndex, geometryIndex)
+*   `geojson` **([FeatureCollection][9]\<Lines> | [Feature][8]\<Lines> | Lines | [Feature][8]<[GeometryCollection][13]> | [GeometryCollection][13])** object
+*   `callback` **[lineEachCallback][24]** a method that takes (currentLine, featureIndex, multiFeatureIndex, geometryIndex)
 
 ### Examples
 
@@ -714,7 +714,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentLine` **[Feature][7]<[LineString][20]>** The current LineString|LinearRing being processed.
+*   `currentLine` **[Feature][8]<[LineString][21]>** The current LineString|LinearRing being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed
@@ -727,7 +727,7 @@ Reduce features in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8]\<Lines> | [Feature][7]\<Lines> | Lines | [Feature][7]<[GeometryCollection][12]> | [GeometryCollection][12])** object
+*   `geojson` **([FeatureCollection][9]\<Lines> | [Feature][8]\<Lines> | Lines | [Feature][8]<[GeometryCollection][13]> | [GeometryCollection][13])** object
 *   `callback` **[Function][1]** a method that takes (previousValue, currentLine, featureIndex, multiFeatureIndex, geometryIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
@@ -760,16 +760,16 @@ Point & MultiPoint will always return null.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** Any GeoJSON Feature or Geometry
-*   `options` **[Object][24]** Optional parameters (optional, default `{}`)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Geometry][11])** Any GeoJSON Feature or Geometry
+*   `options` **[Object][25]** Optional parameters (optional, default `{}`)
 
     *   `options.featureIndex` **[number][3]** Feature Index (optional, default `0`)
     *   `options.multiFeatureIndex` **[number][3]** Multi-Feature Index (optional, default `0`)
     *   `options.geometryIndex` **[number][3]** Geometry Index (optional, default `0`)
     *   `options.segmentIndex` **[number][3]** Segment Index (optional, default `0`)
-    *   `options.properties` **[Object][24]** Translate Properties to output LineString (optional, default `{}`)
-    *   `options.bbox` **[BBox][15]** Translate BBox to output LineString (optional, default `{}`)
-    *   `options.id` **([number][3] | [string][25])** Translate Id to output LineString (optional, default `{}`)
+    *   `options.properties` **[Object][25]** Translate Properties to output LineString (optional, default `{}`)
+    *   `options.bbox` **[BBox][16]** Translate BBox to output LineString (optional, default `{}`)
+    *   `options.id` **([number][3] | [string][26])** Translate Id to output LineString (optional, default `{}`)
 
 ### Examples
 
@@ -792,7 +792,7 @@ turf.findSegment(multiLine, {multiFeatureIndex: -1, segmentIndex: -1});
 // => Feature<LineString<[[-50, -30], [-30, -40]]>>
 ```
 
-Returns **[Feature][7]<[LineString][20]>** 2-vertex GeoJSON Feature LineString
+Returns **[Feature][8]<[LineString][21]>** 2-vertex GeoJSON Feature LineString
 
 ## findPoint
 
@@ -802,16 +802,16 @@ Negative indexes are permitted.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** Any GeoJSON Feature or Geometry
-*   `options` **[Object][24]** Optional parameters (optional, default `{}`)
+*   `geojson` **([FeatureCollection][9] | [Feature][8] | [Geometry][11])** Any GeoJSON Feature or Geometry
+*   `options` **[Object][25]** Optional parameters (optional, default `{}`)
 
     *   `options.featureIndex` **[number][3]** Feature Index (optional, default `0`)
     *   `options.multiFeatureIndex` **[number][3]** Multi-Feature Index (optional, default `0`)
     *   `options.geometryIndex` **[number][3]** Geometry Index (optional, default `0`)
     *   `options.coordIndex` **[number][3]** Coord Index (optional, default `0`)
-    *   `options.properties` **[Object][24]** Translate Properties to output Point (optional, default `{}`)
-    *   `options.bbox` **[BBox][15]** Translate BBox to output Point (optional, default `{}`)
-    *   `options.id` **([number][3] | [string][25])** Translate Id to output Point (optional, default `{}`)
+    *   `options.properties` **[Object][25]** Translate Properties to output Point (optional, default `{}`)
+    *   `options.bbox` **[BBox][16]** Translate BBox to output Point (optional, default `{}`)
+    *   `options.id` **([number][3] | [string][26])** Translate Id to output Point (optional, default `{}`)
 
 ### Examples
 
@@ -834,7 +834,7 @@ turf.findPoint(multiLine, {multiFeatureIndex: -1, coordIndex: -1});
 // => Feature<Point<[-30, -40]>>
 ```
 
-Returns **[Feature][7]<[Point][26]>** 2-vertex GeoJSON Feature Point
+Returns **[Feature][8]<[Point][27]>** 2-vertex GeoJSON Feature Point
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
@@ -842,51 +842,53 @@ Returns **[Feature][7]<[Point][26]>** 2-vertex GeoJSON Feature Point
 
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[4]: #coordeachcallback
+[4]: https://tools.ietf.org/html/rfc7946#section-3
 
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[5]: #coordeachcallback
 
-[6]: #coordreducecallback
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[7]: https://tools.ietf.org/html/rfc7946#section-3.2
+[7]: #coordreducecallback
 
-[8]: https://tools.ietf.org/html/rfc7946#section-3.3
+[8]: https://tools.ietf.org/html/rfc7946#section-3.2
 
-[9]: #propeachcallback
+[9]: https://tools.ietf.org/html/rfc7946#section-3.3
 
-[10]: https://tools.ietf.org/html/rfc7946#section-3.1
+[10]: #propeachcallback
 
-[11]: #propreducecallback
+[11]: https://tools.ietf.org/html/rfc7946#section-3.1
 
-[12]: https://tools.ietf.org/html/rfc7946#section-3.1.8
+[12]: #propreducecallback
 
-[13]: #featureeachcallback
+[13]: https://tools.ietf.org/html/rfc7946#section-3.1.8
 
-[14]: #featurereducecallback
+[14]: #featureeachcallback
 
-[15]: https://tools.ietf.org/html/rfc7946#section-5
+[15]: #featurereducecallback
 
-[16]: #geomeachcallback
+[16]: https://tools.ietf.org/html/rfc7946#section-5
 
-[17]: #geomreducecallback
+[17]: #geomeachcallback
 
-[18]: #flatteneachcallback
+[18]: #geomreducecallback
 
-[19]: #flattenreducecallback
+[19]: #flatteneachcallback
 
-[20]: https://tools.ietf.org/html/rfc7946#section-3.1.4
+[20]: #flattenreducecallback
 
-[21]: #segmenteachcallback
+[21]: https://tools.ietf.org/html/rfc7946#section-3.1.4
 
-[22]: #segmentreducecallback
+[22]: #segmenteachcallback
 
-[23]: #lineeachcallback
+[23]: #segmentreducecallback
 
-[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[24]: #lineeachcallback
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[26]: https://tools.ietf.org/html/rfc7946#section-3.1.2
+[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[27]: https://tools.ietf.org/html/rfc7946#section-3.1.2
 
 <!-- This file is automatically generated. Please don't edit it directly. If you find an error, edit the source file of the module in question (likely index.js or index.ts), and re-run "yarn docs" from the root of the turf project. -->
 

--- a/packages/turf-meta/bench.ts
+++ b/packages/turf-meta/bench.ts
@@ -78,21 +78,21 @@ Object.keys(fixtures).forEach((name) => {
     /* no-op */
   };
   suite
-    .add("segmentEach   - " + name, () => meta.segmentEach(geojson, noop))
-    .add("segmentReduce - " + name, () => meta.segmentReduce(geojson, noop))
-    .add("flattenEach   - " + name, () => meta.flattenEach(geojson, noop))
-    .add("flattenReduce - " + name, () => meta.flattenReduce(geojson, noop))
-    .add("coordEach     - " + name, () => meta.coordEach(geojson, noop))
-    .add("coordReduce   - " + name, () => meta.coordReduce(geojson, noop))
-    .add("propEach      - " + name, () => meta.propEach(geojson, noop))
-    .add("propReduce    - " + name, () => meta.propReduce(geojson, noop))
-    .add("geomEach      - " + name, () => meta.geomEach(geojson, noop))
-    .add("geomReduce    - " + name, () => meta.geomReduce(geojson, noop))
-    .add("featureEach   - " + name, () => meta.featureEach(geojson, noop))
-    .add("featureReduce - " + name, () => meta.featureReduce(geojson, noop))
-    .add("coordAll      - " + name, () => meta.coordAll(geojson))
-    .add("findSegment   - " + name, () => meta.findSegment(geojson))
-    .add("findPoint     - " + name, () => meta.findPoint(geojson));
+    // .add("segmentEach   - " + name, () => meta.segmentEach(geojson, noop))
+    // .add("segmentReduce - " + name, () => meta.segmentReduce(geojson, noop))
+    // .add("flattenEach   - " + name, () => meta.flattenEach(geojson, noop))
+    // .add("flattenReduce - " + name, () => meta.flattenReduce(geojson, noop))
+    // .add("coordEach     - " + name, () => meta.coordEach(geojson, noop))
+    // .add("coordReduce   - " + name, () => meta.coordReduce(geojson, noop))
+    // .add("propEach      - " + name, () => meta.propEach(geojson, noop))
+    // .add("propReduce    - " + name, () => meta.propReduce(geojson, noop))
+    .add("geomEach      - " + name, () => meta.geomEach(geojson, noop));
+  // .add("geomReduce    - " + name, () => meta.geomReduce(geojson, noop))
+  // .add("featureEach   - " + name, () => meta.featureEach(geojson, noop))
+  // .add("featureReduce - " + name, () => meta.featureReduce(geojson, noop))
+  // .add("coordAll      - " + name, () => meta.coordAll(geojson))
+  // .add("findSegment   - " + name, () => meta.findSegment(geojson))
+  // .add("findPoint     - " + name, () => meta.findPoint(geojson));
 });
 
 suite.on("cycle", (e) => console.log(String(e.target))).run();

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -617,41 +617,23 @@ function coordAll(geojson: AllGeoJSON): number[][] {
  * });
  */
 function geomEach<
-  G extends GeometryObject | null,
+  G extends
+    Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon,
   P extends GeoJsonProperties = GeoJsonProperties,
 >(
   geojson:
-    | Feature<G, P>
-    | FeatureCollection<G, P>
-    | G
-    | GeometryCollection
-    | Feature<GeometryCollection, P>,
+    | FeatureCollection<GeometryCollection<G> | G | null, P>
+    | Feature<GeometryCollection<G> | G | null, P>
+    | GeometryCollection<G>
+    | G,
   callback: (
     currentGeometry: G,
     featureIndex: number,
     featureProperties: P,
-    featureBBox: BBox,
-    featureId: Id
-  ) => void
-): void {
-  var i,
-    j,
-    g,
-    geometry,
-    stopG,
-    geometryMaybeCollection,
-    isGeometryCollection,
-    featureProperties,
-    featureBBox,
-    featureId,
-    featureIndex = 0,
-    // @ts-expect-error: Known type conflict
-    isFeatureCollection = geojson.type === "FeatureCollection",
-    // @ts-expect-error: Known type conflict
-    isFeature = geojson.type === "Feature",
-    // @ts-expect-error: Known type conflict
-    stop = isFeatureCollection ? geojson.features.length : 1;
-
+    featureBBox: BBox | undefined,
+    featureId: Id | undefined
+  ) => false | void
+): false | void {
   // This logic may look a little weird. The reason why it is that way
   // is because it's trying to be fast. GeoJSON supports multiple kinds
   // of objects at its root: FeatureCollection, Features, Geometries.
@@ -664,64 +646,39 @@ function geomEach<
   // This also aims to allocate as few resources as possible: just a
   // few numbers and booleans, rather than any temporary arrays as would
   // be required with the normalization approach.
-  for (i = 0; i < stop; i++) {
-    geometryMaybeCollection = isFeatureCollection
-      ? // @ts-expect-error: Known type conflict
-        geojson.features[i].geometry
-      : isFeature
-        ? // @ts-expect-error: Known type conflict
-          geojson.geometry
-        : geojson;
-    featureProperties = isFeatureCollection
-      ? // @ts-expect-error: Known type conflict
-        geojson.features[i].properties
-      : isFeature
-        ? // @ts-expect-error: Known type conflict
-          geojson.properties
-        : {};
-    featureBBox = isFeatureCollection
-      ? // @ts-expect-error: Known type conflict
-        geojson.features[i].bbox
-      : isFeature
-        ? // @ts-expect-error: Known type conflict
-          geojson.bbox
-        : undefined;
-    featureId = isFeatureCollection
-      ? // @ts-expect-error: Known type conflict
-        geojson.features[i].id
-      : isFeature
-        ? // @ts-expect-error: Known type conflict
-          geojson.id
-        : undefined;
-    isGeometryCollection = geometryMaybeCollection
-      ? geometryMaybeCollection.type === "GeometryCollection"
-      : false;
-    stopG = isGeometryCollection
-      ? geometryMaybeCollection.geometries.length
-      : 1;
+  for (
+    let featureIndex = 0,
+      stop = geojson.type === "FeatureCollection" ? geojson.features.length : 1;
+    featureIndex < stop;
+    featureIndex++
+  ) {
+    const feature =
+      geojson.type === "FeatureCollection"
+        ? geojson.features[featureIndex]
+        : geojson.type === "Feature"
+          ? geojson
+          : ({ geometry: geojson } as Feature<G, P>);
+    const geometryMaybeCollection = feature.geometry;
 
-    for (g = 0; g < stopG; g++) {
-      geometry = isGeometryCollection
-        ? geometryMaybeCollection.geometries[g]
-        : geometryMaybeCollection;
+    // Handle null Geometry
+    if (geometryMaybeCollection === null) {
+      continue;
+    }
 
-      // Handle null Geometry
-      if (geometry === null) {
-        if (
-          // @ts-expect-error: Known type conflict
-          callback(
-            // @ts-expect-error: Known type conflict
-            null,
-            featureIndex,
-            featureProperties,
-            featureBBox,
-            featureId
-          ) === false
-        )
-          // @ts-expect-error: Known type conflict
-          return false;
-        continue;
-      }
+    for (
+      let g = 0,
+        stopG =
+          geometryMaybeCollection.type === "GeometryCollection"
+            ? geometryMaybeCollection.geometries.length
+            : 1;
+      g < stopG;
+      g++
+    ) {
+      const geometry =
+        geometryMaybeCollection.type === "GeometryCollection"
+          ? geometryMaybeCollection.geometries[g]
+          : geometryMaybeCollection;
+
       switch (geometry.type) {
         case "Point":
         case "LineString":
@@ -730,33 +687,15 @@ function geomEach<
         case "MultiLineString":
         case "MultiPolygon": {
           if (
-            // @ts-expect-error: Known type conflict
             callback(
               geometry,
               featureIndex,
-              featureProperties,
-              featureBBox,
-              featureId
+              feature.properties,
+              feature.bbox,
+              feature.id
             ) === false
-          )
-            // @ts-expect-error: Known type conflict
+          ) {
             return false;
-          break;
-        }
-        case "GeometryCollection": {
-          for (j = 0; j < geometry.geometries.length; j++) {
-            if (
-              // @ts-expect-error: Known type conflict
-              callback(
-                geometry.geometries[j],
-                featureIndex,
-                featureProperties,
-                featureBBox,
-                featureId
-              ) === false
-            )
-              // @ts-expect-error: Known type conflict
-              return false;
           }
           break;
         }
@@ -764,8 +703,6 @@ function geomEach<
           throw new Error("Unknown Geometry Type");
       }
     }
-    // Only increase `featureIndex` per each feature
-    featureIndex++;
   }
 }
 

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -15,8 +15,12 @@ import type {
   GeoJsonTypes,
   MultiPoint,
   Position,
+  GeoJSON,
 } from "geojson";
-import { AllGeoJSON, Lines, Id } from "@turf/helpers";
+import { Lines, Id } from "@turf/helpers";
+
+export type AllGeoJSON =
+  Feature | FeatureCollection | Geometry | GeometryCollection;
 
 /**
  * Callback for coordEach
@@ -34,7 +38,7 @@ import { AllGeoJSON, Lines, Id } from "@turf/helpers";
  * Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
  *
  * @function
- * @param {AllGeoJSON} geojson any GeoJSON object
+ * @param {GeoJSON} geojson any GeoJSON object
  * @param {coordEachCallback} callback a method that takes (currentCoord, coordIndex, featureIndex, multiFeatureIndex)
  * @param {boolean} [excludeWrapCoord=false] whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration.
  * @returns {void}
@@ -52,15 +56,8 @@ import { AllGeoJSON, Lines, Id } from "@turf/helpers";
  *   //=geometryIndex
  * });
  */
-function coordEach<
-  G extends
-    Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon,
->(
-  geojson:
-    | FeatureCollection<GeometryCollection<G> | G | null>
-    | Feature<GeometryCollection<G> | G | null>
-    | GeometryCollection<G>
-    | G,
+function coordEach(
+  geojson: GeoJSON,
   callback: (
     currentCoord: Position,
     coordIndex: number,
@@ -262,7 +259,7 @@ function coordEach<
  * Reduce coordinates in any GeoJSON object, similar to Array.reduce()
  *
  * @function
- * @param {AllGeoJSON} geojson any GeoJSON object
+ * @param {GeoJSON} geojson any GeoJSON object
  * @param {coordReduceCallback} callback a method that takes (previousValue, currentCoord, coordIndex)
  * @param {Reducer} [initialValue] Value to use as the first argument to the first call of the callback.
  * @param {boolean} [excludeWrapCoord=false] whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration.
@@ -283,11 +280,12 @@ function coordEach<
  *   return currentCoord;
  * });
  */
+
 function coordReduce<Reducer>(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   callback: (
     previousValue: Reducer,
-    currentCoord: number[],
+    currentCoord: Position,
     coordIndex: number,
     featureIndex: number,
     multiFeatureIndex: number,
@@ -306,12 +304,10 @@ function coordReduce<Reducer>(
       multiFeatureIndex,
       geometryIndex
     ) {
-      if (coordIndex === 0 && initialValue === undefined)
-        // @ts-expect-error: Known type conflict
+      if (coordIndex === 0 && initialValue === undefined) {
         previousValue = currentCoord;
-      else
+      } else {
         previousValue = callback(
-          // @ts-expect-error: Known type conflict
           previousValue,
           currentCoord,
           coordIndex,
@@ -319,10 +315,10 @@ function coordReduce<Reducer>(
           multiFeatureIndex,
           geometryIndex
         );
+      }
     },
     excludeWrapCoord
   );
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -354,19 +350,18 @@ function coordReduce<Reducer>(
  * });
  */
 function propEach<Props extends GeoJsonProperties>(
-  geojson: Feature<any> | FeatureCollection<any> | Feature<GeometryCollection>,
-  callback: (currentProperties: Props, featureIndex: number) => void
+  geojson: Feature<Geometry, Props> | FeatureCollection<Geometry, Props>,
+  callback: (currentProperties: Props, featureIndex: number) => false | void
 ): void {
-  var i;
   switch (geojson.type) {
     case "FeatureCollection":
-      for (i = 0; i < geojson.features.length; i++) {
-        // @ts-expect-error: Known type conflict
-        if (callback(geojson.features[i].properties, i) === false) break;
+      for (let i = 0; i < geojson.features.length; i++) {
+        if (callback(geojson.features[i].properties, i) === false) {
+          break;
+        }
       }
       break;
     case "Feature":
-      // @ts-expect-error: Known type conflict
       callback(geojson.properties, 0);
       break;
   }
@@ -418,7 +413,7 @@ function propEach<Props extends GeoJsonProperties>(
  * });
  */
 function propReduce<Reducer, P extends GeoJsonProperties = GeoJsonProperties>(
-  geojson: Feature<any, P> | FeatureCollection<any, P> | Geometry,
+  geojson: Feature<any, P> | FeatureCollection<any, P>,
   callback: (
     previousValue: Reducer,
     currentProperties: P,
@@ -427,16 +422,12 @@ function propReduce<Reducer, P extends GeoJsonProperties = GeoJsonProperties>(
   initialValue?: Reducer
 ): Reducer {
   var previousValue = initialValue;
-  // @ts-expect-error: Known type conflict
   propEach(geojson, function (currentProperties, featureIndex) {
     if (featureIndex === 0 && initialValue === undefined)
-      // @ts-expect-error: Known type conflict
       previousValue = currentProperties;
     else
-      // @ts-expect-error: Known type conflict
       previousValue = callback(previousValue, currentProperties, featureIndex);
   });
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -472,16 +463,16 @@ function featureEach<
   G extends GeometryObject,
   P extends GeoJsonProperties = GeoJsonProperties,
 >(
-  geojson:
-    Feature<G, P> | FeatureCollection<G, P> | Feature<GeometryCollection, P>,
-  callback: (currentFeature: Feature<G, P>, featureIndex: number) => void
+  geojson: Feature<G, P> | FeatureCollection<G, P>,
+  callback: (
+    currentFeature: Feature<G, P>,
+    featureIndex: number
+  ) => false | void
 ): void {
   if (geojson.type === "Feature") {
-    // @ts-expect-error: Known type conflict
     callback(geojson, 0);
   } else if (geojson.type === "FeatureCollection") {
     for (var i = 0; i < geojson.features.length; i++) {
-      // @ts-expect-error: Known type conflict
       if (callback(geojson.features[i], i) === false) break;
     }
   }
@@ -535,8 +526,7 @@ function featureReduce<
   G extends GeometryObject,
   P extends GeoJsonProperties = GeoJsonProperties,
 >(
-  geojson:
-    Feature<G, P> | FeatureCollection<G, P> | Feature<GeometryCollection, P>,
+  geojson: Feature<G, P> | FeatureCollection<G, P>,
   callback: (
     previousValue: Reducer,
     currentFeature: Feature<G, P>,
@@ -547,12 +537,9 @@ function featureReduce<
   var previousValue = initialValue;
   featureEach(geojson, function (currentFeature, featureIndex) {
     if (featureIndex === 0 && initialValue === undefined)
-      // @ts-expect-error: Known type conflict
       previousValue = currentFeature;
-    // @ts-expect-error: Known type conflict
     else previousValue = callback(previousValue, currentFeature, featureIndex);
   });
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -560,7 +547,7 @@ function featureReduce<
  * Get all coordinates from any GeoJSON object.
  *
  * @function
- * @param {AllGeoJSON} geojson any GeoJSON object
+ * @param {GeoJSON} geojson any GeoJSON object
  * @returns {Array<Array<number>>} coordinate position array
  * @example
  * var features = turf.featureCollection([
@@ -571,13 +558,11 @@ function featureReduce<
  * var coords = turf.coordAll(features);
  * //= [[26, 37], [36, 53]]
  */
-function coordAll(geojson: AllGeoJSON): number[][] {
-  // @ts-expect-error: Known type conflict
-  var coords = [];
-  coordEach(geojson, function (coord) {
+function coordAll(geojson: GeoJSON): Position[] {
+  const coords: Position[] = [];
+  coordEach(geojson, (coord) => {
     coords.push(coord);
   });
-  // @ts-expect-error: Known type conflict
   return coords;
 }
 
@@ -787,11 +772,9 @@ function geomReduce<
       featureId
     ) {
       if (featureIndex === 0 && initialValue === undefined)
-        // @ts-expect-error: Known type conflict
         previousValue = currentGeometry;
       else
         previousValue = callback(
-          // @ts-expect-error: Known type conflict
           previousValue,
           currentGeometry,
           featureIndex,
@@ -801,7 +784,6 @@ function geomReduce<
         );
     }
   );
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -836,20 +818,20 @@ function geomReduce<
  * });
  */
 function flattenEach<
-  G extends GeometryObject = GeometryObject,
+  G extends
+    Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon,
   P extends GeoJsonProperties = GeoJsonProperties,
 >(
   geojson:
-    | Feature<G, P>
-    | FeatureCollection<G, P>
-    | G
-    | GeometryCollection
-    | Feature<GeometryCollection, P>,
+    | FeatureCollection<GeometryCollection<G> | G | null, P>
+    | Feature<GeometryCollection<G> | G | null, P>
+    | GeometryCollection<G>
+    | G,
   callback: (
     currentFeature: Feature<G, P>,
     featureIndex: number,
     multiFeatureIndex: number
-  ) => void
+  ) => false | void
 ): void {
   geomEach(geojson, function (geometry, featureIndex, properties, bbox, id) {
     // Callback for single geometry
@@ -860,7 +842,6 @@ function flattenEach<
       case "LineString":
       case "Polygon":
         if (
-          // @ts-expect-error: Known type conflict
           callback(
             feature(geometry, properties, { bbox: bbox, id: id }),
             featureIndex,
@@ -888,18 +869,15 @@ function flattenEach<
 
     for (
       var multiFeatureIndex = 0;
-      // @ts-expect-error: Known type conflict
       multiFeatureIndex < geometry.coordinates.length;
       multiFeatureIndex++
     ) {
-      // @ts-expect-error: Known type conflict
       var coordinate = geometry.coordinates[multiFeatureIndex];
       var geom = {
         type: geomType,
         coordinates: coordinate,
       };
       if (
-        // @ts-expect-error: Known type conflict
         callback(feature(geom, properties), featureIndex, multiFeatureIndex) ===
         false
       )
@@ -981,11 +959,9 @@ function flattenReduce<
         multiFeatureIndex === 0 &&
         initialValue === undefined
       )
-        // @ts-expect-error: Known type conflict
         previousValue = currentFeature;
       else
         previousValue = callback(
-          // @ts-expect-error: Known type conflict
           previousValue,
           currentFeature,
           featureIndex,
@@ -993,7 +969,6 @@ function flattenReduce<
         );
     }
   );
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -1054,13 +1029,11 @@ function segmentEach<P extends GeoJsonProperties = GeoJsonProperties>(
     if (type === "Point" || type === "MultiPoint") return;
 
     // Generate 2-vertex line segments
-    // @ts-expect-error: Known type conflict
     var previousCoords;
     var previousFeatureIndex = 0;
     var previousMultiIndex = 0;
     var prevGeomIndex = 0;
     if (
-      // @ts-expect-error: Known type conflict
       coordEach(
         feature,
         function (
@@ -1072,7 +1045,6 @@ function segmentEach<P extends GeoJsonProperties = GeoJsonProperties>(
         ) {
           // Simulating a meta.coordReduce() since `reduce` operations cannot be stopped by returning `false`
           if (
-            // @ts-expect-error: Known type conflict
             previousCoords === undefined ||
             featureIndex > previousFeatureIndex ||
             multiPartIndexCoord > previousMultiIndex ||
@@ -1086,14 +1058,11 @@ function segmentEach<P extends GeoJsonProperties = GeoJsonProperties>(
             return;
           }
           var currentSegment = lineString(
-            // @ts-expect-error: Known type conflict
             [previousCoords, currentCoord],
             feature.properties
           );
           if (
-            // @ts-expect-error: Known type conflict
             callback(
-              // @ts-expect-error: Known type conflict
               currentSegment,
               featureIndex,
               multiFeatureIndex,
@@ -1197,12 +1166,10 @@ function segmentReduce<
       segmentIndex
     ) {
       if (started === false && initialValue === undefined)
-        // @ts-expect-error: Known type conflict
         previousValue = currentSegment;
       else
         previousValue = callback(
           previousValue,
-          // @ts-expect-error: Known type conflict
           currentSegment,
           featureIndex,
           multiFeatureIndex,
@@ -1212,7 +1179,6 @@ function segmentReduce<
       started = true;
     }
   );
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -1271,7 +1237,6 @@ function lineEach<P extends GeoJsonProperties = GeoJsonProperties>(
     var coords = feature.geometry.coordinates;
     switch (type) {
       case "LineString":
-        // @ts-expect-error: Known type conflict
         if (callback(feature, featureIndex, multiFeatureIndex, 0, 0) === false)
           return false;
         break;
@@ -1282,9 +1247,7 @@ function lineEach<P extends GeoJsonProperties = GeoJsonProperties>(
           geometryIndex++
         ) {
           if (
-            // @ts-expect-error: Known type conflict
             callback(
-              // @ts-expect-error: Known type conflict
               lineString(coords[geometryIndex], feature.properties),
               featureIndex,
               multiFeatureIndex,
@@ -1366,7 +1329,6 @@ function lineReduce<Reducer, P extends GeoJsonProperties = GeoJsonProperties>(
     geojson,
     function (currentLine, featureIndex, multiFeatureIndex, geometryIndex) {
       if (featureIndex === 0 && initialValue === undefined)
-        // @ts-expect-error: Known type conflict
         previousValue = currentLine;
       else
         previousValue = callback(
@@ -1378,7 +1340,6 @@ function lineReduce<Reducer, P extends GeoJsonProperties = GeoJsonProperties>(
         );
     }
   );
-  // @ts-expect-error: Known type conflict
   return previousValue;
 }
 
@@ -1456,7 +1417,6 @@ function findSegment<
       break;
     case "Point" as GeoJsonTypes:
     case "MultiPoint" as GeoJsonTypes:
-      // @ts-expect-error: Known type conflict
       return null;
     case "LineString":
     case "Polygon":
@@ -1469,18 +1429,15 @@ function findSegment<
   }
 
   // Find SegmentIndex
-  // @ts-expect-error: Known type conflict
   if (geometry === null) return null;
   var coords = geometry.coordinates;
   switch (geometry.type) {
     case "Point" as GeoJsonTypes:
     case "MultiPoint" as GeoJsonTypes:
-      // @ts-expect-error: Known type conflict
       return null;
     case "LineString":
       if (segmentIndex < 0) segmentIndex = coords.length + segmentIndex - 1;
       return lineString(
-        // @ts-expect-error: Known type conflict
         [coords[segmentIndex], coords[segmentIndex + 1]],
         properties,
         options
@@ -1491,9 +1448,7 @@ function findSegment<
         segmentIndex = coords[geometryIndex].length + segmentIndex - 1;
       return lineString(
         [
-          // @ts-expect-error: Known type conflict
           coords[geometryIndex][segmentIndex],
-          // @ts-expect-error: Known type conflict
           coords[geometryIndex][segmentIndex + 1],
         ],
         properties,
@@ -1506,9 +1461,7 @@ function findSegment<
         segmentIndex = coords[multiFeatureIndex].length + segmentIndex - 1;
       return lineString(
         [
-          // @ts-expect-error: Known type conflict
           coords[multiFeatureIndex][segmentIndex],
-          // @ts-expect-error: Known type conflict
           coords[multiFeatureIndex][segmentIndex + 1],
         ],
         properties,
@@ -1521,13 +1474,10 @@ function findSegment<
         geometryIndex = coords[multiFeatureIndex].length + geometryIndex;
       if (segmentIndex < 0)
         segmentIndex =
-          // @ts-expect-error: Known type conflict
           coords[multiFeatureIndex][geometryIndex].length - segmentIndex - 1;
       return lineString(
         [
-          // @ts-expect-error: Known type conflict
           coords[multiFeatureIndex][geometryIndex][segmentIndex],
-          // @ts-expect-error: Known type conflict
           coords[multiFeatureIndex][geometryIndex][segmentIndex + 1],
         ],
         properties,
@@ -1610,7 +1560,6 @@ function findPoint<
       break;
     case "Point":
     case "MultiPoint":
-      // @ts-expect-error: Known type conflict
       return null;
     case "LineString":
     case "Polygon":
@@ -1623,9 +1572,7 @@ function findPoint<
   }
 
   // Find Coord Index
-  // @ts-expect-error: Known type conflict
   if (geometry === null) return null;
-  // @ts-expect-error: Known type conflict
   var coords = geometry.coordinates;
   switch (geometry.type) {
     case "Point":

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -1,5 +1,5 @@
 import { feature, point, lineString, isObject } from "@turf/helpers";
-import {
+import type {
   Point,
   LineString,
   Polygon,
@@ -13,6 +13,7 @@ import {
   GeoJsonProperties,
   BBox,
   GeoJsonTypes,
+  GeoJSON,
 } from "geojson";
 import { AllGeoJSON, Lines, Id } from "@turf/helpers";
 
@@ -51,33 +52,20 @@ import { AllGeoJSON, Lines, Id } from "@turf/helpers";
  * });
  */
 function coordEach(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   callback: (
     currentCoord: number[],
     coordIndex: number,
     featureIndex: number,
     multiFeatureIndex: number,
     geometryIndex: number
-  ) => void,
+  ) => false | void,
   excludeWrapCoord?: boolean
-): void {
+): false | void {
   // Handles null Geometry -- Skips this GeoJSON
-  if (geojson === null) return;
-  var j,
-    k,
-    l,
-    geometry,
-    stopG,
-    coords,
-    geometryMaybeCollection,
-    wrapShrink = 0,
-    coordIndex = 0,
-    isGeometryCollection,
-    type = geojson.type,
-    isFeatureCollection = type === "FeatureCollection",
-    isFeature = type === "Feature",
-    // @ts-expect-error: Known type conflict
-    stop = isFeatureCollection ? geojson.features.length : 1;
+  if (geojson === null) {
+    return;
+  }
 
   // This logic may look a little weird. The reason why it is that way
   // is because it's trying to be fast. GeoJSON supports multiple kinds
@@ -91,118 +79,142 @@ function coordEach(
   // This also aims to allocate as few resources as possible: just a
   // few numbers and booleans, rather than any temporary arrays as would
   // be required with the normalization approach.
-  for (var featureIndex = 0; featureIndex < stop; featureIndex++) {
-    geometryMaybeCollection = isFeatureCollection
-      ? // @ts-expect-error: Known type conflict
-        geojson.features[featureIndex].geometry
-      : isFeature
-        ? // @ts-expect-error: Known type conflict
-          geojson.geometry
-        : geojson;
-    isGeometryCollection = geometryMaybeCollection
-      ? geometryMaybeCollection.type === "GeometryCollection"
-      : false;
-    stopG = isGeometryCollection
-      ? geometryMaybeCollection.geometries.length
-      : 1;
 
-    for (var geomIndex = 0; geomIndex < stopG; geomIndex++) {
-      var multiFeatureIndex = 0;
-      var geometryIndex = 0;
-      geometry = isGeometryCollection
-        ? geometryMaybeCollection.geometries[geomIndex]
-        : geometryMaybeCollection;
+  let coordIndex = 0;
 
-      // Handles null Geometry -- Skips this geometry
-      if (geometry === null) continue;
-      coords = geometry.coordinates;
-      var geomType = geometry.type;
+  for (
+    let featureIndex = 0,
+      stop =
+        geojson.type === "FeatureCollection"
+          ? (geojson as FeatureCollection).features.length
+          : 1;
+    featureIndex < stop;
+    featureIndex++
+  ) {
+    const geometryMaybeCollection =
+      geojson.type === "FeatureCollection"
+        ? geojson.features[featureIndex].geometry
+        : geojson.type === "Feature"
+          ? geojson.geometry
+          : geojson;
 
-      wrapShrink =
+    // Handles null Geometry -- Skips this geometry
+    if (geometryMaybeCollection === null) {
+      continue;
+    }
+
+    const stopG =
+      geometryMaybeCollection.type === "GeometryCollection"
+        ? geometryMaybeCollection.geometries.length
+        : 1;
+
+    for (let geomIndex = 0; geomIndex < stopG; geomIndex++) {
+      let multiFeatureIndex = 0;
+      let geometryIndex = 0;
+      const geometry =
+        geometryMaybeCollection.type === "GeometryCollection"
+          ? geometryMaybeCollection.geometries[geomIndex]
+          : geometryMaybeCollection;
+
+      const wrapShrink =
         excludeWrapCoord &&
-        (geomType === "Polygon" || geomType === "MultiPolygon")
+        (geometry.type === "Polygon" || geometry.type === "MultiPolygon")
           ? 1
           : 0;
 
-      switch (geomType) {
+      switch (geometry.type) {
         case null:
           break;
         case "Point":
           if (
-            // @ts-expect-error: Known type conflict
             callback(
-              coords,
+              geometry.coordinates,
               coordIndex,
               featureIndex,
               multiFeatureIndex,
               geometryIndex
             ) === false
-          )
-            // @ts-expect-error: Known type conflict
+          ) {
             return false;
+          }
           coordIndex++;
           multiFeatureIndex++;
           break;
         case "LineString":
         case "MultiPoint":
-          for (j = 0; j < coords.length; j++) {
+          for (let j = 0; j < geometry.coordinates.length; j++) {
             if (
-              // @ts-expect-error: Known type conflict
               callback(
-                coords[j],
+                geometry.coordinates[j],
                 coordIndex,
                 featureIndex,
                 multiFeatureIndex,
                 geometryIndex
               ) === false
-            )
-              // @ts-expect-error: Known type conflict
+            ) {
               return false;
+            }
             coordIndex++;
-            if (geomType === "MultiPoint") multiFeatureIndex++;
+            if (geometry.type === "MultiPoint") {
+              multiFeatureIndex++;
+            }
           }
-          if (geomType === "LineString") multiFeatureIndex++;
+          if (geometry.type === "LineString") {
+            multiFeatureIndex++;
+          }
           break;
         case "Polygon":
         case "MultiLineString":
-          for (j = 0; j < coords.length; j++) {
-            for (k = 0; k < coords[j].length - wrapShrink; k++) {
+          for (let j = 0; j < geometry.coordinates.length; j++) {
+            for (
+              let k = 0;
+              k < geometry.coordinates[j].length - wrapShrink;
+              k++
+            ) {
               if (
-                // @ts-expect-error: Known type conflict
                 callback(
-                  coords[j][k],
+                  geometry.coordinates[j][k],
                   coordIndex,
                   featureIndex,
                   multiFeatureIndex,
                   geometryIndex
                 ) === false
-              )
-                // @ts-expect-error: Known type conflict
+              ) {
                 return false;
+              }
               coordIndex++;
             }
-            if (geomType === "MultiLineString") multiFeatureIndex++;
-            if (geomType === "Polygon") geometryIndex++;
+            if (geometry.type === "MultiLineString") {
+              multiFeatureIndex++;
+            }
+            if (geometry.type === "Polygon") {
+              geometryIndex++;
+            }
           }
-          if (geomType === "Polygon") multiFeatureIndex++;
+          if (geometry.type === "Polygon") {
+            multiFeatureIndex++;
+          }
           break;
         case "MultiPolygon":
-          for (j = 0; j < coords.length; j++) {
+          for (let j = 0; j < geometry.coordinates.length; j++) {
             geometryIndex = 0;
-            for (k = 0; k < coords[j].length; k++) {
-              for (l = 0; l < coords[j][k].length - wrapShrink; l++) {
+            for (let k = 0; k < geometry.coordinates[j].length; k++) {
+              for (
+                let l = 0;
+                l < geometry.coordinates[j][k].length - wrapShrink;
+                l++
+              ) {
                 if (
-                  // @ts-expect-error: Known type conflict
                   callback(
-                    coords[j][k][l],
+                    geometry.coordinates[j][k][l],
                     coordIndex,
                     featureIndex,
                     multiFeatureIndex,
                     geometryIndex
                   ) === false
-                )
-                  // @ts-expect-error: Known type conflict
+                ) {
                   return false;
+                }
                 coordIndex++;
               }
               geometryIndex++;
@@ -211,14 +223,14 @@ function coordEach(
           }
           break;
         case "GeometryCollection":
-          for (j = 0; j < geometry.geometries.length; j++)
+          for (let j = 0; j < geometry.geometries.length; j++) {
             if (
-              // @ts-expect-error: Known type conflict
               coordEach(geometry.geometries[j], callback, excludeWrapCoord) ===
               false
-            )
-              // @ts-expect-error: Known type conflict
+            ) {
               return false;
+            }
+          }
           break;
         default:
           throw new Error("Unknown Geometry Type");

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -13,7 +13,8 @@ import type {
   GeoJsonProperties,
   BBox,
   GeoJsonTypes,
-  GeoJSON,
+  MultiPoint,
+  Position,
 } from "geojson";
 import { AllGeoJSON, Lines, Id } from "@turf/helpers";
 
@@ -51,10 +52,17 @@ import { AllGeoJSON, Lines, Id } from "@turf/helpers";
  *   //=geometryIndex
  * });
  */
-function coordEach(
-  geojson: GeoJSON,
+function coordEach<
+  G extends
+    Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon,
+>(
+  geojson:
+    | FeatureCollection<GeometryCollection<G> | G | null>
+    | Feature<GeometryCollection<G> | G | null>
+    | GeometryCollection<G>
+    | G,
   callback: (
-    currentCoord: number[],
+    currentCoord: Position,
     coordIndex: number,
     featureIndex: number,
     multiFeatureIndex: number,
@@ -62,11 +70,6 @@ function coordEach(
   ) => false | void,
   excludeWrapCoord?: boolean
 ): false | void {
-  // Handles null Geometry -- Skips this GeoJSON
-  if (geojson === null) {
-    return;
-  }
-
   // This logic may look a little weird. The reason why it is that way
   // is because it's trying to be fast. GeoJSON supports multiple kinds
   // of objects at its root: FeatureCollection, Features, Geometries.
@@ -220,16 +223,6 @@ function coordEach(
               geometryIndex++;
             }
             multiFeatureIndex++;
-          }
-          break;
-        case "GeometryCollection":
-          for (let j = 0; j < geometry.geometries.length; j++) {
-            if (
-              coordEach(geometry.geometries[j], callback, excludeWrapCoord) ===
-              false
-            ) {
-              return false;
-            }
           }
           break;
         default:

--- a/packages/turf-meta/test.ts
+++ b/packages/turf-meta/test.ts
@@ -520,14 +520,14 @@ test("null geometries", (t) => {
   );
   t.equal(
     meta.geomReduce(fcNull, (prev) => (prev += 1), 0),
-    2,
+    0,
     "geomReduce"
-  );
+  ); // null geometries are skipped
   t.equal(
     meta.flattenReduce(fcNull, (prev) => (prev += 1), 0),
-    2,
+    0,
     "flattenReduce"
-  );
+  ); // null geometries are skipped
   t.equal(
     meta.coordReduce(fcNull, (prev) => (prev += 1), 0),
     0,
@@ -562,18 +562,18 @@ test("null geometries -- index", (t) => {
       (prev, geom, featureIndex) => prev.concat(featureIndex),
       []
     ),
-    [0, 1, 2, 3],
+    [1, 3],
     "geomReduce"
-  );
+  ); // null features are skipped
   t.deepEqual(
     meta.flattenReduce(
       fc,
       (prev, feature, featureIndex) => prev.concat(featureIndex),
       []
     ),
-    [0, 1, 2, 3],
+    [1, 3],
     "flattenReduce"
-  );
+  ); // null geometries are skipped entirely
   t.end();
 });
 
@@ -1654,25 +1654,5 @@ test("meta -- segmentEach -- Issue #1273", (t) => {
   );
   t.deepEqual(segmentIndexes, [0, 0, 0, 1, 1, 1]);
   t.deepEqual(geometryIndexes, [0, 1, 2, 0, 1, 2]);
-  t.end();
-});
-
-test("meta -- geomEach handles infinitely nested GeometryCollection", (t) => {
-  const evilNestedGeometryCollection: GeometryCollection = {
-    type: "GeometryCollection",
-    geometries: [{ type: "Point", coordinates: [0, 0] }],
-  };
-  evilNestedGeometryCollection.geometries.push(evilNestedGeometryCollection);
-
-  const calls: any[] = [];
-  meta.geomEach(evilNestedGeometryCollection, (g) => {
-    calls.push(g);
-  });
-
-  t.deepEqual(calls, [
-    evilNestedGeometryCollection.geometries[0], // first Geometry of the root collection
-    evilNestedGeometryCollection.geometries[0], // first Geometry of the nested collection
-    evilNestedGeometryCollection, // second Geometry of the nested collection, which is not recursed further
-  ]);
   t.end();
 });

--- a/packages/turf-point-on-feature/index.ts
+++ b/packages/turf-point-on-feature/index.ts
@@ -1,5 +1,4 @@
-import type { Feature, Point } from "geojson";
-import type { AllGeoJSON } from "@turf/helpers";
+import type { Feature, GeoJSON, Point } from "geojson";
 import { explode } from "@turf/explode";
 import { center as centroid } from "@turf/center";
 import { nearestPoint } from "@turf/nearest-point";
@@ -32,7 +31,7 @@ import { featureCollection, feature, point } from "@turf/helpers";
  * //addToMap
  * var addToMap = [polygon, pointOnPolygon];
  */
-function pointOnFeature(geojson: AllGeoJSON): Feature<Point> {
+function pointOnFeature(geojson: GeoJSON): Feature<Point> {
   // normalize
   const fc = normalize(geojson);
 
@@ -131,7 +130,7 @@ function pointOnFeature(geojson: AllGeoJSON): Feature<Point> {
  * @param {GeoJSON} geojson Any GeoJSON
  * @returns {FeatureCollection} FeatureCollection
  */
-function normalize(geojson: AllGeoJSON) {
+function normalize(geojson: GeoJSON) {
   if (geojson.type !== "FeatureCollection") {
     if (geojson.type !== "Feature") {
       return featureCollection([feature(geojson)]);

--- a/packages/turf-point-on-feature/package.json
+++ b/packages/turf-point-on-feature/package.json
@@ -48,6 +48,7 @@
     "@turf/truncate": "workspace:*",
     "@types/benchmark": "catalog:",
     "@types/tape": "catalog:",
+    "@turf/helpers": "workspace:*",
     "benchmark": "catalog:",
     "tape": "catalog:",
     "tsx": "catalog:",
@@ -58,7 +59,6 @@
     "@turf/boolean-point-in-polygon": "workspace:*",
     "@turf/center": "workspace:*",
     "@turf/explode": "workspace:*",
-    "@turf/helpers": "workspace:*",
     "@turf/nearest-point": "workspace:*",
     "@types/geojson": "catalog:"
   },

--- a/packages/turf-projection/index.ts
+++ b/packages/turf-projection/index.ts
@@ -1,6 +1,6 @@
 import type { Position, GeoJSON } from "geojson";
 import { coordEach } from "@turf/meta";
-import { type AllGeoJSON, isNumber } from "@turf/helpers";
+import { isNumber } from "@turf/helpers";
 import { clone } from "@turf/clone";
 
 /**
@@ -18,7 +18,7 @@ import { clone } from "@turf/clone";
  * //addToMap
  * var addToMap = [pt, converted];
  */
-function toMercator<G = AllGeoJSON | Position>(
+function toMercator<G = GeoJSON | Position>(
   geojson: G,
   options: { mutate?: boolean } = {}
 ): G {
@@ -44,7 +44,7 @@ function toMercator<G = AllGeoJSON | Position>(
  * //addToMap
  * var addToMap = [pt, converted];
  */
-function toWgs84<G = AllGeoJSON | Position>(
+function toWgs84<G = GeoJSON | Position>(
   geojson: G,
   options: { mutate?: boolean } = {}
 ): G {

--- a/packages/turf-rewind/index.ts
+++ b/packages/turf-rewind/index.ts
@@ -8,13 +8,13 @@ import type {
   MultiPolygon,
   Polygon,
   FeatureCollection,
+  GeoJSON,
 } from "geojson";
 import { clone } from "@turf/clone";
 import { booleanClockwise } from "@turf/boolean-clockwise";
 import { geomEach, featureEach } from "@turf/meta";
 import { getCoords } from "@turf/invariant";
 import { featureCollection, isObject } from "@turf/helpers";
-import type { AllGeoJSON } from "@turf/helpers";
 
 /**
  * Rewind {@link LineString|(Multi)LineString} or {@link Polygon|(Multi)Polygon} outer ring counterclockwise and inner rings clockwise (Uses {@link http://en.wikipedia.org/wiki/Shoelace_formula|Shoelace Formula}).
@@ -33,7 +33,7 @@ import type { AllGeoJSON } from "@turf/helpers";
  * //addToMap
  * var addToMap = [rewind];
  */
-function rewind<T extends AllGeoJSON>(
+function rewind<T extends GeoJSON>(
   geojson: T,
   options: {
     reverse?: boolean;

--- a/packages/turf-simplify/index.ts
+++ b/packages/turf-simplify/index.ts
@@ -1,8 +1,8 @@
-import { Geometry, Position } from "geojson";
+import type { GeoJSON, Geometry, Position } from "geojson";
 import { cleanCoords } from "@turf/clean-coords";
 import { clone } from "@turf/clone";
 import { geomEach } from "@turf/meta";
-import { AllGeoJSON, isObject } from "@turf/helpers";
+import { isObject } from "@turf/helpers";
 import { simplify as simplifyJS } from "./lib/simplify.js";
 
 /**
@@ -45,7 +45,7 @@ import { simplify as simplifyJS } from "./lib/simplify.js";
  * //addToMap
  * const addToMap = [geojson, result0_01, result0_005]
  */
-function simplify<T extends AllGeoJSON>(
+function simplify<T extends GeoJSON>(
   geojson: T,
   options: {
     tolerance?: number;

--- a/packages/turf-truncate/index.ts
+++ b/packages/turf-truncate/index.ts
@@ -1,5 +1,6 @@
 import { coordEach } from "@turf/meta";
-import { AllGeoJSON, isObject } from "@turf/helpers";
+import { isObject } from "@turf/helpers";
+import type { GeoJSON } from "geojson";
 
 /**
  * Takes a GeoJSON Feature or FeatureCollection and truncates the precision of the geometry.
@@ -24,7 +25,7 @@ import { AllGeoJSON, isObject } from "@turf/helpers";
  * //addToMap
  * var addToMap = [truncated];
  */
-function truncate<T extends AllGeoJSON>(
+function truncate<T extends GeoJSON>(
   geojson: T,
   options?: {
     precision?: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,9 +842,6 @@ importers:
 
   packages/turf-bbox:
     dependencies:
-      '@turf/helpers':
-        specifier: workspace:*
-        version: link:../turf-helpers
       '@turf/meta':
         specifier: workspace:*
         version: link:../turf-meta
@@ -852,6 +849,9 @@ importers:
         specifier: 'catalog:'
         version: 7946.0.14
     devDependencies:
+      '@turf/helpers':
+        specifier: workspace:*
+        version: link:../turf-helpers
       '@types/benchmark':
         specifier: 'catalog:'
         version: 2.1.5
@@ -2000,13 +2000,13 @@ importers:
 
   packages/turf-clone:
     dependencies:
-      '@turf/helpers':
-        specifier: workspace:*
-        version: link:../turf-helpers
       '@types/geojson':
         specifier: 'catalog:'
         version: 7946.0.14
     devDependencies:
+      '@turf/helpers':
+        specifier: workspace:*
+        version: link:../turf-helpers
       '@turf/meta':
         specifier: workspace:*
         version: link:../turf-meta
@@ -4255,9 +4255,6 @@ importers:
       '@turf/explode':
         specifier: workspace:*
         version: link:../turf-explode
-      '@turf/helpers':
-        specifier: workspace:*
-        version: link:../turf-helpers
       '@turf/nearest-point':
         specifier: workspace:*
         version: link:../turf-nearest-point
@@ -4265,6 +4262,9 @@ importers:
         specifier: 'catalog:'
         version: 7946.0.14
     devDependencies:
+      '@turf/helpers':
+        specifier: workspace:*
+        version: link:../turf-helpers
       '@turf/meta':
         specifier: workspace:*
         version: link:../turf-meta


### PR DESCRIPTION
@turf/helpers' `AllGeoJSON` is actually just @types/geojson's `GeoJSON`.

In the process of removing it, @turf/meta's internal type inconsistency caused even more typing issues. Because v8 is breaking, we can actually make the changes required to fix the type errors correctly. This is obviously very performance sensitive and will need careful consideration.

I started with coordEach and am posting this early as a draft if anyone has feedback.