### PR TITLE
Move to pnpm/setup for github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24, 26]
+        node: [22, 24, 26]
 
     steps:
       - name: Checkout
@@ -26,18 +26,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: pnpm/setup
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          run_install: false
+          runtime: node@${{ matrix.node }}
+          require-lockfile: true
+          cache: true
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          cache: "pnpm"
-          node-version: ${{ matrix.node-version }}
-
-      - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm run docs
       - run: git diff --exit-code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: pnpm/setup
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          run_install: false
+          runtime: node@26
+          require-lockfile: true
+          cache: false
 
-      - name: Use Node.js 26
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "26"
-          registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
-
-      - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11.0.0 <12.0.0",
+      "version": "11.21.0",
       "onFail": "download"
     }
   }


### PR DESCRIPTION
The previous pnpm github runners were causing [issues](https://github.com/Turfjs/turf/actions/runs/34133610212/job/101779321291?pr=3160) now that newer pnpm 11's have been released.

It appears that they have released a new simpler action, so lets see if that one works out of the box or if I need to set a specific pnpm version in package.json's devEngines.