### PR TITLE
break(meta) BREAK Improve propEach TypeScript signature

### DIFF
--- a/packages/turf-meta/README.md
+++ b/packages/turf-meta/README.md
@@ -122,7 +122,7 @@ Type: [Function][1]
 *   `currentProperties` **[GeoJsonProperties][9]** The current Properties being processed.
 *   `featureIndex` **[number][3]** The current index of the Feature being processed.
 
-Returns **void**&#x20;
+Returns **(`false` | void)** Return false to stop iteration
 
 ## propEach
 
@@ -130,7 +130,7 @@ Iterate over properties in any GeoJSON object, similar to Array.forEach()
 
 ### Parameters
 
-*   `geojson` **([FeatureCollection][10] | [Feature][9])** any GeoJSON object
+*   `geojson` **([FeatureCollection][10] | [Feature][9])** any GeoJSON Feature or FeatureCollection
 *   `callback` **[propEachCallback][11]** a method that takes (currentProperties, featureIndex)
 
 ### Examples

--- a/packages/turf-meta/index.ts
+++ b/packages/turf-meta/index.ts
@@ -327,14 +327,14 @@ function coordReduce<Reducer>(
  * @callback propEachCallback
  * @param {GeoJsonProperties} currentProperties The current Properties being processed.
  * @param {number} featureIndex The current index of the Feature being processed.
- * @returns {void}
+ * @returns {false | void} Return false to stop iteration
  */
 
 /**
  * Iterate over properties in any GeoJSON object, similar to Array.forEach()
  *
  * @function
- * @param {FeatureCollection|Feature} geojson any GeoJSON object
+ * @param {FeatureCollection|Feature} geojson any GeoJSON Feature or FeatureCollection
  * @param {propEachCallback} callback a method that takes (currentProperties, featureIndex)
  * @returns {void}
  * @example
@@ -349,19 +349,16 @@ function coordReduce<Reducer>(
  * });
  */
 function propEach<Props extends GeoJsonProperties>(
-  geojson: Feature<any> | FeatureCollection<any> | Feature<GeometryCollection>,
-  callback: (currentProperties: Props, featureIndex: number) => void
+  geojson: Feature<Geometry, Props> | FeatureCollection<Geometry, Props>,
+  callback: (currentProperties: Props, featureIndex: number) => false | void
 ): void {
-  var i;
   switch (geojson.type) {
     case "FeatureCollection":
-      for (i = 0; i < geojson.features.length; i++) {
-        // @ts-expect-error: Known type conflict
+      for (let i = 0; i < geojson.features.length; i++) {
         if (callback(geojson.features[i].properties, i) === false) break;
       }
       break;
     case "Feature":
-      // @ts-expect-error: Known type conflict
       callback(geojson.properties, 0);
       break;
   }

--- a/packages/turf-meta/types.ts
+++ b/packages/turf-meta/types.ts
@@ -1,4 +1,4 @@
-import { Point, LineString } from "geojson";
+import { Point, LineString, Polygon, Feature } from "geojson";
 import * as helpers from "@turf/helpers";
 import { featureCollection, point, lineString } from "@turf/helpers";
 import * as meta from "./index.js";
@@ -128,12 +128,24 @@ meta.propReduce(geomCollection, (previous, prop) => prop);
 /**
  * meta.propEach
  */
-const propEachValue: void = meta.propEach(poly, (prop) => prop);
-propEach(features, (prop) => prop);
-meta.propEach(features, (prop) => prop);
-meta.propEach(poly, (prop, index) => prop);
-meta.propEach<{ bar: string }>(poly, (prop) => prop.bar);
-meta.propEach(geomCollection, (prop) => prop);
+const propEachValue: void = meta.propEach(poly, (prop) => {
+  prop;
+});
+propEach(features, (prop) => {
+  prop;
+});
+meta.propEach(features, (prop) => {
+  prop;
+});
+meta.propEach(poly, (prop, index) => {
+  prop;
+});
+meta.propEach(poly as Feature<Polygon, { bar: string }>, (prop) => {
+  prop.bar;
+});
+meta.propEach(geomCollection, (prop) => {
+  prop;
+});
 
 /**
  * meta.coordAll


### PR DESCRIPTION
- Tighten `geojson` parameter type signatures to only Feature and FeatureCollection
- Improve inference of `currentProperties` argument in callback
- Expose `false` return from callback to TypeScript
- Remove @ts-expect-errors
- Modernize the loop syntax

Perf changes are essentially neutral from this.