### PR TITLE
break(meta) BREAK: Update coordEach for improved TypeScript inference

### DIFF
--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -10,13 +10,13 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentCoord` **[Array][2]<[number][3]>** The current coordinate being processed.
+*   `currentCoord` **[Position][2]** The current coordinate being processed.
 *   `coordIndex` **[number][3]** The current index of the coordinate being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed.
 
-Returns **void**&#x20;
+Returns **(`false` | void)** Return false to stop iteration
 
 ## coordEach
 
@@ -24,9 +24,9 @@ Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
 
 ### Parameters
 
-*   `geojson` **AllGeoJSON** any GeoJSON object
-*   `callback` **[coordEachCallback][4]** a method that takes (currentCoord, coordIndex, featureIndex, multiFeatureIndex)
-*   `excludeWrapCoord` **[boolean][5]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
+*   `geojson` **[GeoJSON][4]** any GeoJSON object, nested GeometryCollections are not supported
+*   `callback` **[coordEachCallback][5]** a method that takes (currentCoord, coordIndex, featureIndex, multiFeatureIndex)
+*   `excludeWrapCoord` **[boolean][6]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
 
 ### Examples
 
@@ -45,7 +45,7 @@ turf.coordEach(features, function (currentCoord, coordIndex, featureIndex, multi
 });
 ```
 
-Returns **void**&#x20;
+Returns **(`false` | void)** Returns false if callback returned false
 
 ## coordReduceCallback
 
@@ -70,7 +70,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentCoord` **[Array][2]<[number][3]>** The current coordinate being processed.
+*   `currentCoord` **[Array][7]<[number][3]>** The current coordinate being processed.
 *   `coordIndex` **[number][3]** The current index of the coordinate being processed.
     Starts at index 0, if an initialValue is provided, and at index 1 otherwise.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
@@ -86,9 +86,9 @@ Reduce coordinates in any GeoJSON object, similar to Array.reduce()
 ### Parameters
 
 *   `geojson` **AllGeoJSON** any GeoJSON object
-*   `callback` **[coordReduceCallback][6]** a method that takes (previousValue, currentCoord, coordIndex)
+*   `callback` **[coordReduceCallback][8]** a method that takes (previousValue, currentCoord, coordIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
-*   `excludeWrapCoord` **[boolean][5]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
+*   `excludeWrapCoord` **[boolean][6]** whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration. (optional, default `false`)
 
 ### Examples
 
@@ -119,7 +119,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentProperties` **[GeoJsonProperties][7]** The current Properties being processed.
+*   `currentProperties` **[GeoJsonProperties][9]** The current Properties being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **void**&#x20;
@@ -130,8 +130,8 @@ Iterate over properties in any GeoJSON object, similar to Array.forEach()
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7])** any GeoJSON object
-*   `callback` **[propEachCallback][9]** a method that takes (currentProperties, featureIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9])** any GeoJSON object
+*   `callback` **[propEachCallback][11]** a method that takes (currentProperties, featureIndex)
 
 ### Examples
 
@@ -172,7 +172,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentProperties` **[GeoJsonProperties][7]** The current Properties being processed.
+*   `currentProperties` **[GeoJsonProperties][9]** The current Properties being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **Reducer**&#x20;
@@ -185,8 +185,8 @@ the reduction, so an array of all properties is unnecessary.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** any GeoJSON object
-*   `callback` **[propReduceCallback][11]** a method that takes (previousValue, currentProperties, featureIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Geometry][12])** any GeoJSON object
+*   `callback` **[propReduceCallback][13]** a method that takes (previousValue, currentProperties, featureIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -215,7 +215,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentFeature` **[Feature][7]\<any>** The current Feature being processed.
+*   `currentFeature` **[Feature][9]\<any>** The current Feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **void**&#x20;
@@ -227,8 +227,8 @@ Array.forEach.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[featureEachCallback][13]** a method that takes (currentFeature, featureIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Feature][9]<[GeometryCollection][14]>)** any GeoJSON object
+*   `callback` **[featureEachCallback][15]** a method that takes (currentFeature, featureIndex)
 
 ### Examples
 
@@ -269,7 +269,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentFeature` **[Feature][7]** The current Feature being processed.
+*   `currentFeature` **[Feature][9]** The current Feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
 Returns **Reducer**&#x20;
@@ -280,8 +280,8 @@ Reduce features in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[featureReduceCallback][14]** a method that takes (previousValue, currentFeature, featureIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Feature][9]<[GeometryCollection][14]>)** any GeoJSON object
+*   `callback` **[featureReduceCallback][16]** a method that takes (previousValue, currentFeature, featureIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -322,7 +322,7 @@ var coords = turf.coordAll(features);
 //= [[26, 37], [36, 53]]
 ```
 
-Returns **[Array][2]<[Array][2]<[number][3]>>** coordinate position array
+Returns **[Array][7]<[Array][7]<[number][3]>>** coordinate position array
 
 ## geomEachCallback
 
@@ -332,10 +332,10 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentGeometry` **[GeometryObject][10]** The current Geometry being processed.
+*   `currentGeometry` **[GeometryObject][12]** The current Geometry being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
-*   `featureProperties` **[GeoJsonProperties][7]** The current Feature Properties being processed.
-*   `featureBBox` **[BBox][15]** The current Feature BBox being processed.
+*   `featureProperties` **[GeoJsonProperties][9]** The current Feature Properties being processed.
+*   `featureBBox` **[BBox][17]** The current Feature BBox being processed.
 *   `featureId` **Id** The current Feature Id being processed.
 
 Returns **void**&#x20;
@@ -348,8 +348,8 @@ Note: Nested GeometryCollections are not recursively unwrapped.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10] | [GeometryObject][10] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[geomEachCallback][16]** a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Geometry][12] | [GeometryObject][12] | [Feature][9]<[GeometryCollection][14]>)** any GeoJSON object
+*   `callback` **[geomEachCallback][18]** a method that takes (currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
 
 ### Examples
 
@@ -393,10 +393,10 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentGeometry` **[GeometryObject][10]** The current Geometry being processed.
+*   `currentGeometry` **[GeometryObject][12]** The current Geometry being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
-*   `featureProperties` **[GeoJsonProperties][7]** The current Feature Properties being processed.
-*   `featureBBox` **[BBox][15]** The current Feature BBox being processed.
+*   `featureProperties` **[GeoJsonProperties][9]** The current Feature Properties being processed.
+*   `featureBBox` **[BBox][17]** The current Feature BBox being processed.
 *   `featureId` **Id** The current Feature Id being processed.
 
 Returns **Reducer**&#x20;
@@ -407,8 +407,8 @@ Reduce geometry in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [GeometryObject][10] | [GeometryCollection][12] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[geomReduceCallback][17]** a method that takes (previousValue, currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [GeometryObject][12] | [GeometryCollection][14] | [Feature][9]<[GeometryCollection][14]>)** any GeoJSON object
+*   `callback` **[geomReduceCallback][19]** a method that takes (previousValue, currentGeometry, featureIndex, featureProperties, featureBBox, featureId)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -440,7 +440,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentFeature` **[Feature][7]** The current flattened feature being processed.
+*   `currentFeature` **[Feature][9]** The current flattened feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 
@@ -453,8 +453,8 @@ Array.forEach.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [GeometryObject][10] | [GeometryCollection][12] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[flattenEachCallback][18]** a method that takes (currentFeature, featureIndex, multiFeatureIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [GeometryObject][12] | [GeometryCollection][14] | [Feature][9]<[GeometryCollection][14]>)** any GeoJSON object
+*   `callback` **[flattenEachCallback][20]** a method that takes (currentFeature, featureIndex, multiFeatureIndex)
 
 ### Examples
 
@@ -496,7 +496,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentFeature` **[Feature][7]** The current Feature being processed.
+*   `currentFeature` **[Feature][9]** The current Feature being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 
@@ -508,8 +508,8 @@ Reduce flattened features in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [GeometryObject][10] | [GeometryCollection][12] | [Feature][7]<[GeometryCollection][12]>)** any GeoJSON object
-*   `callback` **[flattenReduceCallback][19]** a method that takes (previousValue, currentFeature, featureIndex, multiFeatureIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [GeometryObject][12] | [GeometryCollection][14] | [Feature][9]<[GeometryCollection][14]>)** any GeoJSON object
+*   `callback` **[flattenReduceCallback][21]** a method that takes (previousValue, currentFeature, featureIndex, multiFeatureIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -539,7 +539,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentSegment` **[Feature][7]<[LineString][20]>** The current Segment being processed.
+*   `currentSegment` **[Feature][9]<[LineString][22]>** The current Segment being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed.
@@ -555,7 +555,7 @@ Iterate over 2-vertex line segment in any GeoJSON object, similar to Array.forEa
 ### Parameters
 
 *   `geojson` **AllGeoJSON** any GeoJSON
-*   `callback` **[segmentEachCallback][21]** a method that takes (currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex)
+*   `callback` **[segmentEachCallback][23]** a method that takes (currentSegment, featureIndex, multiFeatureIndex, geometryIndex, segmentIndex)
 
 ### Examples
 
@@ -603,7 +603,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentSegment` **[Feature][7]<[LineString][20]>** The current Segment being processed.
+*   `currentSegment` **[Feature][9]<[LineString][22]>** The current Segment being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed.
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed.
@@ -618,8 +618,8 @@ Reduce 2-vertex line segment in any GeoJSON object, similar to Array.reduce()
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** any GeoJSON
-*   `callback` **[segmentReduceCallback][22]** a method that takes (previousValue, currentSegment, currentIndex)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Geometry][12])** any GeoJSON
+*   `callback` **[segmentReduceCallback][24]** a method that takes (previousValue, currentSegment, currentIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
 ### Examples
@@ -656,7 +656,7 @@ Type: [Function][1]
 
 ### Parameters
 
-*   `currentLine` **[Feature][7]<[LineString][20]>** The current LineString|LinearRing being processed
+*   `currentLine` **[Feature][9]<[LineString][22]>** The current LineString|LinearRing being processed
 *   `featureIndex` **[number][3]** The current index of the Feature being processed
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed
@@ -670,8 +670,8 @@ similar to Array.forEach.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8]\<Lines> | [Feature][7]\<Lines> | Lines | [Feature][7]<[GeometryCollection][12]> | [GeometryCollection][12])** object
-*   `callback` **[lineEachCallback][23]** a method that takes (currentLine, featureIndex, multiFeatureIndex, geometryIndex)
+*   `geojson` **([FeatureCollection][10]\<Lines> | [Feature][9]\<Lines> | Lines | [Feature][9]<[GeometryCollection][14]> | [GeometryCollection][14])** object
+*   `callback` **[lineEachCallback][25]** a method that takes (currentLine, featureIndex, multiFeatureIndex, geometryIndex)
 
 ### Examples
 
@@ -714,7 +714,7 @@ Type: [Function][1]
 
 *   `previousValue` **Reducer** The accumulated value previously returned in the last invocation
     of the callback, or initialValue, if supplied.
-*   `currentLine` **[Feature][7]<[LineString][20]>** The current LineString|LinearRing being processed.
+*   `currentLine` **[Feature][9]<[LineString][22]>** The current LineString|LinearRing being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed
 *   `multiFeatureIndex` **[number][3]** The current index of the Multi-Feature being processed
 *   `geometryIndex` **[number][3]** The current index of the Geometry being processed
@@ -727,7 +727,7 @@ Reduce features in any GeoJSON object, similar to Array.reduce().
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8]\<Lines> | [Feature][7]\<Lines> | Lines | [Feature][7]<[GeometryCollection][12]> | [GeometryCollection][12])** object
+*   `geojson` **([FeatureCollection][10]\<Lines> | [Feature][9]\<Lines> | Lines | [Feature][9]<[GeometryCollection][14]> | [GeometryCollection][14])** object
 *   `callback` **[Function][1]** a method that takes (previousValue, currentLine, featureIndex, multiFeatureIndex, geometryIndex)
 *   `initialValue` **Reducer?** Value to use as the first argument to the first call of the callback.
 
@@ -760,16 +760,16 @@ Point & MultiPoint will always return null.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** Any GeoJSON Feature or Geometry
-*   `options` **[Object][24]** Optional parameters (optional, default `{}`)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Geometry][12])** Any GeoJSON Feature or Geometry
+*   `options` **[Object][26]** Optional parameters (optional, default `{}`)
 
     *   `options.featureIndex` **[number][3]** Feature Index (optional, default `0`)
     *   `options.multiFeatureIndex` **[number][3]** Multi-Feature Index (optional, default `0`)
     *   `options.geometryIndex` **[number][3]** Geometry Index (optional, default `0`)
     *   `options.segmentIndex` **[number][3]** Segment Index (optional, default `0`)
-    *   `options.properties` **[Object][24]** Translate Properties to output LineString (optional, default `{}`)
-    *   `options.bbox` **[BBox][15]** Translate BBox to output LineString (optional, default `{}`)
-    *   `options.id` **([number][3] | [string][25])** Translate Id to output LineString (optional, default `{}`)
+    *   `options.properties` **[Object][26]** Translate Properties to output LineString (optional, default `{}`)
+    *   `options.bbox` **[BBox][17]** Translate BBox to output LineString (optional, default `{}`)
+    *   `options.id` **([number][3] | [string][27])** Translate Id to output LineString (optional, default `{}`)
 
 ### Examples
 
@@ -792,7 +792,7 @@ turf.findSegment(multiLine, {multiFeatureIndex: -1, segmentIndex: -1});
 // => Feature<LineString<[[-50, -30], [-30, -40]]>>
 ```
 
-Returns **[Feature][7]<[LineString][20]>** 2-vertex GeoJSON Feature LineString
+Returns **[Feature][9]<[LineString][22]>** 2-vertex GeoJSON Feature LineString
 
 ## findPoint
 
@@ -802,16 +802,16 @@ Negative indexes are permitted.
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][8] | [Feature][7] | [Geometry][10])** Any GeoJSON Feature or Geometry
-*   `options` **[Object][24]** Optional parameters (optional, default `{}`)
+*   `geojson` **([FeatureCollection][10] | [Feature][9] | [Geometry][12])** Any GeoJSON Feature or Geometry
+*   `options` **[Object][26]** Optional parameters (optional, default `{}`)
 
     *   `options.featureIndex` **[number][3]** Feature Index (optional, default `0`)
     *   `options.multiFeatureIndex` **[number][3]** Multi-Feature Index (optional, default `0`)
     *   `options.geometryIndex` **[number][3]** Geometry Index (optional, default `0`)
     *   `options.coordIndex` **[number][3]** Coord Index (optional, default `0`)
-    *   `options.properties` **[Object][24]** Translate Properties to output Point (optional, default `{}`)
-    *   `options.bbox` **[BBox][15]** Translate BBox to output Point (optional, default `{}`)
-    *   `options.id` **([number][3] | [string][25])** Translate Id to output Point (optional, default `{}`)
+    *   `options.properties` **[Object][26]** Translate Properties to output Point (optional, default `{}`)
+    *   `options.bbox` **[BBox][17]** Translate BBox to output Point (optional, default `{}`)
+    *   `options.id` **([number][3] | [string][27])** Translate Id to output Point (optional, default `{}`)
 
 ### Examples
 
@@ -834,59 +834,63 @@ turf.findPoint(multiLine, {multiFeatureIndex: -1, coordIndex: -1});
 // => Feature<Point<[-30, -40]>>
 ```
 
-Returns **[Feature][7]<[Point][26]>** 2-vertex GeoJSON Feature Point
+Returns **[Feature][9]<[Point][28]>** 2-vertex GeoJSON Feature Point
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[2]: https://developer.mozilla.org/docs/Web/API/Position
 
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[4]: #coordeachcallback
+[4]: https://tools.ietf.org/html/rfc7946#section-3
 
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[5]: #coordeachcallback
 
-[6]: #coordreducecallback
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[7]: https://tools.ietf.org/html/rfc7946#section-3.2
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[8]: https://tools.ietf.org/html/rfc7946#section-3.3
+[8]: #coordreducecallback
 
-[9]: #propeachcallback
+[9]: https://tools.ietf.org/html/rfc7946#section-3.2
 
-[10]: https://tools.ietf.org/html/rfc7946#section-3.1
+[10]: https://tools.ietf.org/html/rfc7946#section-3.3
 
-[11]: #propreducecallback
+[11]: #propeachcallback
 
-[12]: https://tools.ietf.org/html/rfc7946#section-3.1.8
+[12]: https://tools.ietf.org/html/rfc7946#section-3.1
 
-[13]: #featureeachcallback
+[13]: #propreducecallback
 
-[14]: #featurereducecallback
+[14]: https://tools.ietf.org/html/rfc7946#section-3.1.8
 
-[15]: https://tools.ietf.org/html/rfc7946#section-5
+[15]: #featureeachcallback
 
-[16]: #geomeachcallback
+[16]: #featurereducecallback
 
-[17]: #geomreducecallback
+[17]: https://tools.ietf.org/html/rfc7946#section-5
 
-[18]: #flatteneachcallback
+[18]: #geomeachcallback
 
-[19]: #flattenreducecallback
+[19]: #geomreducecallback
 
-[20]: https://tools.ietf.org/html/rfc7946#section-3.1.4
+[20]: #flatteneachcallback
 
-[21]: #segmenteachcallback
+[21]: #flattenreducecallback
 
-[22]: #segmentreducecallback
+[22]: https://tools.ietf.org/html/rfc7946#section-3.1.4
 
-[23]: #lineeachcallback
+[23]: #segmenteachcallback
 
-[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[24]: #segmentreducecallback
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[25]: #lineeachcallback
 
-[26]: https://tools.ietf.org/html/rfc7946#section-3.1.2
+[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[28]: https://tools.ietf.org/html/rfc7946#section-3.1.2
 
 <!-- This file is automatically generated. Please don't edit it directly. If you find an error, edit the source file of the module in question (likely index.js or index.ts), and re-run "yarn docs" from the root of the turf project. -->
 

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -1,5 +1,5 @@
 import { feature, point, lineString, isObject } from "@turf/helpers";
-import {
+import type {
   Point,
   LineString,
   Polygon,
@@ -13,29 +13,31 @@ import {
   GeoJsonProperties,
   BBox,
   GeoJsonTypes,
+  GeoJSON,
+  Position,
 } from "geojson";
-import { AllGeoJSON, Lines, Id } from "@turf/helpers";
+import type { AllGeoJSON, Lines, Id } from "@turf/helpers";
 
 /**
  * Callback for coordEach
  *
  * @callback coordEachCallback
- * @param {number[]} currentCoord The current coordinate being processed.
+ * @param {Position} currentCoord The current coordinate being processed.
  * @param {number} coordIndex The current index of the coordinate being processed.
  * @param {number} featureIndex The current index of the Feature being processed.
  * @param {number} multiFeatureIndex The current index of the Multi-Feature being processed.
  * @param {number} geometryIndex The current index of the Geometry being processed.
- * @returns {void}
+ * @returns {false|void} Return false to stop iteration
  */
 
 /**
  * Iterate over coordinates in any GeoJSON object, similar to Array.forEach()
  *
  * @function
- * @param {AllGeoJSON} geojson any GeoJSON object
+ * @param {GeoJSON} geojson any GeoJSON object, nested GeometryCollections are not supported
  * @param {coordEachCallback} callback a method that takes (currentCoord, coordIndex, featureIndex, multiFeatureIndex)
  * @param {boolean} [excludeWrapCoord=false] whether or not to include the final coordinate of LinearRings that wraps the ring in its iteration.
- * @returns {void}
+ * @returns {false|void} Returns false if callback returned false
  * @example
  * var features = turf.featureCollection([
  *   turf.point([26, 37], {"foo": "bar"}),
@@ -51,33 +53,21 @@ import { AllGeoJSON, Lines, Id } from "@turf/helpers";
  * });
  */
 function coordEach(
-  geojson: AllGeoJSON,
+  geojson: GeoJSON,
   callback: (
-    currentCoord: number[],
+    currentCoord: Position,
     coordIndex: number,
     featureIndex: number,
     multiFeatureIndex: number,
     geometryIndex: number
-  ) => void,
+  ) => false | void,
   excludeWrapCoord?: boolean
-): void {
-  // Handles null Geometry -- Skips this GeoJSON
+): false | void {
+  // Handles null Geometry -- Skips this GeoJSON, this isn't strictly allowed by the type signature but acts as a nice defense
   if (geojson === null) return;
-  var j,
-    k,
-    l,
-    geometry,
-    stopG,
-    coords,
-    geometryMaybeCollection,
-    wrapShrink = 0,
-    coordIndex = 0,
-    isGeometryCollection,
-    type = geojson.type,
-    isFeatureCollection = type === "FeatureCollection",
-    isFeature = type === "Feature",
-    // @ts-expect-error: Known type conflict
-    stop = isFeatureCollection ? geojson.features.length : 1;
+
+  let coordIndex = 0;
+  const wrapShrink = excludeWrapCoord ? 1 : 0;
 
   // This logic may look a little weird. The reason why it is that way
   // is because it's trying to be fast. GeoJSON supports multiple kinds
@@ -91,117 +81,135 @@ function coordEach(
   // This also aims to allocate as few resources as possible: just a
   // few numbers and booleans, rather than any temporary arrays as would
   // be required with the normalization approach.
-  for (var featureIndex = 0; featureIndex < stop; featureIndex++) {
-    geometryMaybeCollection = isFeatureCollection
-      ? // @ts-expect-error: Known type conflict
-        geojson.features[featureIndex].geometry
-      : isFeature
-        ? // @ts-expect-error: Known type conflict
-          geojson.geometry
-        : geojson;
-    isGeometryCollection = geometryMaybeCollection
-      ? geometryMaybeCollection.type === "GeometryCollection"
-      : false;
-    stopG = isGeometryCollection
-      ? geometryMaybeCollection.geometries.length
-      : 1;
+  const stop =
+    geojson.type === "FeatureCollection" ? geojson.features.length : 1;
+  for (let featureIndex = 0; featureIndex < stop; featureIndex++) {
+    // unwrap a Feature / FeatureCollection to get the underlying Geometry
+    const geometryMaybeCollection =
+      geojson.type === "FeatureCollection"
+        ? geojson.features[featureIndex].geometry
+        : geojson.type === "Feature"
+          ? geojson.geometry
+          : geojson;
 
-    for (var geomIndex = 0; geomIndex < stopG; geomIndex++) {
-      var multiFeatureIndex = 0;
-      var geometryIndex = 0;
-      geometry = isGeometryCollection
-        ? geometryMaybeCollection.geometries[geomIndex]
-        : geometryMaybeCollection;
+    // Handles null Geometry -- Skips this geometry
+    // This can happen with a Feature that contains a null Geometry, which is spec-compliant but not part of @types/geojson
+    if (geometryMaybeCollection === null) continue;
 
-      // Handles null Geometry -- Skips this geometry
-      if (geometry === null) continue;
-      coords = geometry.coordinates;
-      var geomType = geometry.type;
+    const stopG =
+      geometryMaybeCollection.type === "GeometryCollection"
+        ? geometryMaybeCollection.geometries.length
+        : 1;
+    for (let geomIndex = 0; geomIndex < stopG; geomIndex++) {
+      let multiFeatureIndex = 0;
+      let geometryIndex = 0;
 
-      wrapShrink =
-        excludeWrapCoord &&
-        (geomType === "Polygon" || geomType === "MultiPolygon")
-          ? 1
-          : 0;
+      // unwrap a GeometryCollection if one exists
+      const geometry =
+        geometryMaybeCollection.type === "GeometryCollection"
+          ? geometryMaybeCollection.geometries[geomIndex]
+          : geometryMaybeCollection;
 
-      switch (geomType) {
-        case null:
-          break;
+      switch (geometry.type) {
         case "Point":
           if (
-            // @ts-expect-error: Known type conflict
             callback(
-              coords,
+              geometry.coordinates,
               coordIndex,
               featureIndex,
               multiFeatureIndex,
               geometryIndex
             ) === false
           )
-            // @ts-expect-error: Known type conflict
             return false;
           coordIndex++;
           multiFeatureIndex++;
           break;
         case "LineString":
-        case "MultiPoint":
-          for (j = 0; j < coords.length; j++) {
+          for (const coord of geometry.coordinates) {
             if (
-              // @ts-expect-error: Known type conflict
               callback(
-                coords[j],
+                coord,
                 coordIndex,
                 featureIndex,
                 multiFeatureIndex,
                 geometryIndex
               ) === false
             )
-              // @ts-expect-error: Known type conflict
               return false;
             coordIndex++;
-            if (geomType === "MultiPoint") multiFeatureIndex++;
           }
-          if (geomType === "LineString") multiFeatureIndex++;
+          multiFeatureIndex++;
+          break;
+        case "MultiPoint":
+          for (const coord of geometry.coordinates) {
+            if (
+              callback(
+                coord,
+                coordIndex,
+                featureIndex,
+                multiFeatureIndex,
+                geometryIndex
+              ) === false
+            )
+              return false;
+            coordIndex++;
+            multiFeatureIndex++;
+          }
           break;
         case "Polygon":
-        case "MultiLineString":
-          for (j = 0; j < coords.length; j++) {
-            for (k = 0; k < coords[j].length - wrapShrink; k++) {
+          for (const ring of geometry.coordinates) {
+            const len = ring.length - wrapShrink;
+            for (let k = 0; k < len; k++) {
               if (
-                // @ts-expect-error: Known type conflict
                 callback(
-                  coords[j][k],
+                  ring[k],
                   coordIndex,
                   featureIndex,
                   multiFeatureIndex,
                   geometryIndex
                 ) === false
               )
-                // @ts-expect-error: Known type conflict
                 return false;
               coordIndex++;
             }
-            if (geomType === "MultiLineString") multiFeatureIndex++;
-            if (geomType === "Polygon") geometryIndex++;
+            geometryIndex++;
           }
-          if (geomType === "Polygon") multiFeatureIndex++;
+          multiFeatureIndex++;
+          break;
+        case "MultiLineString":
+          for (const line of geometry.coordinates) {
+            for (const coord of line) {
+              if (
+                callback(
+                  coord,
+                  coordIndex,
+                  featureIndex,
+                  multiFeatureIndex,
+                  geometryIndex
+                ) === false
+              )
+                return false;
+              coordIndex++;
+            }
+            multiFeatureIndex++;
+          }
           break;
         case "MultiPolygon":
-          for (j = 0; j < coords.length; j++) {
+          for (const polygon of geometry.coordinates) {
             geometryIndex = 0;
-            for (k = 0; k < coords[j].length; k++) {
-              for (l = 0; l < coords[j][k].length - wrapShrink; l++) {
+            for (const ring of polygon) {
+              const len = ring.length - wrapShrink;
+              for (let l = 0; l < len; l++) {
                 if (
-                  // @ts-expect-error: Known type conflict
                   callback(
-                    coords[j][k][l],
+                    ring[l],
                     coordIndex,
                     featureIndex,
                     multiFeatureIndex,
                     geometryIndex
                   ) === false
                 )
-                  // @ts-expect-error: Known type conflict
                   return false;
                 coordIndex++;
               }
@@ -211,15 +219,7 @@ function coordEach(
           }
           break;
         case "GeometryCollection":
-          for (j = 0; j < geometry.geometries.length; j++)
-            if (
-              // @ts-expect-error: Known type conflict
-              coordEach(geometry.geometries[j], callback, excludeWrapCoord) ===
-              false
-            )
-              // @ts-expect-error: Known type conflict
-              return false;
-          break;
+          throw new Error("Nested GeometryCollections are not supported");
         default:
           throw new Error("Unknown Geometry Type");
       }
@@ -1118,7 +1118,6 @@ function segmentEach<P extends GeoJsonProperties = GeoJsonProperties>(
     var previousMultiIndex = 0;
     var prevGeomIndex = 0;
     if (
-      // @ts-expect-error: Known type conflict
       coordEach(
         feature,
         function (

--- a/packages/turf-meta/test.ts
+++ b/packages/turf-meta/test.ts
@@ -11,8 +11,18 @@ import {
   featureCollection,
   lineStrings,
 } from "@turf/helpers";
-import * as meta from "./index.js";
-import { GeometryCollection } from "geojson";
+import * as meta from "./index.ts";
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJSON,
+  Geometry,
+  GeometryCollection,
+  LineString,
+  MultiLineString,
+  Point,
+  Position,
+} from "geojson";
 
 const pt = point([0, 0], { a: 1 });
 const pt2 = point([1, 1]);
@@ -81,7 +91,7 @@ const geomCollection = geometryCollection(
   { a: 0 }
 );
 const fcNull = featureCollection([feature(null), feature(null)]);
-const fcMixed = featureCollection([
+const fcMixed = featureCollection<Point | LineString | MultiLineString>([
   point([0, 0]),
   lineString([
     [1, 1],
@@ -99,8 +109,13 @@ const fcMixed = featureCollection([
   ]),
 ]);
 
-function collection(feature) {
-  const featureCollection = {
+const fcPoints = featureCollection([pt, pt2]);
+const fcMultiPoly = featureCollection([multiPoly, multiPoly]);
+
+function collection<G extends Geometry>(
+  feature: Feature<G>
+): [Feature<G>, FeatureCollection<G>] {
+  const featureCollection: FeatureCollection<G> = {
     type: "FeatureCollection",
     features: [feature],
   };
@@ -108,14 +123,16 @@ function collection(feature) {
   return [feature, featureCollection];
 }
 
-function featureAndCollection(geometry) {
-  const feature = {
+function featureAndCollection<G extends Geometry>(
+  geometry: G
+): [G, Feature<G>, FeatureCollection<G>] {
+  const feature: Feature<G> = {
     type: "Feature",
     geometry: geometry,
     properties: { a: 1 },
   };
 
-  const featureCollection = {
+  const featureCollection: FeatureCollection<G> = {
     type: "FeatureCollection",
     features: [feature],
   };
@@ -145,7 +162,7 @@ test("coordEach -- Point", (t) => {
 
 test("coordEach -- LineString", (t) => {
   featureAndCollection(line.geometry).forEach((input) => {
-    const output = [];
+    const output: Position[] = [];
     let lastIndex;
     meta.coordEach(input, (coord, index) => {
       output.push(coord);
@@ -162,7 +179,7 @@ test("coordEach -- LineString", (t) => {
 
 test("coordEach -- Polygon", (t) => {
   featureAndCollection(poly.geometry).forEach((input) => {
-    const output = [];
+    const output: Position[] = [];
     let lastIndex;
     meta.coordEach(input, (coord, index) => {
       output.push(coord);
@@ -196,11 +213,34 @@ test("coordEach -- Polygon excludeWrapCoord", (t) => {
   t.end();
 });
 
+test("coordEach -- MultiPolygon excludeWrapCoord", (t) => {
+  featureAndCollection(multiPoly.geometry).forEach((input) => {
+    let lastIndex;
+    meta.coordEach(
+      input,
+      (_coord, index) => {
+        lastIndex = index;
+      },
+      true
+    );
+    t.equal(lastIndex, 5);
+  });
+  t.end();
+});
+
+test("coordEach -- null", (t) => {
+  meta.coordEach(null as unknown as GeoJSON, (c) =>
+    t.fail("coordEach should not call its callback on null input")
+  );
+  t.ok("coordEach should handle null input without failing");
+  t.end();
+});
+
 test("coordEach -- MultiPolygon", (t) => {
-  const coords = [];
-  const coordIndexes = [];
-  const featureIndexes = [];
-  const multiFeatureIndexes = [];
+  const coords: Position[] = [];
+  const coordIndexes: number[] = [];
+  const featureIndexes: number[] = [];
+  const multiFeatureIndexes: number[] = [];
   meta.coordEach(
     multiPoly,
     (coord, coordIndex, featureIndex, multiFeatureIndex) => {
@@ -217,11 +257,32 @@ test("coordEach -- MultiPolygon", (t) => {
   t.end();
 });
 
+test("coordEach -- MultiPoint", (t) => {
+  const coords: Position[] = [];
+  const coordIndexes: number[] = [];
+  const featureIndexes: number[] = [];
+  const multiFeatureIndexes: number[] = [];
+  meta.coordEach(
+    multiPt,
+    (coord, coordIndex, featureIndex, multiFeatureIndex) => {
+      coords.push(coord);
+      coordIndexes.push(coordIndex);
+      featureIndexes.push(featureIndex);
+      multiFeatureIndexes.push(multiFeatureIndex);
+    }
+  );
+  t.deepEqual(coordIndexes, [0, 1]);
+  t.deepEqual(featureIndexes, [0, 0]);
+  t.deepEqual(multiFeatureIndexes, [0, 1]);
+  t.equal(coords.length, 2);
+  t.end();
+});
+
 test("coordEach -- FeatureCollection", (t) => {
-  const coords = [];
-  const coordIndexes = [];
-  const featureIndexes = [];
-  const multiFeatureIndexes = [];
+  const coords: Position[] = [];
+  const coordIndexes: number[] = [];
+  const featureIndexes: number[] = [];
+  const multiFeatureIndexes: number[] = [];
   meta.coordEach(
     fcMixed,
     (coord, coordIndex, featureIndex, multiFeatureIndex) => {
@@ -235,6 +296,23 @@ test("coordEach -- FeatureCollection", (t) => {
   t.deepEqual(featureIndexes, [0, 1, 1, 2, 2, 2, 2]);
   t.deepEqual(multiFeatureIndexes, [0, 0, 0, 0, 0, 1, 1]);
   t.equal(coords.length, 7);
+  t.end();
+});
+
+test("coordEach -- rejects nested GeometryCollection", (t) => {
+  const nestedGeometryCollection: GeometryCollection = {
+    type: "GeometryCollection",
+    geometries: [{ type: "GeometryCollection", geometries: [] }],
+  };
+
+  const calls: any[] = [];
+  try {
+    meta.coordEach(nestedGeometryCollection, (p) => {});
+    t.fail("coordEach should reject nested GeometryCollections");
+  } catch (e) {
+    t.pass("coordEach rejects nested GeometryCollections");
+  }
+
   t.end();
 });
 
@@ -1381,6 +1459,20 @@ test("meta -- breaking of iterations", (t) => {
       return false;
     });
     t.equal(multiCount, 1, func.name);
+
+    // Points
+    let pointCount = 0;
+    func(fcPoints, () => {
+      pointCount++;
+      return false;
+    });
+
+    // MultiPolygons
+    let multiPolyCount = 0;
+    func(fcMultiPoly, () => {
+      multiPolyCount++;
+      return false;
+    });
   }
   t.end();
 });

--- a/packages/turf-meta/types.ts
+++ b/packages/turf-meta/types.ts
@@ -73,9 +73,15 @@ const customLineStrings = featureCollection([customLineString]);
 /**
  * meta.coordEach
  */
-const coordEachValue: void = meta.coordEach(pt, (coords) => coords);
-coordEach(pt, (coords, index) => coords);
-meta.coordEach(pt, (coords, index) => coords);
+const coordEachValue: false | void = meta.coordEach(pt, (coords) => {
+  coords;
+});
+coordEach(pt, (coords, index) => {
+  coords;
+});
+meta.coordEach(pt, (coords, index) => {
+  coords;
+});
 meta.coordEach(pt.geometry, (coords) => {
   const equal: number[] = coords;
 });
@@ -88,7 +94,9 @@ meta.coordEach(poly, (coords) => {
 meta.coordEach(multiPoly, (coords) => {
   const equal: number[] = coords;
 });
-meta.coordEach(geomCollection, (coords) => coords);
+meta.coordEach(geomCollection, (coords) => {
+  coords;
+});
 
 /**
  * meta.coordReduce


### PR DESCRIPTION
Makes several breaking API changes and improves test coverage and speed.

API Changes:
- Now correctly exposes `void | false` return type which lets you short-circuit the loop. This has always existed in the JavaScript path, but was not visible through the TypeScript types
- Changes from `AllGeoJSON` to just `GeoJSON` from @type/geojson, which are equivalent
- The callback now returns a `Position` instead of `number[]`, these are the same thing but Position comes from GeoJSON and is more specific
- Nested `GeometryCollections` are officially unsupported now instead of working but behaving very strangely.

Note on the nested GeometryCollections: its a little unfortunate that `GeoJSON` type quietly infers that you can have nested GeometryCollections. We could narrow the TypeScript types to enforce this, but then consumers would then be forced into doing their own type narrowing before calling coordEach, which is a little annoying as well.

Implementation improvements:
- Remove all @ts-expect-error tags from the implementation
- Remove big `var` block and push allocations into the areas where they are needed
- Break apart each GeoJSON type for clearer logic, this adds some lines but I think the logic can be made clearer because of it. excludeWrapCoord logic and incrementing the counters is now clearer because of it.
- Loop iterators modernized where possible
- excludeWrapCoord logic simplified
- Interestingly there are duplicate `obj.type` checks, but this version benchmarks faster than factoring them out (macos / node 26)
- Added a bit more code coverage and updated the type tests based on the breaking changes that were made

### Benchmarks

```
before
coordEach     - point x 110,457,081 ops/sec ±1.28% (95 runs sampled)
coordEach     - points x 255,247 ops/sec ±0.62% (96 runs sampled)
coordEach     - polygon x 82,126,479 ops/sec ±1.04% (91 runs sampled)
coordEach     - polygons x 124,665 ops/sec ±0.88% (97 runs sampled)

after
coordEach     - point x 130,932,389 ops/sec ±1.88% (94 runs sampled)
coordEach     - points x 418,112 ops/sec ±0.74% (98 runs sampled)
coordEach     - polygon x 86,664,317 ops/sec ±1.28% (91 runs sampled)
coordEach     - polygons x 148,778 ops/sec ±0.29% (96 runs sampled)
```